### PR TITLE
Revert ivy-posframe update

### DIFF
--- a/modules/completion/ivy/packages.el
+++ b/modules/completion/ivy/packages.el
@@ -17,7 +17,7 @@
     (package! flx :pin "17f5c9cb2af18aa6f52910ff4a5a63591261ced5")))
 
 (when (featurep! +childframe)
-  (package! ivy-posframe :pin "82a63ae0fe1976d042ae41e6400c037193cfed8e"))
+  (package! ivy-posframe :pin "44749562a9e68bd43ccaa225b31311476fab1251"))
 
 (when (featurep! +icons)
   (package! all-the-icons-ivy :pin "a70cbfa1effe36efc946a823a580cec686d5e88d"))


### PR DESCRIPTION
The latest version resulted in some problems with ivy/project-search.

With this patch and calling `project-search`, I get the following view:

![image](https://user-images.githubusercontent.com/5718007/90905293-43e4eb00-e3d0-11ea-8b15-3debad9a9679.png)

So I can enter some characters, but I neither see what I enter nor the results. Reverting this update fixes it for me. (Removing +childframe) also fixed it.