### PR TITLE
Add google-java-format support to Java

### DIFF
--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -25,6 +25,7 @@ This module adds [[https://www.java.com][java]] support to Doom Emacs, including
 ** Module Flags
 + =+lsp= Enables integration for the eclipse.jdt.ls LSP server.
 + =+meghanada= Enables the [[https://github.com/mopemope/meghanada-emacs/tree/master][meghanada-mode]]
++ =+google-java-format= Prefers [[https://github.com/google/google-java-format][google-java-format]] for code-formatting.
 
 The =+lsp= and =+meghanada= packages are mutually exclusive and do not work
 together. At the time of writing the =+meghanada= is already configured whereas

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -24,6 +24,17 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
 ;;
 ;;; java-mode
 
+(when (featurep! +google-java-format)
+  (set-formatter! 'google-java-format
+    '("google-java-format" "-")
+    :modes 'java-mode)
+
+  ;; Enforce Google Java Style Guide.
+  ;; See https://google.github.io/styleguide/javaguide.html
+  (setq-hook! 'java-mode-hook
+    tab-width 2
+    fill-column 100))
+
 (add-hook 'java-mode-hook #'rainbow-delimiters-mode)
 
 (cond ((featurep! +lsp)       (load! "+lsp"))

--- a/modules/lang/java/doctor.el
+++ b/modules/lang/java/doctor.el
@@ -1,9 +1,17 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/java/doctor.el
 
+(assert! (or (not (featurep! +google-java-format))
+             (featurep! :editor format))
+         "This module requires (:editor format)")
+
 (assert! (or (not (featurep! +lsp))
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
 (unless (executable-find "javac")
   (warn! "Couldn't find the javac executable, are you sure the JDK is installed?"))
+
+(when (and (featurep! +google-java-format)
+           (not (executable-find "google-java-format")))
+  (warn! "Couldn't find google-java-format. Code-formatting will be unavailable"))


### PR DESCRIPTION
## Description

Add `+google-java-format` flag to `lang/java` module.
https://github.com/google/google-java-format

We can also use Google style in `clang-format` by configuring `.clang-format`, but it doesn't actually obey Google Java Style Guide.