### PR TITLE
Hide common easymotion prefix on which-key

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -193,6 +193,12 @@ localleader prefix."
   (which-key-add-key-based-replacements doom-leader-key "<leader>")
   (which-key-add-key-based-replacements doom-localleader-key "<localleader>")
 
+  ;; Fix #2647: Hide common "evilem-motion-" prefix in easymotion keymap, so
+  ;; the actual motion descriptions would be visible
+  (push
+   '(("\\`g s" . "evilem--?motion-\\(.*\\)") . (nil . "EM \\1"))
+   which-key-replacement-alist)
+
   (which-key-mode +1))
 
 


### PR DESCRIPTION
See doomemacs/modules#29
I'm not sure whether `core/core-keybinds.el` is the right place for this. Maybe
it would fit better in `modules/editor/evil/config.el`, where easymotion is actually
configured?