### PR TITLE
fix(evil): +evil--embrace-escaped isn't active for the first org mode buffer

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -268,6 +268,7 @@ directives. By default, this only recognizes C directives.")
          . +evil-embrace-angle-bracket-modes-hook-h)
   :hook (scala-mode . +evil-embrace-scala-mode-hook-h)
   :init
+  (defvar embrace--pairs-list '((?\\ . nil)))
   (after! evil-surround
     (evil-embrace-enable-evil-surround-integration))
   :config


### PR DESCRIPTION
<!-- 

    YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
    FOLLOWING CRITERIA:

    - [X] It targets the develop branch
    - [X] No other pull requests exist for this issue
    - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
    - [X] Any relevant issues and PRs have been linked to
    - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

For the first buffer by which `evil-embrace` is loaded, `+evil--embrace-escaped` isn&rsquo;t applied. That is, surrounding text object, say `blah` with backslash just result to `\blah\`, contrary to waiting the very next character triggered by `+evil--embrace-escaped`.

This is because the entry associated with `\` doesn&rsquo;t exist when it comes to the default value of `embrace--pairs-list`, hence, from the very *next* buffer the tweak made to `embrace--pairs-list` takes effect.