### PR TITLE
fix: +vc/browse-at-remote-file-or-region -> +vc/browse-at-remote

### DIFF
--- a/modules/editor/evil/+commands.el
+++ b/modules/editor/evil/+commands.el
@@ -33,7 +33,7 @@
 ;;; GIT
 (evil-ex-define-cmd "gist"        #'+gist:send)  ; send current buffer/region to gist
 (evil-ex-define-cmd "gistl"       #'+gist:list)  ; list gists by user
-(evil-ex-define-cmd "gbrowse"     #'+vc/browse-at-remote-file-or-region) ; show file/region in github/gitlab
+(evil-ex-define-cmd "gbrowse"     #'+vc/browse-at-remote) ; show file/region in github/gitlab
 (evil-ex-define-cmd "gissues"     #'forge-browse-issues)  ; show github issues
 (evil-ex-define-cmd "git"         #'magit-status)         ; open magit status window
 (evil-ex-define-cmd "gstage"      #'magit-stage)


### PR DESCRIPTION
+vc/browse-at-remote-file-or-region no longer exists. +vc/browse-at-remote seems like the reasonable replacement.