### PR TITLE
Make mixed-pitch-mode respect `doom-variable-pitch-font`'s size.

### DIFF
--- a/modules/ui/zen/config.el
+++ b/modules/ui/zen/config.el
@@ -72,4 +72,6 @@
             'org-todo-keyword-outd
             'org-todo
             'org-done
-            'font-lock-comment-face))
+            'font-lock-comment-face)
+
+  (setq mixed-pitch-set-height 't))


### PR DESCRIPTION
set `mixed-pitch-set-height` to true. So mixed-pitch-mode will respect `doom-variable-pitch-font`'s size.
