### PR TITLE
Bump :clojure cider

### DIFF
--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -16,6 +16,7 @@
 ;;; Core packages
 (package! clojure-mode :pin "e1dc7caee76d117a366f8b8b1c2da7e6400636a8")
 (package! clj-refactor :pin "9e1f92033449a4abc6218ce31670d89e3e6a4dc5")
-(package! cider :pin "2b8bde358063e782771f2f12bdf32374d68a7174")
+(package! cider :pin "0a9d0ef429e76ee36c34e116c4633c69cea96c67")
+
 (when (featurep! :checkers syntax)
   (package! flycheck-clj-kondo :pin "a558bda44c4cb65b69fa53df233e8941ebd195c5"))


### PR DESCRIPTION
Bump cider version.

Reason: 
- Latest commit fixes this issue: https://github.com/clojure-emacs/cider/issues/3071

Diff of changes in cider: https://github.com/clojure-emacs/cider/compare/2b8bde358...0a9d0ef429e7
