### PR TITLE
Let +phpunit-docker-compose-mode be disabled

### DIFF
--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -198,11 +198,15 @@ A lot of projects rely on running inside docker compose (ie Laravel), and as
 such a minor mode has been configured to attempt to run tests inside the =php-fpm=
 (by default) container.
 
-If for some reason you wish to specify a different container, modify the
-~+php/default-docker-container~ variable (ideally inside a ~.dir-locals.el~ file)
+This mode is disabled by default, to opt-in set =+php-run-tests-in-docker= to =t= in
+your config. If this is done during Emacs running, you will also have to reload
+=php-mode= (i.e. through =M-x php-mode=)
+
+If you wish to specify a different container, modify the
+~+php-default-docker-container~ variable (ideally inside a ~.dir-locals.el~ file)
 
 #+begin_src emacs-lisp
-((php-mode . ((+php/default-docker-container . "php-octane"))))
+((php-mode . ((+php-default-docker-container . "php-octane"))))
 #+end_src
 
 * Troubleshooting

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -9,6 +9,9 @@
 (defvar +php-default-docker-compose "docker-compose.yml"
   "Path to docker-compose file.")
 
+(defvar +php-run-tests-in-docker nil
+  "Whether or not to run tests in a docker environment")
+
 (after! projectile
   (add-to-list 'projectile-project-root-files "composer.json"))
 
@@ -164,8 +167,12 @@
   :files ("composer.json"))
 
 (def-project-mode! +phpunit-docker-compose-mode
+  :when +php-run-tests-in-docker
   :modes '(php-mode docker-compose-mode)
   :files (and "phpunit.xml" (or +php-default-docker-compose  "docker-compose.yml"))
   :on-enter
   (setq phpunit-args `("exec" ,+php-default-docker-container "php" "vendor/bin/phpunit")
-        phpunit-executable (executable-find "docker-compose")))
+        phpunit-executable (executable-find "docker-compose"))
+  :on-exit
+  (setq phpunit-args nil
+        phpunit-executable nil))


### PR DESCRIPTION
Currently no simple way to disable this, this PR aims to make the functionality
opt-in behind a flag