### PR TITLE
Disable projectile cache for fd

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -26,7 +26,8 @@ Emacs.")
              projectile-locate-dominating-file)
   :init
   (setq projectile-cache-file (concat doom-cache-dir "projectile.cache")
-        projectile-enable-caching doom-interactive-p
+        ;; fd is fast enough without caching
+        projectile-enable-caching (not (executable-find doom-projectile-fd-binary))
         projectile-globally-ignored-files '(".DS_Store" "Icon" "TAGS")
         projectile-globally-ignored-file-suffixes '(".elc" ".pyc" ".o")
         projectile-kill-buffers-filter 'kill-only-files


### PR DESCRIPTION
In my experience it's more trouble than it's worth. I've also seen people on doom's discord regularly having issues caused by the cache.

`fd` should be fast enough without caching on higher than calculator-grade hardware ;)