### PR TITLE
feat(eshell): add vertico completion for eshell history

### DIFF
--- a/modules/term/eshell/autoload/eshell.el
+++ b/modules/term/eshell/autoload/eshell.el
@@ -166,6 +166,7 @@ Once the eshell process is killed, the previous frame layout is restored."
         ((featurep! :completion helm)
          (helm-eshell-history))
         ((featurep! :completion vertico)
+         (forward-char 1) ;; Move outside of read only prompt text.
          (consult-history))
         ((eshell-list-history))))
 


### PR DESCRIPTION
Switching to vertico results in +eshell/search-history defaulting to eshell-list-history, using completing-read allows us to tie into vertico completions which are much nicer.
