### PR TITLE
tools/debugger: fix fringe when lsp + vc-gutter

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -158,3 +158,7 @@
   :when (featurep! +lsp)
   :hook (dap-mode . dap-ui-mode)
   :hook (dap-ui-mode . dap-ui-controls-mode))
+
+(when (and (featurep! +lsp) (featurep! :ui vc-gutter))
+  (add-hook 'dap-ui-mode-hook (lambda ()
+                                (setq-local left-fringe-width 10))))

--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -160,5 +160,7 @@
   :hook (dap-ui-mode . dap-ui-controls-mode))
 
 (when (and (featurep! +lsp) (featurep! :ui vc-gutter))
-  (add-hook 'dap-ui-mode-hook (lambda ()
-                                (setq-local left-fringe-width 10))))
+  (defadvice! +debugger--restore-fringe-width-a (&rest _)
+    "Ensure the fringe is wide enough to display breakpoints."
+    :after #'dap-ui--refresh-breakpoints
+    (set-fringe-style)))


### PR DESCRIPTION
When (debugger +lsp) and :ui vc-gutter are both enabled, sometimes the
left fringe where breakpoints and diff are will be half-size, cutting
the breakpoint in half.

This change fixes that.

![image](https://user-images.githubusercontent.com/3026394/116773940-33a20700-aa59-11eb-924c-439f143e23a7.png)