### PR TITLE
fix: make 'doom build' pass on Emacs without native comp

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -185,13 +185,14 @@ users).")
 
 (with-eval-after-load 'comp
   ;; HACK Disable native-compilation for some troublesome packages
-  (mapc (doom-partial #'add-to-list 'native-comp-deferred-compilation-deny-list)
+  (when (featurep 'comp)
+    (mapc (doom-partial #'add-to-list 'native-comp-deferred-compilation-deny-list)
         (let ((local-dir-re (concat "\\`" (regexp-quote doom-local-dir))))
           (list (concat "\\`" (regexp-quote doom-autoloads-file) "\\'")
                 (concat local-dir-re ".*/evil-collection-vterm\\.el\\'")
                 (concat local-dir-re ".*/with-editor\\.el\\'")
                 ;; https://github.com/nnicandro/emacs-jupyter/issues/297
-                (concat local-dir-re ".*/jupyter-channel\\.el\\'")))))
+                (concat local-dir-re ".*/jupyter-channel\\.el\\'"))))))
 
 
 ;;


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

`doom build` currently fails on Emacs <= 27 because due to insufficient feature gating. It turns out that `with-eval-after-load 'comp` doesn't fully ensure that native comp actually loads, and the following code bypasses its checks:

https://github.com/hlissner/doom-emacs/blob/0869d28483b5d81b818b110af351fd5c4dc04dd9/core/cli/packages.el#L227

This PR adds an additional check to ensure that native comp actually did load before running the gated code.

For reference, here's the actual error I got before applying the fix:


```console
❯ doom sync
> Executing 'doom sync' with Emacs 27.2 at 2021-10-25 01:55:03
  > Compiling your literate config...
    - Tangled 36 code blocks from config.org
    - Restarting...
  > Synchronizing your config with Doom Emacs...
    > Regenerating envvars file at "~/.config/emacs/.local/env"
      ✓ Successfully generated "~/.config/emacs/.local/env"
    > Installing packages...
      - No packages need to be installed
    > (Re)building packages...
      x There was an unexpected error
        Message: Symbol's value as variable is void
        Error: (void-variable native-comp-deferred-compilation-deny-list)
        Backtrace:
          (add-to-list native-comp-deferred-compilation-deny-list "\\`/Users/midchil...
          (apply add-to-list (native-comp-deferred-compilation-deny-list "\\`/Users/...
          (#[128 "\302\300\303\301\"\"\207" [add-to-list (native-comp-deferred-comp...
          (mapc #[128 "\302\300\303\301\"\"\207" [add-to-list (native-comp-deferred...
          ((closure (t) nil (mapc (doom-partial #'add-to-list 'native-comp-deferred-...
          (#[0 "        \204\300 \207   \302\303!\211\304\305\306\307\310\3#\311\"\31...
          (compat--require #<subr require> comp nil t)
          (apply compat--require #<subr require> (comp nil t))
          (require comp nil t)
          (and (require 'comp nil t) (condition-case nil (progn (native-comp-availab...
      ! Extended backtrace logged to .local/doom.error.log
```
