### PR TITLE
Initial implementation of dired-sidebar module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -43,6 +43,7 @@
        (popup +defaults)   ; tame sudden yet inevitable temporary windows
        ;;tabs              ; a tab bar for Emacs
        ;;treemacs          ; a project drawer, like neotree but cooler
+       ;;dired-sidebar     ; forget neotree and treemacs, pledge your unwavering loyalty to dired
        ;;unicode           ; extended unicode support for various languages
        vc-gutter         ; vcs diff in the fringe
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -523,6 +523,9 @@
        :desc "REPL"               "r"  #'+eval/open-repl-other-window
        :desc "REPL (same window)" "R"  #'+eval/open-repl-same-window
        :desc "Dired"              "-"  #'dired-jump
+       (:when (and (featurep! :ui dired-sidebar)
+                   (not (featurep! :emacs dired +ranger)))
+        :desc "Project sidebar"              "p" #'dired-sidebar-toggle-sidebar)
        (:when (featurep! :ui neotree)
         :desc "Project sidebar"              "p" #'+neotree/open
         :desc "Find file in project sidebar" "P" #'+neotree/find-this-file)

--- a/modules/ui/dired-sidebar/README.org
+++ b/modules/ui/dired-sidebar/README.org
@@ -1,0 +1,85 @@
+#+TITLE:   ui/dired-sidebar
+#+DATE:    August 26, 2020
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+  - [[#subtree-line-prefix][Subtree Line Prefix]]
+  - [[#sidebar-theme][Sidebar Theme]]
+  - [[#custom-font][Custom Font]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+This module enables =dired-sidebar=, which is a lighter alternative to treemacs
+and neotree. It is rather like having a sidebar with =dired-hide-details-mode=.
+This also integrates with =dired-subtree= and enables it for =dired=.
+
+It respects root directories set by =projectile= and =magit=.
+
+** Maintainers
+This module has no dedicated maintainers.
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://github.com/jojojames/dired-sidebar][dired-sidebar]]
++ [[https://github.com/Fuco1/dired-hacks][dired-subtree]]
+
+* Prerequisites
+This module requires =dired=.
+
+* Features
+Since this is a mode derived from =dired-mode=, it supports exciting features like =wdired-mode=
+and marking files, and all the functionality that entails!
+
+=dired-subtree-cycle=, unlike =org-cycle=, works only under point.
+
+* Configuration
+
+This module will be disabled if =+ranger= is present.
+
+** Subtree Line Prefix
+
+=dired-subtree-line-prefix= is set to ~>~ in this module.
+=dired-sidebar-subtree-line-prefix= can be independently modified.
+
+** Sidebar Theme
+
+=dired-sidebar-theme= is set to =ascii=. =nerd= is another simple theme, although not
+as spartan..
+
+#+begin_src emacs-lisp
+(setq dired-sidebar-theme 'nerd)
+#+end_src
+
+For icons, set to =icons=. This requires flag =+icons= under =:ui dired=. Setting
+=vscode= does not currently work with DOOM Emacs.
+
+#+begin_src emacs-lisp
+(setq dired-sidebar-theme 'icons)
+#+end_src
+
+** Custom Font
+
+#+begin_src emacs-lisp
+(setq dired-sidebar-use-custom-font t
+      dired-sidebar-face '(:family "Helvetica Neue"))
+#+end_src
+
+Consult function =font-spec= for details.
+
+If you wish to use =doom-variable-pitch-font=, add the following to =$DOOMDIR/config.el=.
+
+#+begin_src emacs-lisp
+(add-hook! 'dired-sidebar-mode-hook #'mixed-pitch-mode)
+#+end_src
+
+* TODO Troubleshooting

--- a/modules/ui/dired-sidebar/README.org
+++ b/modules/ui/dired-sidebar/README.org
@@ -14,12 +14,14 @@
   - [[#subtree-line-prefix][Subtree Line Prefix]]
   - [[#sidebar-theme][Sidebar Theme]]
   - [[#custom-font][Custom Font]]
+  - [[#sidebar-position][Sidebar position]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
 This module enables =dired-sidebar=, which is a lighter alternative to treemacs
 and neotree. It is rather like having a sidebar with =dired-hide-details-mode=.
-This also integrates with =dired-subtree= and enables it for =dired=.
+This also integrates with and enables =dired-subtree= for =dired= (and consequently,
+for itself)
 
 It respects root directories set by =projectile= and =magit=.
 
@@ -80,6 +82,14 @@ If you wish to use =doom-variable-pitch-font=, add the following to =$DOOMDIR/co
 
 #+begin_src emacs-lisp
 (add-hook! 'dired-sidebar-mode-hook #'mixed-pitch-mode)
+#+end_src
+
+** Sidebar position
+
+To move it to the right, add the following to =$DOOMDIR/config.el=.
+
+#+begin_src emacs-lisp
+(setq dired-sidebar-display-alist '((side . right) (slot . -1))
 #+end_src
 
 * TODO Troubleshooting

--- a/modules/ui/dired-sidebar/config.el
+++ b/modules/ui/dired-sidebar/config.el
@@ -1,0 +1,29 @@
+;;; ui/dired-sidebar/config.el -*- lexical-binding: t; -*-
+
+(use-package! dired-sidebar
+  :unless (featurep! :emacs dired +ranger)
+  :defer
+  :config
+  (setq dired-sidebar-width 25
+        dired-sidebar-theme 'ascii
+        dired-sidebar-tui-update-delay 5
+        dired-sidebar-recenter-cursor-on-tui-update t
+        dired-sidebar-no-delete-other-windows t
+        dired-sidebar-use-custom-modeline t)
+  (pushnew! dired-sidebar-toggle-hidden-commands
+            'evil-window-rotate-upwards 'evil-window-rotate-downwards)
+  (map! :map dired-sidebar-mode-map
+        :n "q" #'dired-sidebar-toggle-sidebar))
+
+(use-package! dired-subtree
+  :unless (featurep! :emacs dired +ranger)
+  :config
+  (setq dired-subtree-cycle-depth 4
+        dired-subtree-line-prefix ">")
+  (map! :map dired-mode-map
+        [backtab] #'dired-subtree-cycle
+        [tab] #'dired-subtree-toggle
+        :n "g^" #'dired-subtree-beginning
+        :n "g$" #'dired-subtree-end
+        :n "gm" #'dired-subtree-mark-subtree
+        :n "gu" #'dired-subtree-unmark-subtree))

--- a/modules/ui/dired-sidebar/packages.el
+++ b/modules/ui/dired-sidebar/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/dired-sidebar/packages.el
+
+(unless (featurep! :emacs dired +ranger)
+  (package! dired-sidebar :pin "da77919081d9a4e73c2df63542353319381e4f89"))
+(unless (featurep! :emacs dired +ranger)
+  (package! dired-subtree :pin "f49a8bbf95f70671a74a24f7f4de453b2686be46"))


### PR DESCRIPTION
I've been using [dired-sidebar](https://github.com/jojojames/dired-sidebar) in lieu of `neotree` and `treemacs` for a while and since I had a working config, I decided to try my hand at a module.

The configuration might not warrant an entire module, but what it delivers for it is indispensable (for me). It could definitely be a flag under `dired`.

