### PR TITLE
Add bindings for yanking and pasting entire buffers

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -349,12 +349,14 @@
        :desc "New empty buffer"            "N"   #'evil-buffer-new
        :desc "Kill other buffers"          "O"   #'doom/kill-other-buffers
        :desc "Previous buffer"             "p"   #'previous-buffer
+       :desc "Paste and replace buffer"    "P"   #'+default/paste-buffer
        :desc "Revert buffer"               "r"   #'revert-buffer
        :desc "Save buffer"                 "s"   #'basic-save-buffer
        :desc "Save all buffers"            "S"   #'evil-write-all
        :desc "Save buffer as root"         "u"   #'doom/sudo-save-buffer
        :desc "Pop up scratch buffer"       "x"   #'doom/open-scratch-buffer
        :desc "Switch to scratch buffer"    "X"   #'doom/switch-to-scratch-buffer
+       :desc "Yank buffer"                 "Y"   #'+default/yank-buffer
        :desc "Bury buffer"                 "z"   #'bury-buffer
        :desc "Kill buried buffers"         "Z"   #'doom/kill-buried-buffers)
 

--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -51,6 +51,20 @@
   (+default/yank-buffer-path (doom-project-root)))
 
 ;;;###autoload
+(defun +default/yank-buffer ()
+  "Copy entire buffer to the kill ring"
+  (interactive)
+  (clipboard-kill-ring-save (point-min) (point-max)))
+
+;;;###autoload
+(defun +default/paste-buffer ()
+  "Copy from kill ring and replace buffer"
+  (interactive)
+  (delete-region (point-min) (point-max))
+  (clipboard-yank)
+  (deactivate-mark))
+
+;;;###autoload
 (defun +default/insert-file-path (arg)
   "Insert the file name (absolute path if prefix ARG).
 If `buffer-file-name' isn't set, uses `default-directory'."


### PR DESCRIPTION
This commit adds two leader-key bindings, `SPC b Y` and `SPC b P`, that
allow for yanking (copying) from and pasting into/replacing the entire
buffer under focus. These are generally useful when consolidating
changes between files without having to copy between them, or as a
shortcut for copying content into a scratch buffer.
