### PR TITLE
module: add :os exwm

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -109,6 +109,7 @@
        :os
        (:if IS-MAC macos)  ; improve compatibility with macOS
        ;;tty               ; improve the terminal Emacs experience
+       ;;exwm              ; make Emacs your window manager
 
        :lang
        ;;agda              ; types of types of types of types...

--- a/modules/os/exwm/README.org
+++ b/modules/os/exwm/README.org
@@ -1,0 +1,145 @@
+#+TITLE:   private/exwm
+#+DATE:    January 5, 2022
+#+SINCE:   v1.0.0
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+  - [[#hacks][Hacks]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+  - [[#setting-up-your-xinitrc-file][Setting up your ~xinitrc~ file.]]
+  - [[#setting-the-default-major-mode-for-exwm-edit][Setting the default major mode for EXWM Edit.]]
+  - [[#setting-up-link-hints-for-chrome-based-and-firefox-based-web-browsers][Setting up link hints for Chrome-based and Firefox-based web browsers]]
+  - [[#setting-up-multiple-monitors][Setting up multiple monitors]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#how-do-i-send-escape-or-c-c-to-applications][How do I send ~escape~ or ~C-c~ to applications?]]
+  - [[#when-i-mouse-click-while-in-evils-normal-state-i-get-an-error][When I mouse-click while in Evil's normal state I get an error.]]
+
+* Description
+
+This module enables and provides sane defaults for the Emacs X Window Manager
+[[https://github.com/ch11ng/exwm][(EXWM)]].
+
++ Control applications as Emacs buffers.
++ Edit any application's input field with Emacs.
++ Use Emacs input methods in other applications.
++ Use VIM keys in major web browsers like Firefox and Chrome.
++ Truly use Evil everywhere!
+
+** Maintainers
+
++ @[[https://github.com/LemonBreezes][LemonBreezes]] (Author)
+
+** Module Flags
+
+This module provides no flags.
+
+** Plugins
+
+# A list of linked plugins
++ [[https://github.com/ch11ng/exwm][exwm]]
++ [[https://github.com/LemonBreezes/exwm-evil][exwm-evil]]
++ [[https://github.com/walseb/exwm-firefox-evil][exwm-firefox-evil]]
++ [[https://github.com/agzam/exwm-edit][exwm-edit]]
++ [[https://github.com/andreasjansson/language-detection.el][language-detection]]
++ [[https://github.com/ieure/exwm-mff][exwm-mff]]
+
+** Hacks
+
+When switching to a workspace where an EXWM buffer is focused, inputs do not get
+passed to the application. To fix this, I wrote a hook which clicks on the
+application with the mouse to regain focus. The spot I chose for clicking may
+not be blank for all applications. If someone finds a better solution, please
+submit a pull request.
+
+* Prerequisites
+
+This module has no prerequisites.
+
+* Features
+
++ Edit any application's input field with ~C-c '~.
++ Use Emacs input methods in other applications. Simply set the input method as
+  usual with =C-x RET C-\=.
++ Use Evil in any application! Specific browsers such as Google Chrome and
+  Firefox have extended support for Evil keybindings. Simply install the
+  ~link-hints~ extension/add-on and start VIM-ing!
+
+Moreover, when this module is loaded, the following global keybindings are made:
+
+| Keybinding | Description                  |
+|------------+------------------------------|
+| =SPC $=    | Open a GNU/Linux application |
+
+* Configuration
+
+** Setting up your ~xinitrc~ file.
+
+In order to enable EXWM, Emacs needs to be running within X.Org without any
+window manager present. The recommended way to go about this is with the
+~startx~ script. The [[https://github.com/ch11ng/exwm/wiki/Configuration-Example][EXWM wiki]] contains an example ~xinitrc~ file for use by
+~startx~.
+
+** Setting the default major mode for EXWM Edit.
+:PROPERTIES:
+:CREATED_TIME: [2022-01-05 Wed 23:44]
+:END:
+
+By default, when you edit an application's input field and no programming
+language can be detected in the text, ~org-mode~ will your major mode. If you
+would like to change this, set the ~+exwm-edit-default-major-mode~ variable:
+#+begin_src elisp
+(setq +exwm-edit-default-major-mode 'markdown-mode)
+#+end_src
+
+** Setting up link hints for Chrome-based and Firefox-based web browsers
+:PROPERTIES:
+:CREATED_TIME: [2022-01-06 Thu 01:19]
+:END:
+
+For users of Evil, the ~f~ and ~F~ keys are bound to special Link Hint commands
+within Chrome-based and Firefox-based web browsers. For these commands to work,
+you must have the Link Hint add-on/extension installed. For Chrome-based web
+browsers, install Link Hint through [[https://chrome.google.com/webstore/detail/link-hints/kjjgifdfplpegljdfnpmbjmkngdilmkd][here]]. For Firefox-based web browsers, use
+[[https://addons.mozilla.org/en-US/firefox/addon/linkhints/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=search][this]] link instead.
+
+** Setting up multiple monitors
+:PROPERTIES:
+:CREATED_TIME: [2022-01-06 Thu 00:06]
+:END:
+
+Currently this module does not provide any simplified setup for multi-head
+configurations. Please refer to
+https://github.com/ch11ng/exwm/wiki#randr-multi-screen for how to do this.
+
+* Troubleshooting
+
+# Common issues and their solution, or places to look for help.
+
+** How do I send ~escape~ or ~C-c~ to applications?
+:PROPERTIES:
+:CREATED_TIME: [2022-01-06 Thu 00:13]
+:END:
+
+| Keybind   | Description                                            |
+|-----------+--------------------------------------------------------|
+| =C-c C-i= | Send the escape key (only bound when Evil is enabled). |
+| =C-c C-c= | Send the C-c key.                                      |
+
+** When I mouse-click while in Evil's normal state I get an error.
+:PROPERTIES:
+:CREATED_TIME: [2022-01-06 Thu 00:24]
+:END:
+
+I (the author) do not know how to suppress or remove the,
+"evil-mouse-drag-region must be bound to an event with parameters" error. I
+recommend ignoring this error though as your clicks still register.
+
+This bug is a result of a workaround I copied from this GitHub issue:
+https://github.com/walseb/exwm-firefox-evil/issues/1

--- a/modules/os/exwm/autoload/exwm-edit.el
+++ b/modules/os/exwm/autoload/exwm-edit.el
@@ -1,0 +1,69 @@
+;;; private/exwm/autoload/exwm-edit.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defvar +exwm-edit-default-major-mode 'org-mode
+  "The major mode used when a programming language is not detected
+after running `exwm-edit--compose'.")
+
+;;;###autoload
+(defvar +exwm-edit-activate-appropriate-major-mode--timer nil
+  "A variable used internally to store a timer object.")
+
+;;;###autoload
+(defun +exwm-edit-activate-appropriate-major-mode ()
+  "Detects what programming language (if any) is present in the
+application's input field and enables the appropriate major mode."
+  (setq exwm-edit-activate-appropriate-major-mode--timer
+        (run-at-time
+         0.01 0.01
+         (defun exwm-edit-activate-appropriate-major-mode--timer-fn (&rest _)
+           (unless (string-prefix-p "*exwm-edit "
+                                    (buffer-name))
+             (cancel-timer exwm-edit-activate-appropriate-major-mode--timer))
+           (when (buffer-modified-p)
+             (cancel-timer exwm-edit-activate-appropriate-major-mode--timer)
+             (let ((header-line-format--old header-line-format))
+               (when (string-prefix-p "*exwm-edit "
+                                      (buffer-name))
+                 (cl-case (language-detection-buffer)
+                   (ada (ada-mode))
+                   (awk (awk-mode))
+                   (c (c-mode))
+                   (cpp (c++-mode))
+                   (clojure (clojure-mode))
+                   (csharp (csharp-mode))
+                   (css (css-mode))
+                   (dart (dart-mode))
+                   (delphi (delphi-mode))
+                   (emacslisp (emacs-lisp-mode))
+                   (erlang (erlang-mode))
+                   (fortran (fortran-mode))
+                   (fsharp (fsharp-mode))
+                   (go (go-mode))
+                   (groovy (groovy-mode))
+                   (haskell (haskell-mode))
+                   (html (html-mode))
+                   (java (java-mode))
+                   (javascript (javascript-mode))
+                   (json (json-mode))
+                   (latex (latex-mode))
+                   (lisp (lisp-mode))
+                   (lua (lua-mode))
+                   (matlab (matlab-mode))
+                   (objc (objc-mode))
+                   (perl (perl-mode))
+                   (php (php-mode))
+                   (prolog (prolog-mode))
+                   (python (python-mode))
+                   (r r-(mode))
+                   (ruby (ruby-mode))
+                   (rust (rust-mode))
+                   (scala (scala-mode))
+                   (shell (shell-script-mode))
+                   (smalltalk (smalltalk-mode))
+                   (sql (sql-mode))
+                   (swift (swift-mode))
+                   (visualbasic (visual-basic-mode))
+                   (xml (sgml-mode))
+                   (t (funcall +exwm-edit-default-major-mode)))
+                 (setq header-line-format header-line-format--old))))))))

--- a/modules/os/exwm/autoload/exwm-firefox.el
+++ b/modules/os/exwm/autoload/exwm-firefox.el
@@ -1,0 +1,15 @@
+;;; private/exwm/autoload/exwm-firefox.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun exwm-firefox-core-hint-links ()
+  "Select and open a link with your keyboard."
+  (interactive)
+  (exwm-input--fake-key ?\M-j)
+  (exwm-firefox-evil-insert))
+
+;;;###autoload
+(defun exwm-firefox-core-hint-links-new-tab-and-switch ()
+  "Select and open a link in a new tab using your keyboard."
+  (interactive)
+  (exwm-input--fake-key ?\M-l)
+  (exwm-firefox-evil-insert))

--- a/modules/os/exwm/autoload/exwm.el
+++ b/modules/os/exwm/autoload/exwm.el
@@ -1,0 +1,66 @@
+;;; private/exwm/autoload/exwm.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +exwm-do-mouse-click (x y &optional button-num window-id)
+  "Perform a mouse click at (window relative) position X and Y
+
+By default BUTTON-NUM is ``1'' (i.e. main click) and the WINDOW-ID is the currently selected window.
+
+This function was taken from:
+https://github.com/ch11ng/exwm/issues/693#issuecomment-750928572"
+  (let* ((button-index (intern (format "xcb:ButtonIndex:%d" (or button-num 1))))
+         (button-mask (intern (format "xcb:ButtonMask:%d" (or button-num 1))))
+         (window-id (or window-id (exwm--buffer->id
+                                   (window-buffer (selected-window)))
+                        (user-error "No window selected")))
+         (button-actions `((xcb:ButtonPress . ,button-mask)
+                           (xcb:ButtonRelease . 0))))
+    (dolist (b-action button-actions)
+      (xcb:+request exwm--connection
+          (make-instance 'xcb:SendEvent
+                         :propagate 0
+                         :destination window-id
+                         :event-mask xcb:EventMask:NoEvent
+                         :event (xcb:marshal
+                                 (make-instance (car b-action)
+                                                :detail button-index
+                                                :time xcb:Time:CurrentTime
+                                                :root exwm--root
+                                                :event window-id
+                                                :child 0
+                                                :root-x 0
+                                                :root-y 0
+                                                :event-x x
+                                                :event-y y
+                                                :state (cdr b-action)
+                                                :same-screen 0)
+                                 exwm--connection))))
+    (xcb:flush exwm--connection)))
+
+;;;###autoload
+(defun +exwm-refocus-application (&rest _)
+  "Click on a specific portion of the application to refocus input."
+  (run-at-time
+   0.02 nil
+   (defun +exwm-refocus-application--timer (&rest _)
+     (cl-destructuring-bind
+         ((mouse-x . mouse-y) dim-x dim-y)
+         (list (mouse-absolute-pixel-position)
+               (window-pixel-width) (window-pixel-height))
+       (when (exwm--buffer->id (current-buffer))
+         ;; All that matters is that this spot be blank in the application.
+         (+exwm-do-mouse-click (floor (* dim-x (/ 1.0 1000)))
+                               (floor (* dim-y (/ 120.0 1410)))))))))
+
+;;;###autoload
+(defun +exwm-rename-buffer-to-title ()
+  "Rename the buffer to its `exwm-title'."
+  (unless (or (string-prefix-p "sun-awt-X11-" exwm-instance-name)
+              (string= "gimp" exwm-instance-name))
+    (exwm-workspace-rename-buffer exwm-title)))
+
+;;;###autoload
+(defun exwm--update-utf8-title-advice (oldfun id &optional force)
+  "Only update the window title when the buffer is visible."
+  (when (get-buffer-window (exwm--id->buffer id))
+    (funcall oldfun id force)))

--- a/modules/os/exwm/config.el
+++ b/modules/os/exwm/config.el
@@ -1,0 +1,116 @@
+;;; private/exwm/config.el -*- lexical-binding: t; -*-
+
+(add-hook 'exwm-update-title-hook #'+exwm-rename-buffer-to-title)
+
+(use-package! exwm
+  :config
+  (use-package! exwm-randr
+    :config
+    (exwm-randr-enable))
+
+  (use-package! exwm-systemtray
+    :config
+    (exwm-systemtray-enable))
+
+  ;; A few `ido' fixes.
+  (use-package! exwm-config
+    :config
+    (exwm-config--fix/ido-buffer-window-other-frame))
+
+  ;; Configure emacs input methods in all X windows.
+  (use-package! exwm-xim
+    :config
+    ;; These variables are required for X programs to connect with XIM.
+    (setenv "XMODIFIERS" "@im=exwm-xim")
+    (setenv "GTK_IM_MODULE" "xim")
+    (setenv "QT_IM_MODULE" "xim")
+    (setenv "CLUTTER_IM_MODULE" "xim")
+    (setenv "QT_QPA_PLATFORM" "xcb")
+    (setenv "SDL_VIDEODRIVER" "x11")
+    (exwm-xim-enable))
+
+  ;; Do not show warnings when a window manager is already running.
+  (advice-add #'exwm-init :around
+              (defun +ignore-warnings-a (oldfun &rest args)
+                (cl-letf (((symbol-function #'warn) (symbol-function #'ignore)))
+                  (apply oldfun args))))
+
+  (exwm-enable)
+
+  ;; Prevent EXWM buffers from changing their name while not focused.
+  ;; This allows Persp to restore them as intended.
+  (when (featurep! :ui workspaces)
+    (advice-add #'exwm--update-utf8-title :around
+                #'exwm--update-utf8-title-advice))
+
+  ;; For some reason, after switching workspaces, input focus is not updated.
+  ;; HACK This uses a mouse click to regain focus.
+  (advice-add #'+workspace-switch :after #'+exwm-refocus-application)
+
+  ;; Show EXWM buffers in buffer switching prompts.
+  (add-hook 'exwm-mode-hook #'doom-mark-buffer-as-real-h)
+
+  (map! :leader
+        :desc "Open a GNU/Linux application" "$" #'counsel-linux-app))
+
+
+(cl-pushnew ?\C-c exwm-input-prefix-keys)
+(map! :map exwm-mode-map
+      :desc "Send C-c" "C-c" (cmd! (exwm-input--fake-key ?\C-c)))
+
+(use-package exwm-evil
+  :when (featurep! :editor evil)
+  :after exwm
+  :config
+  (exwm-evil-enable-mouse-workaround)
+  (add-hook 'exwm-manage-finish-hook 'exwm-evil-mode)
+  (cl-pushnew 'escape exwm-input-prefix-keys)
+  (map! :map exwm-evil-mode-map
+        ;; We need a way to send `escape' and `C-c' keys to the EXWM application.
+        :prefix "C-c"
+        :desc "Send Escape" "C-i" (cmd! (exwm-input--fake-key 'escape))))
+
+(use-package! exwm-firefox-evil
+  :when (featurep! :editor evil)
+  :after exwm
+  :config
+  (cl-pushnew 'escape exwm-input-prefix-keys)
+  ;; We can use VIM keys with any browser that has compatible keybindings.
+  (cl-loop for class in '("firefoxdeveloperedition"
+                          "\"firefoxdeveloperedition\""
+                          "IceCat"
+                          "chromium-browser"
+                          "Google-chrome"
+                          "Google-chrome-unstable")
+           do (cl-pushnew class exwm-firefox-evil-firefox-class-name
+                          :test #'string=))
+
+  (add-hook 'exwm-manage-finish-hook 'exwm-firefox-evil-activate-if-firefox)
+  (map! :map exwm-firefox-evil-mode-map
+        :n "f" #'exwm-firefox-core-hint-links ; Requires Link Hints add-on.
+        :n "F" #'exwm-firefox-core-hint-links-new-tab-and-switch
+        :n "u" #'exwm-firefox-core-tab-close-undo
+        :n "U" #'exwm-firefox-core-undo
+        :n "/" #'exwm-firefox-core-find ; Compatible with Chrome as well.
+        :after exwm-evil
+        ;; This way we can use prefix arguments with these commands.
+        :n "j" #'exwm-evil-core-down
+        :n "k" #'exwm-evil-core-up
+        :n "h" #'exwm-evil-core-left
+        :n "l" #'exwm-evil-core-right
+        :n "+" #'exwm-evil-core-zoom-in
+        :n "-" #'exwm-evil-core-zoom-out
+        :n "=" #'exwm-evil-core-reset-zoom))
+
+(use-package! exwm-edit
+  :after exwm
+  :config
+  (setq exwm-edit-split "below")
+  (add-hook! '(exwm-edit-before-finish-hook
+               exwm-edit-before-cancel-hook)
+    (defun exwm-edit-clear-last-kill ()
+      (setq exwm-edit-last-kill nil)))
+  (add-hook 'exwm-edit-compose-hook #'exwm-edit-activate-appropriate-major-mode))
+
+(use-package! exwm-mff
+  :hook (exwm-init . exwm-mff-mode))

--- a/modules/os/exwm/packages.el
+++ b/modules/os/exwm/packages.el
@@ -1,0 +1,12 @@
+;; -*- no-byte-compile: t; -*-
+;;; private/exwm/packages.el
+
+(package! exwm :pin "10bd12234e896d35a2c4eafabc62a31126d23bf3")
+(when (featurep! :editor evil)
+  (package! exwm-evil
+    :recipe (:host github :repo "LemonBreezes/exwm-evil")
+    :pin "373c2f52f46b742622a92352d7a035ccde1aee00")
+  (package! exwm-firefox-evil :pin "14643ee53a506ddcb5d2e06cb9f1be7310cd00b1"))
+(package! exwm-edit :pin "2fd9426922c8394ec8d21c50dcc20b7d03af21e4")
+(package! language-detection :pin "54a6ecf55304fba7d215ef38a4ec96daff2f35a4")
+(package! exwm-mff :pin "89206f2e3189f589c27c56bd2b6203e906ee7100")


### PR DESCRIPTION
Hello everyone, I have written an EXWM module for Doom Emacs, which I hope you will all enjoy. 

Some features of note from this module are:
- Evil support for all EXWM buffers, with the entire suite of commands supported on Firefox-based and Chrome-based web browsers.
- The ability to edit any input field using Emacs with language detection for selecting the appropriate major mode. 

I was going to include a feature for automatically creating/destroying workspaces for EXWM applications but decided not to include it in the initial pull request. I would love to include it in a module flag.