### PR TITLE
Add NOTANGLE to environment variable exclusions

### DIFF
--- a/core/cli/env.el
+++ b/core/cli/env.el
@@ -66,7 +66,7 @@ Why this over exec-path-from-shell?
     "^SSH_\\(AUTH_SOCK\\|AGENT_PID\\)$"
     "^HOME$" "^PWD$" "^PS1$" "^R?PROMPT$" "^TERM$"
     ;; Doom envvars
-    "^DEBUG$" "^INSECURE$" "^YES$" "^__")
+    "^DEBUG$" "^INSECURE$" "^NOTANGLE$" "^YES$" "^__")
   "Environment variables to not save in `doom-env-file'.
 
 Each string is a regexp, matched against variable names to omit from


### PR DESCRIPTION
I found that because I use `vterm` inside Emacs, the `NOTANGLE` variable was being persisted into my Doom environment file and the knock-on was an inability to tangle.

Signed-off-by: Martin Baillie <martin@baillie.email>