### PR TITLE
bump: :emacs vc :tools magit

### DIFF
--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -6,7 +6,6 @@
 (package! smerge-mode :built-in t)
 
 (package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
-(package! git-commit :pin "1e40d0021790707f6e88debda04f6b14d9429586")
+(package! git-commit :pin "aba0a596115b42fbd60347d893bcc319020ce5a2")
 (package! git-timemachine :pin "3381797bcbf906b18dff654a2361032d2d01b4a3")
-(package! gitconfig-mode :pin "433e1c57a63c88855fc41a942e29d7bc8c9c16c7")
-(package! gitignore-mode :pin "433e1c57a63c88855fc41a942e29d7bc8c9c16c7")
+(package! git-modes :pin "62fbf2e5b84ca789e7bc2f87939386023b5ba3df")

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,9 +1,9 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "bb7b7a402025e26aabc0aee6e97c2ee852a806a9")
+(when (package! magit :pin "aba0a596115b42fbd60347d893bcc319020ce5a2")
   (when (featurep! +forge)
-    (package! forge :pin "8264234db61b8a7f427b972aaef6235f9f6a13fa"))
+    (package! forge :pin "72b29bd7bc4172705b55bdd2a5070202ec154069"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "60152d5c4e4b73e72e15f23ca16e8cc7734906bc")
-  (package! github-review :pin "4d91dd6c56be1ae2b93b6b9e50c73f657cc461b6"))
+  (package! github-review :pin "2a24e75dfc2d9f37789ff60b4c10deb7c96f3f88"))


### PR DESCRIPTION
Also fixed an error:
```
    x There was an unexpected error
      Message: error
      Error: (error "Could not find package gitconfig-mode. Updating recipe repositories: (org-elpa melpa gnu-elpa-mirror el-get emacsmirror-mirror) with ‘straight-pull-recipe-repositories’ may fix this")
      Backtrace:
        (error "Could not find package %S. Updating recipe repositories: %S with `...
        (if (straight--package-built-in-p melpa-style-recipe) (throw '--cl-block-s...
        (or (straight-recipes-retrieve melpa-style-recipe nil cause) (if (straight...
        (if recipe-specified-p melpa-style-recipe (or (straight-recipes-retrieve m...
        (let* ((recipe-specified-p (listp melpa-style-recipe)) (full-melpa-style-r...
        (or (and (symbolp melpa-style-recipe) (gethash (symbol-name melpa-style-re...
        (catch '--cl-block-straight--convert-recipe-- (if (memq melpa-style-recipe...
        (straight--convert-recipe gitconfig-mode nil)
        (let ((recipe (straight--convert-recipe (or (straight--get-overridden-reci...
        (catch '--cl-block-straight-use-package-- (let ((recipe (straight--convert...
    ! Extended backtrace logged to .local/doom.error.log
```

So, it:
 - Fixes #5667
 - Fixes #5668

Until it is merged, you may use workaround which can be found at https://github.com/hlissner/doom-emacs/issues/5667#issuecomment-948229579