### PR TITLE
fix: unicode font initializing early in daemon

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -666,6 +666,9 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 
 ;; Apply `doom-font' et co
 (add-hook 'doom-after-init-modules-hook #'doom-init-fonts-h -100)
+(add-transient-hook! 'after-make-frame-functions
+  (when doom-unicode-font
+    (set-fontset-font t 'unicode doom-unicode-font)))
 
 ;; Apply `doom-theme'
 (add-hook (if (daemonp)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

### Issue

When Emacs is started in daemon mode, *some* unicode characters were broken until `doom/reload-font` is called. I believe `doom-unicode-font` were being set early by `after-init-hook`.

My `doom-unicode-font` is "Joypixels".

### To reproduce

1. Insert 🕐
2. Check above unicode char in daemon mode
3. Call `doom/reload-font` to fix it

Also check it without daemon mode to see it doesn't have this problem.

### Fix

This PR sets `doom-unicode-font` using `after-make-frame-functions` transient hook.