### PR TITLE
docs: fix wrong link syntax

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -298,7 +298,7 @@ to least recommended for Doom (based on compatibility).
   #+END_SRC
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have
-  experienced [flashing artifacts when scrolling](https://github.com/d12frosted/homebrew-emacs-plus/issues/314):
+  experienced [[https://github.com/d12frosted/homebrew-emacs-plus/issues/314][flashing artifacts when scrolling]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
   brew install emacs-plus


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Markdown style link syntax doesn't work in `.org` file.
Replace it with the org-mode style link syntax.