### PR TITLE
fix(dired): add dired-mode to `evil-snipe-disabled-modes`

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -356,7 +356,7 @@ directives. By default, this only recognizes C directives.")
         evil-snipe-repeat-scope 'visible
         evil-snipe-char-fold t)
   :config
-  (pushnew! evil-snipe-disabled-modes 'Info-mode 'calc-mode 'treemacs-mode))
+  (pushnew! evil-snipe-disabled-modes 'Info-mode 'calc-mode 'treemacs-mode 'dired-mode))
 
 
 (use-package! evil-surround


### PR DESCRIPTION
Fixes #3359 

Evil binding overwrite S binding in dired (create symlink) with Snipe's search backwards. Arguably, the symlink one is more useful and I don't see much use for snipe in dired buffers.
Open to discussion if others disagree.
