### PR TITLE
feat(rest): add new feature flag +jq

### DIFF
--- a/modules/lang/rest/README.org
+++ b/modules/lang/rest/README.org
@@ -33,12 +33,14 @@ arcane wizardry.
 This module has no dedicated maintainers.
 
 ** Module Flags
-This module provides no flags.
++ =+jq= Enable jq hooks
 
 ** Plugins
 + [[https://github.com/pashky/restclient.el][restclient]]
 + =:completion company=
   + [[https://github.com/iquiw/company-restclient][company-restclient]]
++ =+jq=
+  + [[https://github.com/ljos/jq-mode][jq-mode]]
 
 ** Hacks
 + restclient has been modified not to silently reject self-signed or invalid

--- a/modules/lang/rest/config.el
+++ b/modules/lang/rest/config.el
@@ -33,3 +33,11 @@ certs, rather than reject them silently."
   :when (featurep! :completion company)
   :after restclient
   :config (set-company-backend! 'restclient-mode 'company-restclient))
+
+(use-package! restclient-jq
+  :when (featurep! +jq)
+  :after restclient)
+
+(use-package! jq-mode
+  :when (featurep! +jq)
+  :after restclient-jq)

--- a/modules/lang/rest/packages.el
+++ b/modules/lang/rest/packages.el
@@ -4,3 +4,11 @@
 (package! restclient :pin "176d9cb6552f04d98c33e29fc673862bdf3bca03")
 (when (featurep! :completion company)
   (package! company-restclient :pin "e5a3ec54edb44776738c13e13e34c85b3085277b"))
+
+(when (featurep! +jq)
+  (package! jq-mode :pin "42ad0a99f0114233e2cb317585cb9af494d18a2f")
+  (package! restclient-jq
+    :pin "2cc1fd3496f57288de3f97c27a5f018284db2d23"
+    :recipe (:host github
+             :repo "pashky/restclient.el"
+             :files ("restclient-jq.el"))))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->


restclient.el supports using jq to parse the response and save it to variable, but it's not been included in the package, I've added a feature flag to enable it.
