### PR TITLE
feat(layout): add colemak layout

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -91,7 +91,7 @@ Modules that reconfigure or augment packages or features built into Emacs.
 * :input
 + [[file:../modules/input/chinese/README.org][chinese]] - TODO
 + [[file:../modules/input/japanese/README.org][japanese]] - TODO
-+ [[file:../modules/input/layout/README.org][layout]] =+azerty +bepo= - TODO
++ [[file:../modules/input/layout/README.org][layout]] =+azerty +bepo +colemak= - TODO
 
 * :lang
 Modules that bring support for a language or group of languages to Emacs.

--- a/modules/input/layout/+colemak.el
+++ b/modules/input/layout/+colemak.el
@@ -16,6 +16,8 @@
         :mnv  "ge" #'evil-previous-visual-line
         :mnvo "i"  #'evil-forward-char
         :mnv  "I"  #'evil-window-bottom
+        :nv   "gi" #'evil-lion-left
+        :nv   "gI" #'evil-lion-right
         :mnv  "zi" #'evil-scroll-column-right
         :mnv  "zI" #'evil-scroll-right
         :mnv  "j"  #'evil-forward-word-end

--- a/modules/input/layout/+colemak.el
+++ b/modules/input/layout/+colemak.el
@@ -1,0 +1,42 @@
+;;; input/layout/+colemak.el -*- lexical-binding: t; -*-
+
+;; Colemak keeps exactly the same keys as QWERTY, just moving them around
+;; Therefore, it only makes sense to move the ergonomic HJKL, and any conflicting keys
+;; This does not remap any keys outside of Evil mode
+
+;; Borrows heavily from https://github.com/wbolster/emacs-evil-colemak-basics
+
+(defun +layout-remap-evil-keys-for-colemak-h ()
+  (map! :mnv  "n"  #'evil-next-line
+        :nv   "N"  #'evil-join
+        :mnv  "gn" #'evil-next-visual-line
+        :nv   "gN" #'evil-join-whitespace
+        :mnv  "e"  #'evil-previous-line
+        :mnv  "E"  #'evil-lookup
+        :mnv  "ge" #'evil-previous-visual-line
+        :mnvo "i"  #'evil-forward-char
+        :mnv  "I"  #'evil-window-bottom
+        :mnv  "zi" #'evil-scroll-column-right
+        :mnv  "zI" #'evil-scroll-right
+        :mnv  "j"  #'evil-forward-word-end
+        :mnv  "J"  #'evil-forward-word-end
+        :mnv  "gj" #'evil-backward-word-end
+        :mnv  "gJ" #'evil-backward-word-end
+        :mnv  "k"  #'evil-search-next
+        :mnv  "K"  #'evil-search-previous
+        :mnv  "gk" #'evil-next-match
+        :mnv  "gK" #'evil-previous-match
+        :n    "l"  #'evil-undo
+        :v    "l"  #'evil-downcase
+        :v    "L"  #'evil-upcase
+        :nv   "gl" #'evil-downcase
+        :nv   "gL" #'evil-upcase
+        :n    "u"  #'evil-insert
+        :vo   "u"  evil-inner-text-objects-map
+        :n    "U"  #'evil-insert-line
+        :v    "U"  #'evil-insert
+        :n    "gu" #'evil-insert-resume
+        :n    "gU" #'evil-insert-0-line))
+
+(when (featurep! :editor evil)
+  (+layout-remap-evil-keys-for-colemak-h))

--- a/modules/input/layout/+colemak.el
+++ b/modules/input/layout/+colemak.el
@@ -36,7 +36,27 @@
         :n    "U"  #'evil-insert-line
         :v    "U"  #'evil-insert
         :n    "gu" #'evil-insert-resume
-        :n    "gU" #'evil-insert-0-line))
+        :n    "gU" #'evil-insert-0-line
+        (:map doom-leader-file-map
+         "w"       #'save-buffer)
+        (:map evil-window-map
+         "n"       #'evil-window-down
+         "N"       #'+evil/window-move-down
+         "C-n"     #'evil-window-down
+         "C-S-n"   #'evil-window-move-very-bottom
+         "e"       #'evil-window-up
+         "E"       #'+evil/window-move-up
+         "C-e"     #'evil-window-up
+         "C-S-e"   #'evil-window-move-very-top
+         "i"       #'evil-window-right
+         "I"       #'+evil/window-move-right
+         "C-i"     #'evil-window-right
+         "C-S-i"   #'evil-window-move-far-right
+         "k"       #'evil-window-new)
+        (:when (featurep! :tools magit)
+         :map magit-mode-map
+         :nv "n"   #'evil-next-visual-line
+         :nv "e"   #'evil-previous-visual-line)))
 
 (when (featurep! :editor evil)
   (+layout-remap-evil-keys-for-colemak-h))

--- a/modules/input/layout/+colemak.el
+++ b/modules/input/layout/+colemak.el
@@ -52,11 +52,14 @@
          "I"       #'+evil/window-move-right
          "C-i"     #'evil-window-right
          "C-S-i"   #'evil-window-move-far-right
-         "k"       #'evil-window-new)
-        (:when (featurep! :tools magit)
-         :map magit-mode-map
-         :nv "n"   #'evil-next-visual-line
-         :nv "e"   #'evil-previous-visual-line)))
+         "k"       #'evil-window-new)))
+
+(defun +layout-remap-magit-evil-keys-for-colemak-h ()
+  (map! :map magit-mode-map
+        :nv "n"    #'evil-next-visual-line
+        :nv "e"    #'evil-previous-visual-line))
 
 (when (featurep! :editor evil)
-  (+layout-remap-evil-keys-for-colemak-h))
+  (+layout-remap-evil-keys-for-colemak-h)
+  (when (featurep! :tools magit)
+    (add-hook 'magit-mode-hook #'+layout-remap-magit-evil-keys-for-colemak-h)))

--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -35,6 +35,8 @@ This module provides barebones support for using Doom with non-qwerty layouts.
 + =+bepo= Remaps keybinds to accommodate the
   [[https://en.wikipedia.org/wiki/B%C3%89PO][BÉPO keyboard layout]] (version
   1.1, in particualr).
++ =+colemak= Remaps keybinds to accommodate the
+  [[https://en.wikipedia.org/wiki/Colemak][Colemak keyboard layout]]
 
 ** Plugins
 None

--- a/modules/input/layout/autoload/colemak.el
+++ b/modules/input/layout/autoload/colemak.el
@@ -1,0 +1,19 @@
+;;; input/layout/autoload/colemak.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +layout-colemak-rotate-dh ()
+  "Swap the H and M key-maps.
+This is intended for use with the Colemak-DH layout."
+    (map! :mnvo "m"  #'evil-backward-char
+          :n    "zm" #'evil-scroll-column-left
+          :n    "zM" #'evil-scroll-left
+          :n    "h"  #'evil-set-marker
+          :mnv  "zh" #'evil-close-folds
+          (:map evil-window-map
+           "m"       #'evil-window-left
+           "M"       #'+evil/window-move-left
+           "C-m"     #'evil-window-left
+           "C-s-m"   #'evil-window-move-far-left
+           "h h"     #'doom/window-maximize-buffer
+           "h s"     #'doom/window-maximize-horizontally
+           "h v"     #'doom/window-maximize-vertically)))

--- a/modules/input/layout/autoload/colemak.el
+++ b/modules/input/layout/autoload/colemak.el
@@ -17,3 +17,22 @@ This is intended for use with the Colemak-DH layout."
          "h h"     #'doom/window-maximize-buffer
          "h s"     #'doom/window-maximize-horizontally
          "h v"     #'doom/window-maximize-vertically)))
+
+;;;###autoload
+(defun +layout-colemak-rotate-t-f-j ()
+  "Rotate the T, F and J keys.
+T becomes find-char   (Qwerty F, same position)
+F becomes end-of-word (Qwerty E, same position)
+J becomes until-char  (Qwerty T, different position)"
+  (map! :mnv "t"  #'evil-snipe-f
+        :mnv "T"  #'evil-snipe-F
+        :mnv "gt" #'find-file-at-point
+        :mnv "gT" #'evil-find-file-at-point-with-line
+        :mnv "f"  #'evil-forward-word-end
+        :mnv "F"  #'evil-forward-WORD-end
+        :mnv "gf" #'evil-backward-word-end
+        :mnv "gF" #'evil-backward-WORD-end
+        :mnv "j"  #'evil-snipe-t
+        :mnv "J"  #'evil-snipe-T
+        :mnv "gj" #'+workspace:switch-next
+        :mnv "gJ" #'+workspace:switch-previous))

--- a/modules/input/layout/autoload/colemak.el
+++ b/modules/input/layout/autoload/colemak.el
@@ -4,16 +4,16 @@
 (defun +layout-colemak-rotate-dh ()
   "Swap the H and M key-maps.
 This is intended for use with the Colemak-DH layout."
-    (map! :mnvo "m"  #'evil-backward-char
-          :n    "zm" #'evil-scroll-column-left
-          :n    "zM" #'evil-scroll-left
-          :n    "h"  #'evil-set-marker
-          :mnv  "zh" #'evil-close-folds
-          (:map evil-window-map
-           "m"       #'evil-window-left
-           "M"       #'+evil/window-move-left
-           "C-m"     #'evil-window-left
-           "C-s-m"   #'evil-window-move-far-left
-           "h h"     #'doom/window-maximize-buffer
-           "h s"     #'doom/window-maximize-horizontally
-           "h v"     #'doom/window-maximize-vertically)))
+  (map! :mnvo "m"  #'evil-backward-char
+        :n    "zm" #'evil-scroll-column-left
+        :n    "zM" #'evil-scroll-left
+        :n    "h"  #'evil-set-marker
+        :mnv  "zh" #'evil-close-folds
+        (:map evil-window-map
+         "m"       #'evil-window-left
+         "M"       #'+evil/window-move-left
+         "C-m"     #'evil-window-left
+         "C-s-m"   #'evil-window-move-far-left
+         "h h"     #'doom/window-maximize-buffer
+         "h s"     #'doom/window-maximize-horizontally
+         "h v"     #'doom/window-maximize-vertically)))

--- a/modules/input/layout/config.el
+++ b/modules/input/layout/config.el
@@ -4,5 +4,7 @@
   (defun +layout-init-h ()
     (cond ((featurep! +bepo)
            (load! "+bepo"))
+          ((featurep! +colemak)
+           (load! "+colemak"))
           ((featurep! +azerty)
            (load! "+azerty")))))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #783 

The Colemak keyboard layout moves the default navigation keys (HJKL) to positions where they must be pressed by the same finger, negating some of the efficiency benefits of the layout.

This PR adds a `+colemak` option to the `:input layout` module, which remaps HJKL to the original Querty positions (HNEI), and remaps the over-ridden keys to their Querty positions. The design is based off of https://github.com/wbolster/emacs-evil-colemak-basics/blob/master/evil-colemak-basics.el, which seems to be a consensus from the issue. 