### PR TITLE
fix flickering PDFs in pdf-view-mode

### DIFF
--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -37,4 +37,10 @@
   ;; The next rules are not needed, they are defined in modules/ui/popups/+hacks.el
   ;; (set-popup-rule! "\\*Contents\\*" :side 'right :size 40)
   ;; (set-popup-rule! "* annots\\*$" :side 'left :size 40 :select nil)
+
+  ;; fix flckering pdfs when evil-mode is enabled
+  (evil-set-initial-state 'pdf-view-mode 'emacs)
+  (add-hook 'pdf-view-mode-hook
+            (lambda ()
+              (set (make-local-variable 'evil-emacs-state-cursor) (list nil))))
   )


### PR DESCRIPTION
Zooming into PDFs in PDFView conflicts with blinking cursors in evil-mode what causes the PDFs to flicker. 

This applies the fix from https://github.com/politza/pdf-tools/issues/201 what resolves the issue for me.
