### PR TITLE
fix(go): company-go pin after melpa recipe change

### DIFF
--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -9,7 +9,7 @@
 (package! go-gen-test :pin "35df36dcd555233ee1a618c0f6a58ce6db4154d9")
 
 (when (featurep! :completion company)
-  (package! company-go :pin "4acdcbdea79de6b3dee1c637eca5cbea0fdbe37c"))
+  (package! company-go :pin "31948b463f2fc18f8801e5a8fe511fef300eb3dd"))
 
 (when (featurep! :checkers syntax)
   (package! flycheck-golangci-lint :pin "8e446c68311048f0b87febf8ef0379e29d358851"))


### PR DESCRIPTION
melpa/melpa@552d033e573f updated the recipe for company-go to pull from
emacsattic instead of mdempsky/gocode, which does not contain the commit
Doom pins company-go to.

Pin to the latest commit in the new repository instead, which is one
commit behind the previous repo (it does not have
mdempsky/gocode@f531cad26218, but it looks like this does not matter for
Doom).