### PR TITLE
Update clj-refactor to latest commit on master

### DIFF
--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -15,7 +15,7 @@
 
 ;;; Core packages
 (package! clojure-mode :pin "e1dc7caee76d117a366f8b8b1c2da7e6400636a8")
-(package! clj-refactor :pin "23743432c39be9b62630f3f6468ac36ebc12aaff")
+(package! clj-refactor :pin "9e1f92033449a4abc6218ce31670d89e3e6a4dc5")
 (package! cider :pin "2b8bde358063e782771f2f12bdf32374d68a7174")
 (when (featurep! :checkers syntax)
   (package! flycheck-clj-kondo :pin "a558bda44c4cb65b69fa53df233e8941ebd195c5"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #5593

**What has changed:**

Pin `clj-refactor` to [the latest commit on master](https://github.com/clojure-emacs/clj-refactor.el/commit/9e1f92033449a4abc6218ce31670d89e3e6a4dc5).

The diff between current pinned commit and the new pinned commit is here: https://github.com/clojure-emacs/clj-refactor.el/compare/23743432c39be9b62630f3f6468ac36ebc12aaff...9e1f92033449a4abc6218ce31670d

**Why:**

Fixes the issue of `clj-refactor` and `refactor-nrepl` version being out-of-sync as described in #5593
