### PR TITLE
fix(eshell): use completing-read for eshell-history if vertico is used 

### DIFF
--- a/modules/term/eshell/autoload/eshell.el
+++ b/modules/term/eshell/autoload/eshell.el
@@ -165,6 +165,13 @@ Once the eshell process is killed, the previous frame layout is restored."
                      :action #'ivy-completion-in-region-action)))
         ((featurep! :completion helm)
          (helm-eshell-history))
+        ((featurep! :completion vertico)
+         (completing-read "Command: "
+                          (delete-dups
+                           (when (> (ring-size eshell-history-ring) 0)
+                             (ring-elements eshell-history-ring)))
+                          )
+         )
         ((eshell-list-history))))
 
 ;;;###autoload


### PR DESCRIPTION
Switching to vertico results in `+eshell/search-history` defaulting to `eshell-list-history`,  using `completing-read` allows us to tie into vertico completions which are much nicer.

 
