### PR TITLE
work around expired ssl cert

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -3,7 +3,7 @@
 
 (package! org
   :recipe (:host nil
-           :repo "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+           :repo "git://git.sv.gnu.org/emacs/org-mode.git"
            :files (:defaults "etc")
            ;; HACK Org requires a post-install compilation step to generate a
            ;;      org-version.el with org-release and org-git-version
@@ -18,7 +18,7 @@
                              (cdr (doom-call-process "git" "rev-parse" "--short" "HEAD")))
                      "(provide 'org-version)\n")))
   :pin "cc2490a7061955395c4f5a1a23a088044554a2f7")
-(package! org-contrib :pin "b8012e759bd5bf5da802b0b41734a8fec218323c")
+;(package! org-contrib :pin "b8012e759bd5bf5da802b0b41734a8fec218323c")
 
 (package! avy)
 (package! htmlize :pin "dd27bc3f26efd728f2b1f01f9e4ac4f61f2ffbf9")


### PR DESCRIPTION
Refer to issue #5655
This patch lets me install doom-emacs.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #5655 <!-- remove if not applicable -->

Found an alternative git repo for org-mode and just commented out the org-contrib package since it had the same issue. May require further work to find an alternative to org-contrib.
