### PR TITLE
setq auth-sources properly

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -8,8 +8,8 @@
 
 ;; Don't store authinfo in plain text!
 (setq auth-sources
-  (list (expand-file-name "authinfo.gpg" doom-etc-dir)
-        "~/.authinfo.gpg"))
+      (list (expand-file-name "authinfo.gpg" doom-etc-dir)
+            "~/.authinfo.gpg"))
 
 (after! epa
   (setq epa-file-encrypt-to


### PR DESCRIPTION
On my system when I SPC-h-v auth-sources it's set to the default (`("~/.authinfo" "~/.authinfo.gpg" "~/.netrc")`) even though [it's defvar'd](https://github.com/hlissner/doom-emacs/blob/develop/modules/config/default/config.el#L10).