### PR TITLE
fix: update to `go install` instead of `go get`

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -78,14 +78,14 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 #+BEGIN_SRC sh
 export GOPATH=~/work/go
 
-go get -u github.com/x-motemen/gore/cmd/gore
-go get -u github.com/stamblerre/gocode
-go get -u golang.org/x/tools/cmd/godoc
-go get -u golang.org/x/tools/cmd/goimports
-go get -u golang.org/x/tools/cmd/gorename
-go get -u golang.org/x/tools/cmd/guru
-go get -u github.com/cweill/gotests/...
-go get -u github.com/fatih/gomodifytags
+go install github.com/x-motemen/gore/cmd/gore@latest
+go install github.com/stamblerre/gocode@latest
+go install golang.org/x/tools/cmd/godoc@latest
+go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/cmd/gorename@latest
+go install golang.org/x/tools/cmd/guru@latest
+go install github.com/cweill/gotests/gotests@latest
+go install github.com/fatih/gomodifytags@latest
 #+END_SRC
 
 + ~golangci-lint~ (optional: for flycheck to integrate golangci-lint results)


### PR DESCRIPTION
Currently the dependencies listed use `go get`, but this is soon to be deprecated. Replace
the `go get` commands with `go install` command.
