### PR TITLE
Fix #5038: Error on Emacs/sandbox startup

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -154,7 +154,7 @@ users).")
 ;;; Native Compilation support (http://akrl.sdf.org/gccemacs.html)
 
 ;; REVIEW Remove after a couple months
-(when (boundp 'comp-deferred-compilation)
+(when (and (boundp 'comp-eln-load-path) (not (boundp 'native-comp-eln-load-path)))
   (defvaralias 'native-comp-deferred-compilation 'comp-deferred-compilation)
   (defvaralias 'native-comp-deferred-compilation-deny-list 'comp-deferred-compilation-deny-list)
   (defvaralias 'native-comp-eln-load-path 'comp-eln-load-path)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Fixes #5038 which was incorrectly closed. <!-- remove if not applicable -->

Changed the conditional gating the `native-comp-* -> comp-*` compatibility aliases, to fix a severe `(error "Cannot make an internal variable an alias")` when `core/core.el` is loaded.
