### PR TITLE
Add nix-shell for Clojure

### DIFF
--- a/modules/lang/clojure/shell.nix
+++ b/modules/lang/clojure/shell.nix
@@ -1,0 +1,13 @@
+{ nixpkgs ? import <nixpkgs> { } }:
+
+let
+  inherit (nixpkgs) pkgs;
+
+  doom-emacs = pkgs.callPackage ../../../test/shell.nix { };
+  clojure = import ./test/clojure.nix;
+
+in pkgs.stdenv.mkDerivation {
+  name = "clojure-shell";
+  buildInputs = clojure.buildInputs ++ doom-emacs.buildInputs;
+  shellHook = doom-emacs.shellHook;
+}

--- a/modules/lang/clojure/test/clojure.nix
+++ b/modules/lang/clojure/test/clojure.nix
@@ -1,0 +1,6 @@
+let pkgs = import <nixpkgs> { };
+
+in pkgs.stdenv.mkDerivation rec {
+  name = "clojure";
+  buildInputs = with pkgs; [ jdk11 leiningen clojure-lsp ];
+}


### PR DESCRIPTION
Part of  #2552.

I decided to re-use the setup that's already there in `test/shell.nix`. This just adds the required Clojure dependencies. I think this approach can greatly reduce the amount of setup for the individual nix environments.

### Unsupported Feature

`clj-kondo`, a requirement for linting, is currently broken on `nix` so it is missing here. I will look into fixing it on the nix end. Once that's done, we can just add it here.