### PR TITLE
Add `:tools tree-sitter` module

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -195,7 +195,7 @@ Small modules that give Emacs access to external tools & services.
 + [[file:../modules/tools/taskrunner/README.org][taskrunner]] - TODO
 + [[file:../modules/tools/terraform/README.org][terraform]] - TODO
 + tmux - TODO
-+ [[file:../modules/tools/tree-sitter/README.org][tree-sitter]]  - TODO
++ [[file:../modules/tools/tree-sitter/README.org][tree-sitter]]  - syntax and parsing, sitting in a tree...
 + [[file:../modules/tools/upload/README.org][upload]] - TODO
 
 * :ui

--- a/init.example.el
+++ b/init.example.el
@@ -105,6 +105,7 @@
        ;;taskrunner        ; taskrunner for all your projects
        ;;terraform         ; infrastructure as code
        ;;tmux              ; an API for interacting with tmux
+       ;;tree-sitter       ; syntax and parsing, sitting in a tree...
        ;;upload            ; map local to remote projects via ssh/ftp
 
        :os

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -169,11 +169,9 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
                                        (eq (overlay-get ov 'creator) 'ts-fold))
                                      ;; `overlays-in' does not provide a list that is sorted
                                      ;; (in the way we need it atleast) so we need to sort it based on direction
-                                     (cl-sort (eval `(overlays-in ,@arg-list))
-                                              (lambda (ov1 ov2)
-                                                (funcall comp-fun (overlay-start ov1) (overlay-start ov2)))))))
-                          (if (and ovs (<= count (length ovs)))
-                                   (goto-char (overlay-start (nth (- (abs count) 1) ovs))))))))
+                                     (cl-sort (apply #'overlays-in arg-list) comp-fun :key #'overlay-start))))
+                          (if (and ovs (<= (abs count) (length ovs)))
+                              (goto-char (overlay-start (nth (- (abs count) 1) ovs))))))))
            if (save-excursion (funcall fn))
            collect it into points
            finally do

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -109,18 +109,20 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   "Open folds at LEVEL (or all folds if LEVEL is nil)."
   (interactive
    (list (if current-prefix-arg (prefix-numeric-value current-prefix-arg))))
-  (when (featurep 'vimish-fold)
-    (vimish-fold-unfold-all))
-  (save-excursion
-    (+fold--ensure-hideshow-mode)
-    (if (integerp level)
-        (progn
-          (outline-hide-sublevels (max 1 (1- level)))
-          (hs-life-goes-on
-           (hs-hide-level-recursive (1- level) (point-min) (point-max))))
-      (hs-show-all)
-      (when (fboundp 'outline-show-all)
-        (outline-show-all)))))
+  (cond ((+fold--ts-fold-p)
+         (ts-fold-open-all))
+        ((featurep 'vimish-fold)
+         (vimish-fold-unfold-all))
+        (t (save-excursion
+             (+fold--ensure-hideshow-mode)
+             (if (integerp level)
+                 (progn
+                   (outline-hide-sublevels (max 1 (1- level)))
+                   (hs-life-goes-on
+                    (hs-hide-level-recursive (1- level) (point-min) (point-max))))
+               (hs-show-all)
+               (when (fboundp 'outline-show-all)
+                 (outline-show-all)))))))
 
 ;;;###autoload
 (defun +fold/close-all (&optional level)
@@ -128,13 +130,15 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive
    (list (if current-prefix-arg (prefix-numeric-value current-prefix-arg))))
   (save-excursion
-    (when (featurep 'vimish-fold)
-      (vimish-fold-refold-all))
-    (+fold--ensure-hideshow-mode)
-    (hs-life-goes-on
-     (if (integerp level)
-         (hs-hide-level-recursive (1- level) (point-min) (point-max))
-       (hs-hide-all)))))
+    (cond ((+fold--ts-fold-p)
+           (ts-fold-close-all))
+          (t (when (featurep 'vimish-fold)
+               (vimish-fold-refold-all))
+             (+fold--ensure-hideshow-mode)
+             (hs-life-goes-on
+              (if (integerp level)
+                  (hs-hide-level-recursive (1- level) (point-min) (point-max))
+                (hs-hide-all)))))))
 
 ;;;###autoload
 (defun +fold/next (count)

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -32,6 +32,10 @@
             (end-of-line)
             (+fold--hideshow-fold-p))))))
 
