### PR TITLE
bump: :emacs vc

### DIFF
--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -8,5 +8,4 @@
 (package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
 (package! git-commit :pin "1e40d0021790707f6e88debda04f6b14d9429586")
 (package! git-timemachine :pin "3381797bcbf906b18dff654a2361032d2d01b4a3")
-(package! gitconfig-mode :pin "433e1c57a63c88855fc41a942e29d7bc8c9c16c7")
-(package! gitignore-mode :pin "433e1c57a63c88855fc41a942e29d7bc8c9c16c7")
+(package! git-modes :pin "62fbf2e5b84ca789e7bc2f87939386023b5ba3df")


### PR DESCRIPTION
Doom configs that use the `:emacs vc` module are broken due to this issue