### PR TITLE
Update Erlang module docs

### DIFF
--- a/modules/lang/erlang/README.org
+++ b/modules/lang/erlang/README.org
@@ -1,5 +1,5 @@
 #+TITLE:   lang/erlang
-#+DATE:    January 14, 2020
+#+DATE:    October 28, 2021
 #+SINCE:   {replace with next tagged release version}
 #+STARTUP: inlineimages nofold
 
@@ -14,25 +14,23 @@
 * Description
 
 This module provides support [[https://www.erlang.org/][Erlang programming language]]. Support for the
-[[https://github.com/erlang/sourcer][sourcer]] language server is optional.
+[[https://erlang-ls.github.io][erlang_ls]] language server is optional.
 
 ** Maintainers
 This module has no dedicated maintainers.
 
 ** Module Flags
-+ ~+lsp~ Enable LSP Support. Requires [[https://github.com/erlang/sourcer][sourcer]].
-
++ ~+lsp~ Enable LSP Support. Requires [[https://erlang-ls.github.io][erlang_ls]].
 
 ** Plugins
 + Erlang Mode (bundled with Erlang installations)
-+ [[https://github.com/joedevivo/flycheck-rebar3][flycheck-rebar3]]
-+ [[https://github.com/s-kostyaev/ivy-erlang-complete][ivy-erlang-complete]]
++ [[https://github.com/s-kostyaev/company-erlang][company-erlang]]
 
 * Prerequisites
 You should have Erlang installed. Check your distribution's package manager or a
-version management tool such as [[https://github.com/kerl/kerl][kerl]].
+version management tool such as [[https://github.com/kerl/kerl][kerl]] or [[https://asdf-vm.com][asdf]].
 
-If you want LSP support, install [[https://github.com/erlang/sourcer][sourcer]].
+If you want LSP support, install [[https://erlang-ls.github.io][erlang_ls]].
 
 * Features
 - Code completion (~+lsp~, ~:completion company~, and ~:completion ivy~)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Ref #1166  

Update the module docs with new info about `company-erlang` and the current best language server: ErlangLS.
Before the outdated information about sourcerer would cause some confusion for new users. 