+;; NOTE: does this need more?
+(defun +fold--ts-fold-p ()
+  (featurep 'ts-fold))
+
 (defun +fold--invisible-points (count)
   (let (points)
     (save-excursion
@@ -62,7 +66,7 @@
 (defun +fold/toggle ()
   "Toggle the fold at point.
 
-Targets `vimmish-fold', `hideshow' and `outline' folds."
+Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
     (cond ((+fold--vimish-fold-p) (vimish-fold-toggle))
@@ -70,29 +74,32 @@ Targets `vimmish-fold', `hideshow' and `outline' folds."
            (cl-letf (((symbol-function #'outline-hide-subtree)
                       (symbol-function #'outline-hide-entry)))
              (outline-toggle-children)))
+          ((+fold--ts-fold-p) (ts-fold-toggle))
           ((+fold--hideshow-fold-p) (+fold-from-eol (hs-toggle-hiding))))))
 
 ;;;###autoload
 (defun +fold/open ()
   "Open the folded region at point.
 
-Targets `vimmish-fold', `hideshow' and `outline' folds."
+Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
     (cond ((+fold--vimish-fold-p) (vimish-fold-unfold))
           ((+fold--outline-fold-p)
            (outline-show-children)
            (outline-show-entry))
+          ((+fold--ts-fold-p) (ts-fold-open))
           ((+fold--hideshow-fold-p) (+fold-from-eol (hs-show-block))))))
 
 ;;;###autoload
 (defun +fold/close ()
   "Close the folded region at point.
 
-Targets `vimmish-fold', `hideshow' and `outline' folds."
+Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
     (cond ((+fold--vimish-fold-p) (vimish-fold-refold))
+          ((+fold--ts-fold-p) (ts-fold-close))
           ((+fold--hideshow-fold-p) (+fold-from-eol (hs-hide-block)))
           ((+fold--outline-fold-p) (outline-hide-subtree)))))
 

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -34,7 +34,7 @@
 
 ;; NOTE: does this need more?
 (defun +fold--ts-fold-p ()
-  (and tree-sitter-mode
+  (and (bound-and-true-p tree-sitter-mode)
        (featurep 'ts-fold)))
 
 (defun +fold--invisible-points (count)

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -34,7 +34,8 @@
 
 ;; NOTE: does this need more?
 (defun +fold--ts-fold-p ()
-  (featurep 'ts-fold))
+  (and tree-sitter-mode
+       (featurep 'ts-fold)))
 
 (defun +fold--invisible-points (count)
   (let (points)

--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -172,7 +172,8 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
                                      (cl-sort (eval `(overlays-in ,@arg-list))
                                               (lambda (ov1 ov2)
                                                 (funcall comp-fun (overlay-start ov1) (overlay-start ov2)))))))
-                          (if ovs (goto-char (overlay-start (nth (- (abs count) 1) ovs))))))))
+                          (if (and ovs (<= count (length ovs)))
+                                   (goto-char (overlay-start (nth (- (abs count) 1) ovs))))))))
            if (save-excursion (funcall fn))
            collect it into points
            finally do

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -86,3 +86,9 @@
     "zE" #'vimish-fold-delete-all)
   :config
   (vimish-fold-global-mode +1))
+
+(use-package! ts-fold
+  :when (featurep! :tools tree-sitter)
+  :after tree-sitter
+  :config
+  (ts-fold-mode +1))

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -91,4 +91,11 @@
   :when (featurep! :tools tree-sitter)
   :after tree-sitter
   :config
+  ;; we want to use our own face so we nullify this one to have no effect and
+  ;; make it more similar to hideshows
+  (custom-set-faces! '(ts-fold-replacement-face :foreground nil
+                                                :box nil
+                                                :inherit font-lock-comment-face
+                                                :weight light))
+  (setq ts-fold-replacement "  [...]  ")
   (ts-fold-mode +1))

--- a/modules/editor/fold/packages.el
+++ b/modules/editor/fold/packages.el
@@ -7,5 +7,5 @@
 (when (featurep! :editor evil)
   (package! evil-vimish-fold :pin "b6e0e6b91b8cd047e80debef1a536d9d49eef31a"))
 (when (featurep! :tools tree-sitter)
-  (package! ts-fold :pin "d6fbca3748a113c1ededbf20d84712048ade74da"
+  (package! ts-fold :pin "01d6485398a553a4fc4bbb3910edeb881c657f1f"
     :recipe (:host github :repo "jcs090218/ts-fold")))

--- a/modules/editor/fold/packages.el
+++ b/modules/editor/fold/packages.el
@@ -6,3 +6,6 @@
 (package! vimish-fold :pin "a6501cbfe3db791f9ca17fd986c7202a87f3adb8")
 (when (featurep! :editor evil)
   (package! evil-vimish-fold :pin "b6e0e6b91b8cd047e80debef1a536d9d49eef31a"))
+(when (featurep! :tools tree-sitter)
+  (package! ts-fold :pin "d6fbca3748a113c1ededbf20d84712048ade74da"
+    :recipe (:host github :repo "jcs090218/ts-fold")))

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -42,4 +42,6 @@
 ;; Tree Sitter
 (eval-when! (featurep! +tree-sitter)
   (add-hook! '(agda-mode
-               agda2-mode) #'turn-on-tree-sitter-mode))
+               agda2-mode)
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -41,7 +41,6 @@
 
 ;; Tree Sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! '(agda-mode
-               agda2-mode)
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! '(agda-mode-local-vars-hook
+               agda2-mode-local-vars-hook)
+             #'tree-sitter!))

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -38,3 +38,8 @@
           "h"   #'agda2-display-implicit-arguments
           "q"   #'agda2-quit
           "r"   #'agda2-restart)))
+
+;; Tree Sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! '(agda-mode
+               agda2-mode) #'turn-on-tree-sitter-mode))

--- a/modules/lang/agda/doctor.el
+++ b/modules/lang/agda/doctor.el
@@ -1,0 +1,5 @@
+;;; lang/agda/doctor.el -*- lexical-binding: t; -*-
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -308,4 +308,6 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
   (add-hook! '(c-mode-hook
-               c++-mode-hook) #'turn-on-tree-sitter-mode))
+               c++-mode-hook)
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -307,7 +307,6 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! '(c-mode-hook
-               c++-mode-hook)
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! '(c-mode-local-vars-hook
+               c++-mode-local-vars-hook)
+             #'tree-sitter!))

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -304,3 +304,8 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
                                               "-isystem/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include"
                                               "-isystem/usr/local/include"]
                                   :resourceDir (cdr (doom-call-process "clang" "-print-resource-dir"))))))))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! '(c-mode-hook
+               c++-mode-hook) #'turn-on-tree-sitter-mode))

--- a/modules/lang/cc/doctor.el
+++ b/modules/lang/cc/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (when (require 'rtags nil t)
   ;; rtags
   (when-let (bins (cl-remove-if #'rtags-executable-find

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -75,6 +75,4 @@ or terminating simple string."
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'csharp-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'csharp-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -72,3 +72,7 @@ or terminating simple string."
 
 
 (use-package! sln-mode :mode "\\.sln\\'")
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'csharp-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -75,4 +75,6 @@ or terminating simple string."
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'csharp-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'csharp-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/csharp/doctor.el
+++ b/modules/lang/csharp/doctor.el
@@ -5,3 +5,7 @@
   (let ((omnisharp-bin (or omnisharp-server-executable-path (omnisharp--server-installation-path t))))
     (unless (file-exists-p omnisharp-bin)
       (warn! "Omnisharp server isn't installed, completion won't work"))))
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -99,3 +99,6 @@
         "T" #'exunit-toggle-file-and-test
         "t" #'exunit-toggle-file-and-test-other-window
         "s" #'exunit-verify-single))
+
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'elixir-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/elixir/doctor.el
+++ b/modules/lang/elixir/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/elixir/doctor.el
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/elm/config.el
+++ b/modules/lang/elm/config.el
@@ -24,6 +24,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'elm-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'elm-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/elm/config.el
+++ b/modules/lang/elm/config.el
@@ -24,4 +24,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'elm-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'elm-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/elm/config.el
+++ b/modules/lang/elm/config.el
@@ -21,3 +21,7 @@
   :when (featurep! :checkers syntax)
   :after elm-mode
   :config (add-to-list 'flycheck-checkers 'elm))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'elm-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/elm/doctor.el
+++ b/modules/lang/elm/doctor.el
@@ -1,0 +1,5 @@
+;;; lang/elm/doctor.el -*- lexical-binding: t; -*-
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -79,6 +79,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'go-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'go-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -79,4 +79,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'go-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'go-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -76,3 +76,7 @@
 (use-package! flycheck-golangci-lint
   :when (featurep! :checkers syntax)
   :hook (go-mode . flycheck-golangci-lint-setup))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'go-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/go/doctor.el
+++ b/modules/lang/go/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "guru")
   (warn! "Couldn't find guru. Refactoring commands (go-guru-*) won't work"))
 

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -49,3 +49,7 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
   (set-docsets! 'groovy-mode "Groovy" "Groovy_JDK")
   (set-eval-handler! 'groovy-mode "groovy")
   (set-repl-handler! 'groovy-mode #'+java/open-groovy-repl))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'java-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -52,6 +52,4 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'java-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'java-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -52,4 +52,6 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'java-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'java-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/java/doctor.el
+++ b/modules/lang/java/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "javac")
   (warn! "Couldn't find the javac executable, are you sure the JDK is installed?"))
 

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -330,6 +330,6 @@ to tide."
                js3-mode-hook
                typescript-mode-hook
                typescript-tsx-mode-hook
-               rjsx-mode)
+               rjsx-mode-hook)
              #'turn-on-tree-sitter-mode
              #'+tree-sitter-keys-mode))

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -127,7 +127,17 @@
     (define-derived-mode typescript-tsx-mode web-mode "TypeScript-TSX")
     (when (featurep! +lsp)
       (after! lsp-mode
-        (add-to-list 'lsp--formatting-indent-alist '(typescript-tsx-mode . typescript-indent-level)))))
+        (add-to-list 'lsp--formatting-indent-alist '(typescript-tsx-mode . typescript-indent-level))))
+    (when (featurep! +tree-sitter)
+      (after! tree-sitter
+        (pushnew! tree-sitter-major-mode-language-alist '(typescript-tsx-mode . tsx))
+        (pushnew! evil-textobj-tree-sitter-major-mode-language-alist '(typescript-tsx-mode . "tsx"))
+
+        ;; HACK: the tsx grammer doesn't work with the hightlighting provided by
+        ;; font-lock-keywords.
+        ;; https://github.com/emacs-tree-sitter/tree-sitter-langs/issues/23
+        (setq-hook! 'typescript-tsx-mode-hook
+          tree-sitter-hl-use-font-lock-keywords nil))))
 
   (set-docsets! '(typescript-mode typescript-tsx-mode)
     :add "TypeScript" "AngularTS")
@@ -319,6 +329,7 @@ to tide."
                js2-mode-hook
                js3-mode-hook
                typescript-mode-hook
+               typescript-tsx-mode-hook
                rjsx-mode)
              #'turn-on-tree-sitter-mode
              #'+tree-sitter-keys-mode))

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -319,4 +319,6 @@ to tide."
                js2-mode-hook
                js3-mode-hook
                typescript-mode-hook
-               rjsx-mode) #'turn-on-tree-sitter-mode))
+               rjsx-mode)
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -134,8 +134,7 @@
         (pushnew! evil-textobj-tree-sitter-major-mode-language-alist '(typescript-tsx-mode . "tsx"))
 
         ;; HACK: the tsx grammer doesn't work with the hightlighting provided by
-        ;; font-lock-keywords.
-        ;; https://github.com/emacs-tree-sitter/tree-sitter-langs/issues/23
+        ;; font-lock-keywords. See emacs-tree-sitter/tree-sitter-langs#23
         (setq-hook! 'typescript-tsx-mode-hook
           tree-sitter-hl-use-font-lock-keywords nil))))
 

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -324,12 +324,9 @@ to tide."
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! '(javascript-mode-hook
-               js-mode-hook
-               js2-mode-hook
-               js3-mode-hook
-               typescript-mode-hook
-               typescript-tsx-mode-hook
-               rjsx-mode-hook)
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! '(js-mode-local-vars-hook
+               js2-mode-local-vars-hook
+               typescript-mode-local-vars-hook
+               typescript-tsx-mode-local-vars-hook
+               rjsx-mode-local-vars-hook)
+             #'tree-sitter!))

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -311,3 +311,12 @@ to tide."
 
 (def-project-mode! +javascript-gulp-mode
   :when (locate-dominating-file default-directory "gulpfile.js"))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! '(javascript-mode-hook
+               js-mode-hook
+               js2-mode-hook
+               js3-mode-hook
+               typescript-mode-hook
+               rjsx-mode) #'turn-on-tree-sitter-mode))

--- a/modules/lang/javascript/doctor.el
+++ b/modules/lang/javascript/doctor.el
@@ -4,3 +4,7 @@
 (assert! (or (not (featurep! +lsp))
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/json/config.el
+++ b/modules/lang/json/config.el
@@ -32,4 +32,6 @@
 
 (eval-when! (featurep! +tree-sitter)
   (add-hook! '(json-mode
-               jsonc-mode) #'turn-on-tree-sitter-mode))
+               jsonc-mode)
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/json/config.el
+++ b/modules/lang/json/config.el
@@ -29,3 +29,7 @@
         :map json-mode-map
         :localleader
         "s" #'counsel-jq))
+
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! '(json-mode
+               jsonc-mode) #'turn-on-tree-sitter-mode))

--- a/modules/lang/json/config.el
+++ b/modules/lang/json/config.el
@@ -31,7 +31,6 @@
         "s" #'counsel-jq))
 
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! '(json-mode
-               jsonc-mode)
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! '(json-mode-local-vars-hook
+               jsonc-mode-local-vars-hook)
+             #'tree-sitter!))

--- a/modules/lang/json/doctor.el
+++ b/modules/lang/json/doctor.el
@@ -3,3 +3,7 @@
 (when (and (featurep! :completion ivy)
            (not (executable-find "jq")))
   (warn! "Couldn't find jq. counsel-jq won't work." ))
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -102,6 +102,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'julia-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'julia-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -102,4 +102,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'julia-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'julia-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -99,3 +99,7 @@
   ;; Prevent timeout while installing LanguageServer.jl
   (setq-hook! 'julia-mode-hook eglot-connect-timeout (max eglot-connect-timeout 60))
   :config (eglot-jl-init))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'julia-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/julia/doctor.el
+++ b/modules/lang/julia/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (when (featurep! +lsp)
   (let ((args
          (cond ((require 'eglot-jl nil t)

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -47,3 +47,7 @@
 
 (use-package! nix-repl
   :commands nix-repl-show)
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'nix-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/nix/doctor.el
+++ b/modules/lang/nix/doctor.el
@@ -7,3 +7,6 @@
 (unless (executable-find "nixfmt")
   (warn! "Couldn't find nixfmt. nix-format-buffer won't work."))
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -121,6 +121,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'tuareg-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'tuareg-mode-local-vars-hook #'tree-sitter))

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -121,4 +121,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'tuareg-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'tuareg-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -118,3 +118,7 @@
                 ((equal ext ".eliomi")
                  (setq-local ocamlformat-file-kind 'interface)))))
       (setq +format-with 'ocamlformat))))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'tuareg-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/ocaml/doctor.el
+++ b/modules/lang/ocaml/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "ocamlmerlin")
   (warn! "Couldn't find ocamlmerlin. Lookup, completion and syntax checking won't work"))
 

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -179,6 +179,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! #'php-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'php-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -179,4 +179,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! #'php-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! #'php-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -176,3 +176,7 @@
   :on-exit
   (setq phpunit-args nil
         phpunit-executable nil))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! #'php-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/php/doctor.el
+++ b/modules/lang/php/doctor.el
@@ -4,3 +4,7 @@
 (assert! (or (not (featurep! +lsp))
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -345,3 +345,7 @@
   (use-package! lsp-pyright
     :when (featurep! +pyright)
     :after lsp-mode))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'python-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -348,4 +348,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'python-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'python-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -348,6 +348,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'python-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'python-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (if (not (or (executable-find "python")
              (executable-find "python3")))
     (error! "Couldn't find python in your PATH")

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -195,3 +195,7 @@
   (map! :localleader
         :map projectile-rails-mode-map
         "r" #'projectile-rails-command-map))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'ruby-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -198,6 +198,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'ruby-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'ruby-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -198,4 +198,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'ruby-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'ruby-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/ruby/doctor.el
+++ b/modules/lang/ruby/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "ruby")
   (warn! "Ruby isn't installed."))
 

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -84,4 +84,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'rustic-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'rustic-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -81,3 +81,7 @@
   (set-lookup-handlers! 'rustic-mode
     :definition '(racer-find-definition :async t)
     :documentation '+rust-racer-lookup-documentation))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'rustic-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -84,6 +84,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'rustic-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'rustic-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/rust/doctor.el
+++ b/modules/lang/rust/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "rustc")
   (warn! "Couldn't find rustc binary"))
 

--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -50,3 +50,7 @@
 (use-package! sbt-mode
   :after scala-mode
   :config (set-repl-handler! 'scala-mode #'+scala/open-repl :persist t))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'scala-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -53,6 +53,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'scala-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'scala-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -53,4 +53,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'scala-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'scala-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/scala/doctor.el
+++ b/modules/lang/scala/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (if (and (featurep! +lsp)
          (not (executable-find "metals-emacs")))
     (warn! "metals-emacs isn't installed"))

--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -96,6 +96,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'sh-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'sh-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -24,18 +24,18 @@
   (set-repl-handler! 'sh-mode #'+sh/open-repl)
   (set-lookup-handlers! 'sh-mode :documentation #'+sh-lookup-documentation-handler)
   (set-ligatures! 'sh-mode
-    ;; Functional
-    :def "function"
-    ;; Types
-    :true "true" :false "false"
-    ;; Flow
-    :not "!"
-    :and "&&" :or "||"
-    :in "in"
-    :for "for"
-    :return "return"
-    ;; Other
-    :dot "." :dot "source")
+                  ;; Functional
+                  :def "function"
+                  ;; Types
+                  :true "true" :false "false"
+                  ;; Flow
+                  :not "!"
+                  :and "&&" :or "||"
+                  :in "in"
+                  :for "for"
+                  :return "return"
+                  ;; Other
+                  :dot "." :dot "source")
 
   (when (featurep! +lsp)
     (add-hook 'sh-mode-local-vars-hook #'lsp! 'append))
@@ -93,3 +93,7 @@
   :config
   (when (featurep! +lsp)
     (add-hook 'powershell-mode-local-vars-hook #'lsp! 'append)))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'sh-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -24,18 +24,18 @@
   (set-repl-handler! 'sh-mode #'+sh/open-repl)
   (set-lookup-handlers! 'sh-mode :documentation #'+sh-lookup-documentation-handler)
   (set-ligatures! 'sh-mode
-                  ;; Functional
-                  :def "function"
-                  ;; Types
-                  :true "true" :false "false"
-                  ;; Flow
-                  :not "!"
-                  :and "&&" :or "||"
-                  :in "in"
-                  :for "for"
-                  :return "return"
-                  ;; Other
-                  :dot "." :dot "source")
+    ;; Functional
+    :def "function"
+    ;; Types
+    :true "true" :false "false"
+    ;; Flow
+    :not "!"
+    :and "&&" :or "||"
+    :in "in"
+    :for "for"
+    :return "return"
+    ;; Other
+    :dot "." :dot "source")
 
   (when (featurep! +lsp)
     (add-hook 'sh-mode-local-vars-hook #'lsp! 'append))

--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -96,4 +96,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'sh-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'sh-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/sh/doctor.el
+++ b/modules/lang/sh/doctor.el
@@ -3,3 +3,7 @@
 (when (featurep! :checkers syntax)
  (unless (executable-find "shellcheck")
   (warn! "Couldn't find shellcheck. Shell script linting will not work")))
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -34,6 +34,4 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'swift-mode-hook
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! 'swift-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -31,3 +31,7 @@
                           "sourcekit"
                           "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit-lsp"
                           "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit"))))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'swift-mode-hook #'turn-on-tree-sitter-mode))

--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -34,4 +34,6 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! 'swift-mode-hook #'turn-on-tree-sitter-mode))
+  (add-hook! 'swift-mode-hook
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/swift/doctor.el
+++ b/modules/lang/swift/doctor.el
@@ -1,0 +1,5 @@
+;;; lang/swift/doctor.el -*- lexical-binding: t; -*-
+
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")

--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -60,4 +60,6 @@
 (eval-when! (featurep! +tree-sitter)
   (add-hook! '(html-mode-hook
                mhtml-mode-hook
-               css-mode-hook)) #'turn-on-tree-sitter-mode)
+               css-mode-hook)
+             #'turn-on-tree-sitter-mode
+             #'+tree-sitter-keys-mode))

--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -58,8 +58,7 @@
 
 ;; Tree sitter
 (eval-when! (featurep! +tree-sitter)
-  (add-hook! '(html-mode-hook
-               mhtml-mode-hook
-               css-mode-hook)
-             #'turn-on-tree-sitter-mode
-             #'+tree-sitter-keys-mode))
+  (add-hook! '(html-mode-local-vars-hook
+               mhtml-mode-local-vars-hook
+               css-mode-local-vars-hook)
+             #'tree-sitter!))

--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -55,3 +55,9 @@
   (def-project-mode! +web-phaser-mode
     :modes '(+javascript-npm-mode)
     :when (+javascript-npm-dep-p '(or phaser phaser-ce))))
+
+;; Tree sitter
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! '(html-mode-hook
+               mhtml-mode-hook
+               css-mode-hook)) #'turn-on-tree-sitter-mode)

--- a/modules/lang/web/doctor.el
+++ b/modules/lang/web/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "js-beautify")
   (warn! "Couldn't find js-beautify. Code formatting in JS/CSS/HTML modes will not work."))
 

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -30,3 +30,6 @@
         "f" #'zig-format-buffer
         "r" #'zig-run
         "t" #'zig-test-buffer))
+
+(eval-when! (featurep! +tree-sitter)
+  (add-hook! 'zig-mode-local-vars-hook #'tree-sitter!))

--- a/modules/lang/zig/doctor.el
+++ b/modules/lang/zig/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +tree-sitter))
+             (featurep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
 (unless (executable-find "zig")
   (warn! "Couldn't find zig binary"))
 

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -82,7 +82,7 @@ If you wish to disable tree sitter text objects then you can just remove
 =+tree-sitter-keys-mode= from the language mode hook, for example if we did not
 want it for ruby we would use this snippet
 #+begin_src emacs-lisp
-(remove-hook! 'ruby-mode-hook #'+tree-sitter-keys-mode)
+(remove-hook 'ruby-mode-hook #'+tree-sitter-keys-mode)
 #+end_src
 
 ** Adding your own text objects
@@ -105,9 +105,9 @@ If you want to disable highlighting by default you can add a
 
 If you only want it for certain modes then
 #+begin_src emacs-lisp
-(remove-hook! 'tree-sitter-after-on-hook #'tree-sitter-hl-mode)
+(remove-hook 'tree-sitter-after-on-hook #'tree-sitter-hl-mode)
 
-(add-hook! 'MAJOR-MODE-HOOK #'tree-sitter-hl-mode)
+(add-hook 'MAJOR-MODE-HOOK #'tree-sitter-hl-mode)
 #+end_src
 
 * Troubleshooting

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -58,7 +58,7 @@ they are still being worked on.
 * Features
 ** Language support
 Currently Emacs tree sitter has got [[https://github.com/emacs-tree-sitter/tree-sitter-langs/tree/master/repos][parsers for these languages]] with syntax
-highlighting support for [[https://emacs-tree-sitter.github.io/syntax-highlighting/][these languages]].
+highlighting support for [[https://emacs-tree-sitter.github.io/syntax-highlighting/][these languages]] as well as ~typescript-tsx-mode~
 
 ** Text Objects
 Not all language support all text objects (yet). [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects][Here is a table of the text

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -76,6 +76,16 @@ They are used in a container context (not =vf= but =vaf= or =vif=)
 you can also jump to the next / previous node type in a buffer by using =[g=
 or =]g= respectfully, the following key will correspond to the text object you
 want to jump to
+Currently keys are bound to:
+| key | text object    |
+|-----+----------------|
+| =a= | parameter list |
+| =f= | function       |
+| =F= | function call  |
+| =c= | comment        |
+| =C= | class          |
+| =i= | conditional    |
+| =l= | loop           |
 
 * Configuration
 ** Disable text objects for certain modes

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -8,12 +8,12 @@
   - [[#maintainers][Maintainers]]
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
-  - [[#hacks][Hacks]]
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
   - [[#language-support][Language support]]
   - [[#text-objects][Text Objects]]
 - [[#configuration][Configuration]]
+  - [[#disable-text-objects-for-certain-modes][Disable text objects for certain modes]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -41,9 +41,6 @@ This module provides no flags.
 + [[https://github.com/emacs-tree-sitter/tree-sitter-langs][tree-sitter-langs]]
 + [[https://github.com/meain/evil-textobj-tree-sitter][evil-textobj-tree-sitter]]* (=:editor evil +everywhere=)
 
-** TODO Hacks
-# A list of internal modifications to included packages; omit if unneeded
-
 * Prerequisites
 This module has no prerequisites.
 
@@ -68,8 +65,14 @@ Currently text objects are bound to:
 
 They are used in a container context (not =vf= but =vaf= or =vif=)
 
-* TODO Configuration
-# How to configure this module, including common problems and how to address them.
+* Configuration
+** Disable text objects for certain modes
+If you wish to disable tree sitter text objects then you can just remove
+=+tree-sitter-keys-mode= from the language mode hook, for example if we did not
+want it for ruby we would use this snippet
+#+begin_src emacs-lisp
+(remove-hook! 'ruby-mode-hook #'+tree-sitter-keys-mode)
+#+end_src
 
 * TODO Troubleshooting
 # Common issues and their solution, or places to look for help.

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -54,6 +54,8 @@ This module has no prerequisites.
 ** Language support
 Currently Emacs tree sitter has got [[https://github.com/emacs-tree-sitter/tree-sitter-langs/tree/master/repos][parsers for these languages]] with syntax
 highlighting support for [[https://emacs-tree-sitter.github.io/syntax-highlighting/][these languages]] as well as ~typescript-tsx-mode~
+To enable tree sitter for individual languages add the =+tree-sitter= flag.
+Check the module readme of your language for support.
 
 ** Text Objects
 Not all language support all text objects (yet). [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects][Here is a table of the text

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -14,7 +14,10 @@
   - [[#text-objects][Text Objects]]
 - [[#configuration][Configuration]]
   - [[#disable-text-objects-for-certain-modes][Disable text objects for certain modes]]
+  - [[#adding-your-own-text-objects][Adding your own text objects]]
+  - [[#disabling-highlighting-for-certain-modes][Disabling highlighting for certain modes]]
 - [[#troubleshooting][Troubleshooting]]
+  - [[#error-bad-bounding-indices-0-1][=(error "Bad bounding indices: 0, 1")=]]
 
 * Description
 This module adds [[https://tree-sitter.github.io/tree-sitter/][tree-sitter]] support to doom:
@@ -22,7 +25,8 @@ This module adds [[https://tree-sitter.github.io/tree-sitter/][tree-sitter]] sup
 #+begin_quote
 Tree sitter is a parser generator tool and an incremental parsing library. It
 can build a concrete syntax tree for a source file and efficiently update the
-syntax tree as the source file is edited.
+syntax tree as the source file is edited. This allows for features of the editor
+  to become syntax aware.
 #+end_quote
 
 It includes:
@@ -74,5 +78,33 @@ want it for ruby we would use this snippet
 (remove-hook! 'ruby-mode-hook #'+tree-sitter-keys-mode)
 #+end_src
 
-* TODO Troubleshooting
-# Common issues and their solution, or places to look for help.
+** Adding your own text objects
+If you wish to [[https://github.com/meain/evil-textobj-tree-sitter#custom-textobjects][add your own custom text objects]] then you need to bind them and
+add them to the ~+tree-sitter-{inner, outer}-text-objects-map~
+for example:
+#+begin_src emacs-lisp
+(map! (:map +tree-sitter-outer-text-objects-map
+       "m" (evil-textobj-tree-sitter-get-textobj "import"
+             '((python-mode . [(import_statement) @import])
+               (rust-mode . [(use_declaration) @import])))))
+#+end_src
+
+** Disabling highlighting for certain modes
+If you want to disable highlighting by default you can add a 
+#+begin_src emacs-lisp
+(after! MODE-PACKAGE
+  (tree-sitter-hl-mode -1))
+#+end_src
+
+If you only want it for certain modes then
+#+begin_src emacs-lisp
+(remove-hook! 'tree-sitter-after-on-hook #'tree-sitter-hl-mode)
+
+(add-hook! 'MAJOR-MODE-HOOK #'tree-sitter-hl-mode)
+#+end_src
+
+* Troubleshooting
+** =(error "Bad bounding indices: 0, 1")=
+This means that the text object does not have the underlying query needed, this can be
+fixed by either adding in a custom query (which would override the current key
+bound.) or [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects/][contributing upstream!]]

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -19,7 +19,6 @@
   - [[#disabling-highlighting-for-certain-modes][Disabling highlighting for certain modes]]
 - [[#troubleshooting][Troubleshooting]]
   - [[#error-bad-bounding-indices-0-1][=(error "Bad bounding indices: 0, 1")=]]
-  - [[#no-textobj-text-object-found][=No 'TEXTOBJ' text object found=]]
 
 * Description
 This module adds [[https://tree-sitter.github.io/tree-sitter/][tree-sitter]] support to doom:
@@ -116,11 +115,3 @@ If you only want it for certain modes then
 This means that the text object does not have the underlying query needed, this can be
 fixed by either adding in a custom query (which would override the current key
 bound.) or [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects/][contributing upstream!]]
-
-** =No 'TEXTOBJ' text object found=
-the main reason for this is the underlying text object using the =#make-range!=
-predicate, which at the moment [[https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/180][is not implemented in emacs tree sitter]] (see this
-issue on [[https://github.com/meain/evil-textobj-tree-sitter/issues/33][evil-textobj-tree-sitter]]).
-
-the only way around it is to rewrite the query to not use =#make-range!= or to
-implement that predicate the elisp tree sitter core

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -12,6 +12,7 @@
 - [[#features][Features]]
   - [[#language-support][Language support]]
   - [[#text-objects][Text Objects]]
+  - [[#goto-certain-nodes][Goto certain nodes]]
 - [[#configuration][Configuration]]
   - [[#disable-text-objects-for-certain-modes][Disable text objects for certain modes]]
   - [[#adding-your-own-text-objects][Adding your own text objects]]
@@ -75,6 +76,11 @@ Currently text objects are bound to:
 | =l= | loop                |
 
 They are used in a container context (not =vf= but =vaf= or =vif=)
+
+** Goto certain nodes
+you can also jump to the next / previous node type in a buffer by using =[g=
+or =]g= respectfully, the following key will correspond to the text object you
+want to jump to
 
 * Configuration
 ** Disable text objects for certain modes

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -34,6 +34,8 @@ It includes:
 + Structural text objects to manipulate functions statements and other code
   structures like any other text object
 
+*Currently this module does not support M1 macbooks due to grammars being built for x86*
+
 ** Maintainers
 - @jeetelongname
 
@@ -46,7 +48,10 @@ This module provides no flags.
 + [[https://github.com/meain/evil-textobj-tree-sitter][evil-textobj-tree-sitter]]* (=:editor evil +everywhere=)
 
 * Prerequisites
-This module has no prerequisites.
+This module has no prerequisites. but if you are using an M1 mac (or a system
+that's is not using an X86 instruction set) then you will not be able to use this
+module for the moment, functions are being put in place for this use case but
+they are still being worked on.
 
 * Features
 ** Language support
@@ -56,7 +61,7 @@ highlighting support for [[https://emacs-tree-sitter.github.io/syntax-highlighti
 ** Text Objects
 Not all language support all text objects (yet). [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects][Here is a table of the text
 objects languages support]]
-Note: only languages with parsers in emacs have text object support currently.
+Note: only languages with parser's in emacs have text object support currently.
 Currently text objects are bound to:
 | key | text object         |
 |-----+---------------------|

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -65,6 +65,7 @@ Note: only languages with parser's in emacs have text object support currently.
 Currently text objects are bound to:
 | key | text object         |
 |-----+---------------------|
+| =a= | parameter list      |
 | =f= | function definition |
 | =F= | function call       |
 | =C= | class               |

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -15,6 +15,7 @@
   - [[#goto-certain-nodes][Goto certain nodes]]
 - [[#configuration][Configuration]]
   - [[#disable-text-objects-for-certain-modes][Disable text objects for certain modes]]
+  - [[#rebinding-text-objects][Rebinding text objects]]
   - [[#adding-your-own-text-objects][Adding your own text objects]]
   - [[#disabling-highlighting-for-certain-modes][Disabling highlighting for certain modes]]
 - [[#troubleshooting][Troubleshooting]]
@@ -83,6 +84,23 @@ If you wish to disable tree sitter text objects then you can just remove
 want it for ruby we would use this snippet
 #+begin_src emacs-lisp
 (remove-hook 'ruby-mode-hook #'+tree-sitter-keys-mode)
+#+end_src
+
+** Rebinding text objects
+Rebinding keys is the same as any other key but do notes they need to be bound 
+to the keymaps ~+tree-sitter-inner-text-object-map~ or
+~+tree-sitter-outer-text-object-map~
+#+begin_src emacs-lisp
+(map! (:map +tree-sitter-outer-text-objects-map
+       "f" nil
+       "f" (evil-textobj-tree-sitter-get-textobj "call.inner")
+       "F" nil
+       "F" (evil-textobj-tree-sitter-get-textobj "function.inner"))
+      (:map +tree-sitter-inner-text-objects-map
+       "f" nil
+       "f" (evil-textobj-tree-sitter-get-textobj "call.inner")
+       "F" nil
+       "F" (evil-textobj-tree-sitter-get-textobj "function.inner")))
 #+end_src
 
 ** Adding your own text objects

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -84,7 +84,7 @@ Currently keys are bound to:
 | =F= | function call  |
 | =c= | comment        |
 | =C= | class          |
-| =i= | conditional    |
+| =v= | conditional    |
 | =l= | loop           |
 
 * Configuration

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -62,12 +62,12 @@ Note: only languages with parsers in emacs have text object support currently.
 Currently text objects are bound to:
 | key | text object         |
 |-----+---------------------|
-| =a= | parameter list      |
+| =A= | parameter list      |
 | =f= | function definition |
 | =F= | function call       |
 | =C= | class               |
 | =c= | comment             |
-| =i= | conditional         |
+| =v= | conditional         |
 | =l= | loop                |
 
 They are used in a container context (not =vf= but =vaf= or =vif=)

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -18,6 +18,7 @@
   - [[#disabling-highlighting-for-certain-modes][Disabling highlighting for certain modes]]
 - [[#troubleshooting][Troubleshooting]]
   - [[#error-bad-bounding-indices-0-1][=(error "Bad bounding indices: 0, 1")=]]
+  - [[#no-textobj-text-object-found][=No 'TEXTOBJ' text object found=]]
 
 * Description
 This module adds [[https://tree-sitter.github.io/tree-sitter/][tree-sitter]] support to doom:
@@ -114,3 +115,11 @@ If you only want it for certain modes then
 This means that the text object does not have the underlying query needed, this can be
 fixed by either adding in a custom query (which would override the current key
 bound.) or [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects/][contributing upstream!]]
+
+** =No 'TEXTOBJ' text object found=
+the main reason for this is the underlying text object using the =#make-range!=
+predicate, which at the moment [[https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/180][is not implemented in emacs tree sitter]] (see this
+issue on [[https://github.com/meain/evil-textobj-tree-sitter/issues/33][evil-textobj-tree-sitter]]).
+
+the only way around it is to rewrite the query to not use =#make-range!= or to
+implement that predicate the elisp tree sitter core

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -36,8 +36,6 @@ It includes:
 + Structural text objects to manipulate functions statements and other code
   structures like any other text object
 
-*Currently this module does not support M1 macbooks due to grammars being built for x86*
-
 ** Maintainers
 - @jeetelongname
 
@@ -50,10 +48,7 @@ This module provides no flags.
 + [[https://github.com/meain/evil-textobj-tree-sitter][evil-textobj-tree-sitter]]* (=:editor evil +everywhere=)
 
 * Prerequisites
-This module has no prerequisites. but if you are using an M1 mac (or a system
-that's is not using an X86 instruction set) then you will not be able to use this
-module for the moment, functions are being put in place for this use case but
-they are still being worked on.
+This module has no prerequisites. 
 
 * Features
 ** Language support
@@ -63,7 +58,7 @@ highlighting support for [[https://emacs-tree-sitter.github.io/syntax-highlighti
 ** Text Objects
 Not all language support all text objects (yet). [[https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects][Here is a table of the text
 objects languages support]]
-Note: only languages with parser's in emacs have text object support currently.
+Note: only languages with parsers in emacs have text object support currently.
 Currently text objects are bound to:
 | key | text object         |
 |-----+---------------------|

--- a/modules/tools/tree-sitter/autoload.el
+++ b/modules/tools/tree-sitter/autoload.el
@@ -1,5 +1,10 @@
 ;;; tools/tree-sitter/autoload.el -*- lexical-binding: t; -*-
 
+;;;###autodef
+(defun tree-sitter! ()
+  (turn-on-tree-sitter-mode)
+  (+tree-sitter-keys-mode))
+
 ;;;###autoload
 (defun +tree-sitter-goto-textobj (group &optional previous end query)
   "Thin wrapper that returns the symbol of a named function, used in keybindings."

--- a/modules/tools/tree-sitter/autoload.el
+++ b/modules/tools/tree-sitter/autoload.el
@@ -2,8 +2,8 @@
 
 ;;;###autodef
 (defun tree-sitter! ()
-  (turn-on-tree-sitter-mode)
-  (+tree-sitter-keys-mode))
+  (interactive)
+  (turn-on-tree-sitter-mode))
 
 ;;;###autoload
 (defun +tree-sitter-goto-textobj (group &optional previous end query)

--- a/modules/tools/tree-sitter/autoload.el
+++ b/modules/tools/tree-sitter/autoload.el
@@ -5,6 +5,13 @@
   (interactive)
   (turn-on-tree-sitter-mode))
 
+;; HACK: Remove and refactor when `use-package' eager macro expansion is solved or `use-package!' is removed
+;;;###autoload
+(defun +tree-sitter-get-textobj (group &optional query)
+  "A wrapper around `evil-textobj-tree-sitter-get-textobj' to
+prevent eager expansion."
+  (eval `(evil-textobj-tree-sitter-get-textobj ,group ,query)))
+
 ;;;###autoload
 (defun +tree-sitter-goto-textobj (group &optional previous end query)
   "Thin wrapper that returns the symbol of a named function, used in keybindings."

--- a/modules/tools/tree-sitter/autoload.el
+++ b/modules/tools/tree-sitter/autoload.el
@@ -1,0 +1,10 @@
+;;; tools/tree-sitter/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +tree-sitter-goto-textobj (group &optional previous end query)
+  "Thin wrapper that returns the symbol of a named function, used in keybindings."
+  (let ((sym (intern (format "+goto%s%s-%s" (if previous "-previous" "") (if end "-end" "") group))))
+    (fset sym (lambda ()
+                (interactive)
+                (evil-textobj-tree-sitter-goto-textobj group previous end query)))
+    sym))

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -43,4 +43,9 @@
      :textobj "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner") (evil-textobj-tree-sitter-get-textobj "conditional.outer")
 
      :textobj "l" nil nil
-     :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))))
+     :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))
+    (after! which-key
+      (setq which-key-allow-multiple-replacements t)
+      (pushnew!
+       which-key-replacement-alist
+       '(("" . "\\`+?evil-textobj-tree-sitter-function--\\(.*\\)\\(?:.inner\\|.outer\\)") . (nil . "\\1"))))))

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -1,9 +1,6 @@
 ;;; tools/tree-sitter/config.el -*- lexical-binding: t; -*-
 
-
-
 (use-package! tree-sitter
-  ;; :hook (prog-mode . turn-on-tree-sitter-mode)
   :defer t ;; loading is handled by individual modes
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
@@ -17,7 +14,7 @@
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
-(if (daemonp) ;; eager load when in daemon as its start time is easily consumed
+(if (daemonp) ;; HACK: eager load when in daemon as its start time is easily consumed
     (require 'tree-sitter-langs)
   (add-hook! 'tree-sitter-after-on-hook
     (require 'tree-sitter-langs)))

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -1,7 +1,6 @@
 ;;; tools/tree-sitter/config.el -*- lexical-binding: t; -*-
 
 (use-package! tree-sitter
-  :defer t ;; loading is handled by individual modes
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
   ;; This makes every node a link to a section of code

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -11,12 +11,19 @@
 
 (defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
 (defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
+(defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
+(defvar +tree-sitter-goto-next-map (make-sparse-keymap))
 
 (defvar +tree-sitter-keys-mode-map
   (let ((keymap (make-sparse-keymap)))
+    ;; ts text objects
     (evil-define-key '(visual operator) '+tree-sitter-keys-mode
       "i" +tree-sitter-inner-text-objects-map
       "a" +tree-sitter-outer-text-objects-map)
+    ;; ts goto nodes
+    (evil-define-key 'normal '+tree-sitter-keys-mode
+      "[g" +tree-sitter-goto-previous-map
+      "]g" +tree-sitter-goto-next-map)
     keymap)
   "Basic keymap for tree sitter text objects")
 
@@ -43,7 +50,25 @@
          "C" (evil-textobj-tree-sitter-get-textobj "class.outer")
          "c" (evil-textobj-tree-sitter-get-textobj "comment.outer")
          "i" (evil-textobj-tree-sitter-get-textobj "conditional.outer")
-         "l" (evil-textobj-tree-sitter-get-textobj "loop.outer")))
+         "l" (evil-textobj-tree-sitter-get-textobj "loop.outer"))
+
+        (:map +tree-sitter-goto-previous-map
+         "a" (+tree-sitter-goto-textobj "parameter.outer" t)
+         "f" (+tree-sitter-goto-textobj "function.outer" t)
+         "F" (+tree-sitter-goto-textobj "call.outer" t)
+         "C" (+tree-sitter-goto-textobj "class.outer" t)
+         "c" (+tree-sitter-goto-textobj "comment.outer" t)
+         "i" (+tree-sitter-goto-textobj "conditional.outer" t)
+         "l" (+tree-sitter-goto-textobj "loop.outer" t))
+        (:map +tree-sitter-goto-next-map
+         "a" (+tree-sitter-goto-textobj "parameter.outer")
+         "f" (+tree-sitter-goto-textobj "function.outer")
+         "F" (+tree-sitter-goto-textobj "call.outer")
+         "C" (+tree-sitter-goto-textobj "class.outer")
+         "c" (+tree-sitter-goto-textobj "comment.outer")
+         "i" (+tree-sitter-goto-textobj "conditional.outer")
+         "l" (+tree-sitter-goto-textobj "loop.outer")))
+
 
   (after! which-key
     (setq which-key-allow-multiple-replacements t)

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -37,19 +37,19 @@
   :config
 
   (map! (:map +tree-sitter-inner-text-objects-map
-         "a" (evil-textobj-tree-sitter-get-textobj "parameter.inner")
+         "A" (evil-textobj-tree-sitter-get-textobj ("parameter.inner" "call.inner"))
          "f" (evil-textobj-tree-sitter-get-textobj "function.inner")
          "F" (evil-textobj-tree-sitter-get-textobj "call.inner")
          "C" (evil-textobj-tree-sitter-get-textobj "class.inner")
-         "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner")
+         "v" (evil-textobj-tree-sitter-get-textobj "conditional.inner")
          "l" (evil-textobj-tree-sitter-get-textobj "loop.inner"))
         (:map +tree-sitter-outer-text-objects-map
-         "a" (evil-textobj-tree-sitter-get-textobj "parameter.outer")
+         "A" (evil-textobj-tree-sitter-get-textobj ("parameter.outer" "call.outer"))
          "f" (evil-textobj-tree-sitter-get-textobj "function.outer")
          "F" (evil-textobj-tree-sitter-get-textobj "call.outer")
          "C" (evil-textobj-tree-sitter-get-textobj "class.outer")
          "c" (evil-textobj-tree-sitter-get-textobj "comment.outer")
-         "i" (evil-textobj-tree-sitter-get-textobj "conditional.outer")
+         "v" (evil-textobj-tree-sitter-get-textobj "conditional.outer")
          "l" (evil-textobj-tree-sitter-get-textobj "loop.outer"))
 
         (:map +tree-sitter-goto-previous-map

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -27,11 +27,10 @@
   (use-package! evil-textobj-tree-sitter
     :after tree-sitter
     :config
-    ;; FIXME: only bind when using a supported major mode
     (map!
      :map +tree-sitter-enabled-mode-maps
      :textobj "f" nil nil
-     :textobj "f" (evil-textobj-tree-sitter-get-textobj "function.inner") (evil-textobj-tree-sitter-get-textobj "function.outer") ;; redef
+     :textobj "f" (evil-textobj-tree-sitter-get-textobj "function.inner") (evil-textobj-tree-sitter-get-textobj "function.outer")
 
      :textobj "F" (evil-textobj-tree-sitter-get-textobj "call.inner") (evil-textobj-tree-sitter-get-textobj "call.outer")
 

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -9,7 +9,11 @@
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
-(add-hook! 'tree-sitter-after-on-hook (require 'tree-sitter-langs))
+(if (daemonp) ;; eager load when in daemon as its start time is easily consumed
+    (require 'tree-sitter-langs)
+  (add-hook! 'tree-sitter-after-on-hook
+    (require 'tree-sitter-langs)))
+
 
 (when (featurep! :editor evil +everywhere)
   (use-package! evil-textobj-tree-sitter
@@ -32,4 +36,3 @@
 
      :textobj "l" nil nil
      :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))))
-

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -4,45 +4,47 @@
   :defer t ;; loading is handled by individual modes
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
-  (defvar +tree-sitter-enabled-mode-maps (seq-map (lambda (mode)
-                                                     (intern (concat
-                                                              (symbol-name (car mode)) "-map")))
-                                                   tree-sitter-major-mode-language-alist)
-    "List of mode hooks for tree sitter enabled modes.")
   ;; This makes every node a link to a section of code
   (setq tree-sitter-debug-jump-buttons t
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
-(if (daemonp) ;; HACK: eager load when in daemon as its start time is easily consumed
-    (require 'tree-sitter-langs)
-  (add-hook! 'tree-sitter-after-on-hook
-    (require 'tree-sitter-langs)))
+(defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
+(defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
 
+(defvar +tree-sitter-keys-mode-map
+  (let ((keymap (make-sparse-keymap)))
+    (evil-define-key '(visual operator) '+tree-sitter-keys-mode
+      "i" +tree-sitter-inner-text-objects-map
+      "a" +tree-sitter-outer-text-objects-map)
+    keymap)
+  "Basic keymap for tree sitter text objects")
 
-(when (featurep! :editor evil +everywhere)
-  (use-package! evil-textobj-tree-sitter
-    :after tree-sitter
-    :config
-    (map!
-     :map +tree-sitter-enabled-mode-maps
-     :textobj "f" nil nil
-     :textobj "f" (evil-textobj-tree-sitter-get-textobj "function.inner") (evil-textobj-tree-sitter-get-textobj "function.outer")
+(define-minor-mode +tree-sitter-keys-mode
+  "A minor mode with tree sitter keybinds."
+  :keymap +tree-sitter-keys-mode-map)
 
-     :textobj "F" (evil-textobj-tree-sitter-get-textobj "call.inner") (evil-textobj-tree-sitter-get-textobj "call.outer")
+(use-package! evil-textobj-tree-sitter
+  :when (featurep! :editor evil +everywhere)
+  :after tree-sitter
+  :config
 
-     :textobj "C" (evil-textobj-tree-sitter-get-textobj "class.inner") (evil-textobj-tree-sitter-get-textobj "class.outer")
+  (map! (:map +tree-sitter-inner-text-objects-map
+         "f" (evil-textobj-tree-sitter-get-textobj "function.inner")
+         "F" (evil-textobj-tree-sitter-get-textobj "call.inner")
+         "C" (evil-textobj-tree-sitter-get-textobj "class.inner")
+         "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner")
+         "l" (evil-textobj-tree-sitter-get-textobj "loop.inner"))
+        (:map +tree-sitter-outer-text-objects-map
+         "f" (evil-textobj-tree-sitter-get-textobj "function.outer")
+         "F" (evil-textobj-tree-sitter-get-textobj "call.outer")
+         "C" (evil-textobj-tree-sitter-get-textobj "class.outer")
+         "c" (evil-textobj-tree-sitter-get-textobj "comment.outer")
+         "i" (evil-textobj-tree-sitter-get-textobj "conditional.outer")
+         "l" (evil-textobj-tree-sitter-get-textobj "loop.outer")))
 
-     :textobj "c" nil nil
-     :textobj "c" nil (evil-textobj-tree-sitter-get-textobj "comment.outer")
-
-     :textobj "i" nil nil
-     :textobj "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner") (evil-textobj-tree-sitter-get-textobj "conditional.outer")
-
-     :textobj "l" nil nil
-     :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))
-    (after! which-key
-      (setq which-key-allow-multiple-replacements t)
-      (pushnew!
-       which-key-replacement-alist
-       '(("" . "\\`+?evil-textobj-tree-sitter-function--\\(.*\\)\\(?:.inner\\|.outer\\)") . (nil . "\\1"))))))
+  (after! which-key
+    (setq which-key-allow-multiple-replacements t)
+    (pushnew!
+     which-key-replacement-alist
+     '(("" . "\\`+?evil-textobj-tree-sitter-function--\\(.*\\)\\(?:.inner\\|.outer\\)") . (nil . "\\1")))))

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -47,7 +47,7 @@
          "F" (+tree-sitter-goto-textobj "call.outer" t)
          "C" (+tree-sitter-goto-textobj "class.outer" t)
          "c" (+tree-sitter-goto-textobj "comment.outer" t)
-         "i" (+tree-sitter-goto-textobj "conditional.outer" t)
+         "v" (+tree-sitter-goto-textobj "conditional.outer" t)
          "l" (+tree-sitter-goto-textobj "loop.outer" t))
         (:map +tree-sitter-goto-next-map
          "a" (+tree-sitter-goto-textobj "parameter.outer")
@@ -55,7 +55,7 @@
          "F" (+tree-sitter-goto-textobj "call.outer")
          "C" (+tree-sitter-goto-textobj "class.outer")
          "c" (+tree-sitter-goto-textobj "comment.outer")
-         "i" (+tree-sitter-goto-textobj "conditional.outer")
+         "v" (+tree-sitter-goto-textobj "conditional.outer")
          "l" (+tree-sitter-goto-textobj "loop.outer")))
 
 

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -4,12 +4,13 @@
   :hook (prog-mode . turn-on-tree-sitter-mode)
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
-  (require 'tree-sitter-langs)
-
   ;; This makes every node a link to a section of code
   (setq tree-sitter-debug-jump-buttons t
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
+
+(use-package! tree-sitter-langs
+  :after tree-sitter)
 
 (when (featurep! :editor evil +everywhere)
   (use-package! evil-textobj-tree-sitter

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -1,9 +1,17 @@
 ;;; tools/tree-sitter/config.el -*- lexical-binding: t; -*-
 
+
+
 (use-package! tree-sitter
-  :hook (prog-mode . turn-on-tree-sitter-mode)
+  ;; :hook (prog-mode . turn-on-tree-sitter-mode)
+  :defer t ;; loading is handled by individual modes
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
+  (defvar +tree-sitter-enabled-mode-maps (seq-map (lambda (mode)
+                                                     (intern (concat
+                                                              (symbol-name (car mode)) "-map")))
+                                                   tree-sitter-major-mode-language-alist)
+    "List of mode hooks for tree sitter enabled modes.")
   ;; This makes every node a link to a section of code
   (setq tree-sitter-debug-jump-buttons t
         ;; and this highlights the entire sub tree in your code
@@ -21,6 +29,7 @@
     :config
     ;; FIXME: only bind when using a supported major mode
     (map!
+     :map +tree-sitter-enabled-mode-maps
      :textobj "f" nil nil
      :textobj "f" (evil-textobj-tree-sitter-get-textobj "function.inner") (evil-textobj-tree-sitter-get-textobj "function.outer") ;; redef
 

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -9,8 +9,7 @@
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
-(use-package! tree-sitter-langs
-  :after tree-sitter)
+(add-hook! 'tree-sitter-after-on-hook (require 'tree-sitter-langs))
 
 (when (featurep! :editor evil +everywhere)
   (use-package! evil-textobj-tree-sitter
@@ -33,3 +32,4 @@
 
      :textobj "l" nil nil
      :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))))
+

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -14,22 +14,23 @@
 (defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
 (defvar +tree-sitter-goto-next-map (make-sparse-keymap))
 
-(defvar +tree-sitter-keys-mode-map
-  (let ((keymap (make-sparse-keymap)))
-    ;; ts text objects
-    (evil-define-key '(visual operator) '+tree-sitter-keys-mode
-      "i" +tree-sitter-inner-text-objects-map
-      "a" +tree-sitter-outer-text-objects-map)
-    ;; ts goto nodes
-    (evil-define-key 'normal '+tree-sitter-keys-mode
-      "[g" +tree-sitter-goto-previous-map
-      "]g" +tree-sitter-goto-next-map)
-    keymap)
-  "Basic keymap for tree sitter text objects")
+(when (featurep! :editor evil +everywhere)
+  (defvar +tree-sitter-keys-mode-map
+    (let ((keymap (make-sparse-keymap)))
+      ;; ts text objects
+      (evil-define-key '(visual operator) '+tree-sitter-keys-mode
+        "i" +tree-sitter-inner-text-objects-map
+        "a" +tree-sitter-outer-text-objects-map)
+      ;; ts goto nodes
+      (evil-define-key 'normal '+tree-sitter-keys-mode
+        "[g" +tree-sitter-goto-previous-map
+        "]g" +tree-sitter-goto-next-map)
+      keymap)
+    "Basic keymap for tree sitter text objects")
 
-(define-minor-mode +tree-sitter-keys-mode
-  "A minor mode with tree sitter keybinds."
-  :keymap +tree-sitter-keys-mode-map)
+  (define-minor-mode +tree-sitter-keys-mode
+    "A minor mode with tree sitter keybinds."
+    :keymap +tree-sitter-keys-mode-map))
 
 (use-package! evil-textobj-tree-sitter
   :when (featurep! :editor evil +everywhere)

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -8,12 +8,13 @@
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
-(defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
-(defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
-(defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
-(defvar +tree-sitter-goto-next-map (make-sparse-keymap))
 
 (when (featurep! :editor evil +everywhere)
+  (defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
+  (defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
+  (defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
+  (defvar +tree-sitter-goto-next-map (make-sparse-keymap))
+
   (defvar +tree-sitter-keys-mode-map
     (let ((keymap (make-sparse-keymap)))
       ;; ts text objects

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -3,6 +3,7 @@
 (use-package! tree-sitter
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
+  (require 'tree-sitter-langs)
   ;; This makes every node a link to a section of code
   (setq tree-sitter-debug-jump-buttons t
         ;; and this highlights the entire sub tree in your code
@@ -12,7 +13,6 @@
   :when (featurep! :editor evil +everywhere)
   :after tree-sitter
   :config
-
   (defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
   (defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
   (defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
@@ -26,20 +26,20 @@
     "]g" +tree-sitter-goto-next-map)
 
   (map! (:map +tree-sitter-inner-text-objects-map
-         "A" (evil-textobj-tree-sitter-get-textobj ("parameter.inner" "call.inner"))
-         "f" (evil-textobj-tree-sitter-get-textobj "function.inner")
-         "F" (evil-textobj-tree-sitter-get-textobj "call.inner")
-         "C" (evil-textobj-tree-sitter-get-textobj "class.inner")
-         "v" (evil-textobj-tree-sitter-get-textobj "conditional.inner")
-         "l" (evil-textobj-tree-sitter-get-textobj "loop.inner"))
+         "A" (+tree-sitter-get-textobj '("parameter.inner" "call.inner"))
+         "f" (+tree-sitter-get-textobj "function.inner")
+         "F" (+tree-sitter-get-textobj "call.inner")
+         "C" (+tree-sitter-get-textobj "class.inner")
+         "v" (+tree-sitter-get-textobj "conditional.inner")
+         "l" (+tree-sitter-get-textobj "loop.inner"))
         (:map +tree-sitter-outer-text-objects-map
-         "A" (evil-textobj-tree-sitter-get-textobj ("parameter.outer" "call.outer"))
-         "f" (evil-textobj-tree-sitter-get-textobj "function.outer")
-         "F" (evil-textobj-tree-sitter-get-textobj "call.outer")
-         "C" (evil-textobj-tree-sitter-get-textobj "class.outer")
-         "c" (evil-textobj-tree-sitter-get-textobj "comment.outer")
-         "v" (evil-textobj-tree-sitter-get-textobj "conditional.outer")
-         "l" (evil-textobj-tree-sitter-get-textobj "loop.outer"))
+         "A" (+tree-sitter-get-textobj '("parameter.outer" "call.outer"))
+         "f" (+tree-sitter-get-textobj "function.outer")
+         "F" (+tree-sitter-get-textobj "call.outer")
+         "C" (+tree-sitter-get-textobj "class.outer")
+         "c" (+tree-sitter-get-textobj "comment.outer")
+         "v" (+tree-sitter-get-textobj "conditional.outer")
+         "l" (+tree-sitter-get-textobj "loop.outer"))
 
         (:map +tree-sitter-goto-previous-map
          "a" (+tree-sitter-goto-textobj "parameter.outer" t)

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -8,34 +8,22 @@
         ;; and this highlights the entire sub tree in your code
         tree-sitter-debug-highlight-jump-region t))
 
+(use-package! evil-textobj-tree-sitter
+  :when (featurep! :editor evil +everywhere)
+  :after tree-sitter
+  :config
 
-(when (featurep! :editor evil +everywhere)
   (defvar +tree-sitter-inner-text-objects-map (make-sparse-keymap))
   (defvar +tree-sitter-outer-text-objects-map (make-sparse-keymap))
   (defvar +tree-sitter-goto-previous-map (make-sparse-keymap))
   (defvar +tree-sitter-goto-next-map (make-sparse-keymap))
 
-  (defvar +tree-sitter-keys-mode-map
-    (let ((keymap (make-sparse-keymap)))
-      ;; ts text objects
-      (evil-define-key '(visual operator) '+tree-sitter-keys-mode
-        "i" +tree-sitter-inner-text-objects-map
-        "a" +tree-sitter-outer-text-objects-map)
-      ;; ts goto nodes
-      (evil-define-key 'normal '+tree-sitter-keys-mode
-        "[g" +tree-sitter-goto-previous-map
-        "]g" +tree-sitter-goto-next-map)
-      keymap)
-    "Basic keymap for tree sitter text objects")
-
-  (define-minor-mode +tree-sitter-keys-mode
-    "A minor mode with tree sitter keybinds."
-    :keymap +tree-sitter-keys-mode-map))
-
-(use-package! evil-textobj-tree-sitter
-  :when (featurep! :editor evil +everywhere)
-  :after tree-sitter
-  :config
+  (evil-define-key '(visual operator) 'tree-sitter-mode
+    "i" +tree-sitter-inner-text-objects-map
+    "a" +tree-sitter-outer-text-objects-map)
+  (evil-define-key 'normal 'tree-sitter-mode
+    "[g" +tree-sitter-goto-previous-map
+    "]g" +tree-sitter-goto-next-map)
 
   (map! (:map +tree-sitter-inner-text-objects-map
          "A" (evil-textobj-tree-sitter-get-textobj ("parameter.inner" "call.inner"))

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -30,12 +30,14 @@
   :config
 
   (map! (:map +tree-sitter-inner-text-objects-map
+         "a" (evil-textobj-tree-sitter-get-textobj "parameter.inner")
          "f" (evil-textobj-tree-sitter-get-textobj "function.inner")
          "F" (evil-textobj-tree-sitter-get-textobj "call.inner")
          "C" (evil-textobj-tree-sitter-get-textobj "class.inner")
          "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner")
          "l" (evil-textobj-tree-sitter-get-textobj "loop.inner"))
         (:map +tree-sitter-outer-text-objects-map
+         "a" (evil-textobj-tree-sitter-get-textobj "parameter.outer")
          "f" (evil-textobj-tree-sitter-get-textobj "function.outer")
          "F" (evil-textobj-tree-sitter-get-textobj "call.outer")
          "C" (evil-textobj-tree-sitter-get-textobj "class.outer")

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -5,8 +5,8 @@
   :pin "3cfab8a0e945db9b3df84437f27945746a43cc71")
 
 (package! tree-sitter-langs
-  :pin "0dd5e56e2f5646aa51ed0fc9eb869a8f7090228a")
+  :pin "deb2d8674be8f777ace50e15c7c041aeddb1d0b2")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "bfdef5a292f7dde36967bb86eb2f7009b03631b1"))
+    :pin "0bf5bbbfecba95d49d40441ea54c6130e52bbeb1"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,11 +2,11 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "771239bacecf6c3ba9ee8b9eecec2b9fdd8e2256")
+  :pin "5e1091658d625984c6c5756e3550c4d2eebd73a1")
 
 (package! tree-sitter-langs
-  :pin "a9b0390a751be0a631cf8a356d61933795d9fcbc")
+  :pin "599570cd2a6d1b43a109634896b5c52121e155e3")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "607b71f38a1b2d7fa464814d968427435d31dd7c"))
+    :pin "ff733576d1dc5395c08d8f0e396b7a7073e39674"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,11 +2,11 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "5e1091658d625984c6c5756e3550c4d2eebd73a1")
+  :pin "3cfab8a0e945db9b3df84437f27945746a43cc71")
 
 (package! tree-sitter-langs
   :pin "0dd5e56e2f5646aa51ed0fc9eb869a8f7090228a")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "e5fda8eca926e65f7aadc9ed27d768eb6d1d415f"))
+    :pin "bfdef5a292f7dde36967bb86eb2f7009b03631b1"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,11 +2,11 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "4d9871d23999fe5f8de821e23c9ec576df2b2738")
+  :pin "8bbbfa4fc5f478f10c7cb968177d5a907fe5928f")
 
 (package! tree-sitter-langs
-  :pin "fa47b55f7bd11bd2b17ab48deb03ed23000bb974")
+  :pin "86a894a617976aefa453fa6ce8dd9871c58f733e")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "eedc1f54611e4403ea228b33056388a8539a2b3e"))
+    :pin "4d79ea71219cb0153baf4046af8aae6b1ed2fcfb"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -5,8 +5,8 @@
   :pin "5e1091658d625984c6c5756e3550c4d2eebd73a1")
 
 (package! tree-sitter-langs
-  :pin "f4effc81fcac3592bce7072619a0e17043412cf4")
+  :pin "0dd5e56e2f5646aa51ed0fc9eb869a8f7090228a")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "f3b3e9554e5ecae55200454804e183e268b4a6fc"))
+    :pin "e5fda8eca926e65f7aadc9ed27d768eb6d1d415f"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -9,4 +9,4 @@
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "08823ff97277fe50540d8226c7d298e06fb14932"))
+    :pin "607b71f38a1b2d7fa464814d968427435d31dd7c"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -5,8 +5,8 @@
   :pin "5e1091658d625984c6c5756e3550c4d2eebd73a1")
 
 (package! tree-sitter-langs
-  :pin "599570cd2a6d1b43a109634896b5c52121e155e3")
+  :pin "f4effc81fcac3592bce7072619a0e17043412cf4")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "ff733576d1dc5395c08d8f0e396b7a7073e39674"))
+    :pin "f3b3e9554e5ecae55200454804e183e268b4a6fc"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,10 +2,10 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "48b06796a3b2e76ce004972d929de38146eafaa0")
+  :pin "771239bacecf6c3ba9ee8b9eecec2b9fdd8e2256")
 
 (package! tree-sitter-langs
-  :pin "3c0c82f9fb0a796f5ebd7e1e4c89f13d5ab6ef58")
+  :pin "a9b0390a751be0a631cf8a356d61933795d9fcbc")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,11 +2,11 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "8bbbfa4fc5f478f10c7cb968177d5a907fe5928f")
+  :pin "48b06796a3b2e76ce004972d929de38146eafaa0")
 
 (package! tree-sitter-langs
-  :pin "86a894a617976aefa453fa6ce8dd9871c58f733e")
+  :pin "3c0c82f9fb0a796f5ebd7e1e4c89f13d5ab6ef58")
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "4d79ea71219cb0153baf4046af8aae6b1ed2fcfb"))
+    :pin "08823ff97277fe50540d8226c7d298e06fb14932"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

This PR adds tree sitter support to doom. 
currently it adds:
- syntax highlighting to the languages that support it.
- structural text objects using [evil-textobj-treesitter](https://github.com/meain/evil-textobj-treesitter)

With plans to add: 
- better code folding using tree sitter [(and powered with hideshow!)](https://github.com/jeetelongname/hideshow-tree-sitter)
- a better tree visualization mode (similar to the [playground on tree sitters website](https://tree-sitter.github.io/tree-sitter/playground) or `TSplayground` in neovim (package needs to be found or written) 
- functions and query's that leverage tree sitter for statistics and other useful purposes. 
- any other package that is deemed useful! 

more information on module development is available on [this discourse post](https://discourse.doomemacs.org/t/treesitter-module-developement/1589)
PR's and patches are welcome as well as pointers and suggestions! feel free to ping me on discord if you have any questions.

 related issues:
 - #4151 

