### PR TITLE
Add nimble keybinding

### DIFF
--- a/modules/lang/nim/config.el
+++ b/modules/lang/nim/config.el
@@ -29,6 +29,8 @@ windows."
   (map! :localleader
         :map nim-mode-map
         "b" #'nim-compile
+        (:prefix ("p" . "project")
+         :desc "nimble run" "r" #'nimble-run)
         "h" #'nimsuggest-show-doc
         "d" #'nimsuggest-find-definition))
 


### PR DESCRIPTION
I'm not sure about the exact keybinding to use. I see that 'b' is sometimes to group build commands, but nim provides building from a file also and `b` is bound to that command. So I thought that nimble could be put under 'p' for project (as it is a project manager for nim).