### PR TITLE
feat(eshell,vterm): add with-editor support

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -125,6 +125,12 @@ You should use `set-eshell-alias!' to change this.")
                   +eshell-aliases))))
 
 
+(when (featurep! +with-editor)
+  (add-hook! 'eshell-mode-hook
+             #'with-editor-export-editor
+             #'with-editor-export-git-editor))
+
+
 (after! esh-mode
   (map! :map eshell-mode-map
         :n  "RET"    #'+eshell/goto-end-of-prompt

--- a/modules/term/eshell/packages.el
+++ b/modules/term/eshell/packages.el
@@ -8,6 +8,9 @@
 (package! eshell-did-you-mean :pin "80cd8c4b186a2fb29621cf634bcf2bcd914f1e3d")
 (package! eshell-syntax-highlighting :pin "8e3a685fc6d97af79e1046e5b24385786d8e92f6")
 
+(when (featurep! +with-editor)
+  (package! with-editor :pin "cfcbc2731e402b9169c0dc03e89b5b57aa988502"))
+
 (unless IS-WINDOWS
   (package! fish-completion :pin "10384881817b5ae38cf6197a077a663420090d2c")
   (package! bash-completion :pin "c5eaeed156ab906190c662d491269230967104b1"))

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -29,3 +29,8 @@
     confirm-kill-processes nil
     ;; Prevent premature horizontal scrolling
     hscroll-margin 0))
+
+(when (featurep! +with-editor)
+  (add-hook! 'vterm-mode-hook
+             #'with-editor-export-editor
+             #'with-editor-export-git-editor))

--- a/modules/term/vterm/packages.el
+++ b/modules/term/vterm/packages.el
@@ -4,3 +4,6 @@
 (package! vterm
   :built-in 'prefer
   :pin "a940dd2ee8a82684860e320c0f6d5e15d31d916f")
+
+(when (featurep! +with-editor)
+  (package! with-editor :pin "cfcbc2731e402b9169c0dc03e89b5b57aa988502"))


### PR DESCRIPTION
This sets $EDITOR to emacsclient automatically from terminal sessions.
Even though with-editor supports term and shell, it's not added for
those by default because the exporting of the environmental variables is
visible when first opening the terminals for them (this is not the case
for eshell and vterm).

Ref magit/with-editor#101

-------

I think this is a very sensible default, however there are some things to consider:

For vterm, due to the way that `with-editor` clears the terminal after exporting the variables, they stay on the screen after opening the vterm for the first time for a fraction of a second (no such problem in eshell). Due to this, it may be desired to not have this on by default, in that case there are basically two other options:

1. have a `:term with-editor` module that turns this on for activated `:term` modules (or just `eshell` and `vterm` if on)
2. give each module a `+with-editor` flag that turns this on, with a warning in the `shell` and `term` readme's about the output.

On top of that, there is also the following recommended setup:
``` emacs-lisp
(define-key (current-global-map)
  [remap async-shell-command] 'with-editor-async-shell-command)
(define-key (current-global-map)
  [remap shell-command] 'with-editor-shell-command)
```
however it doesn't really neatly fit within `:term eshell` or `:term vterm`, so perhaps `:term with-editor` is the better way to go.

As for why to have this and not just have users set `$EDITOR` to `emacsclient`, from the [magit wiki](https://github.com/magit/magit/wiki/Emacsclient) it seems that in some cases this isn't a robust fix (it anecdotally works for me, but I have Emacs installed through nix). Also, people might not want `emacsclient` as their editor when they are in a standalone terminal, but when using a terminal inside Emacs the chances of that are slim to none imo.

Todo after review but before merge:
- [ ] modify the `with-editor` commit to be the latest one
- [ ] rebase on latest `develop`