### PR TITLE
feat(vc): use smerge-vc-next-conflict instead of smerge-next

### DIFF
--- a/modules/emacs/vc/autoload/hydra.el
+++ b/modules/emacs/vc/autoload/hydra.el
@@ -20,7 +20,7 @@
 "
     ("g" (progn (goto-char (point-min)) (smerge-next)))
     ("G" (progn (goto-char (point-max)) (smerge-prev)))
-    ("C-j" smerge-next)
+    ("C-j" smerge-vc-next-conflict)
     ("C-k" smerge-prev)
     ("j" next-line)
     ("k" previous-line)


### PR DESCRIPTION
This is provided by `smerge-mode` in Emacs 27, and functions exactly
like `smerge-next`, except that if there are no more conflicts in the
current file, it will go to the next file with conflicts.

Arguably this could be a different key binding. However, I find that it
is almost strictly superior to `smerge-next`: I can't think of a case
where I *wouldn't* immediately want to go to the next file with
conflicts, and even if you do by accident you can just pop back to the
preceding buffer. So I think it warrants being the default.

-------

I am aware of https://github.com/hlissner/doom-emacs/pull/4788, which also adds a binding for this. However, I hope this PR will be more acceptable: it doesn't add anything new, but instead modifies the hydra keybinding. 

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
