### PR TITLE
fix(org): wrong arg type when leaving present mode

### DIFF
--- a/modules/lang/org/autoload/contrib-present.el
+++ b/modules/lang/org/autoload/contrib-present.el
@@ -78,7 +78,9 @@
            (ignore-errors (org-latex-preview '(4))))
           (t
            (text-scale-set 0)
-           (set-window-fringes nil fringe-mode fringe-mode)
+           (pcase (type-of fringe-mode)
+             ((or 'integer 'symbol) (set-window-fringes nil fringe-mode fringe-mode))
+             ('cons (set-window-fringes nil (car fringe-mode) (cdr fringe-mode)))
            (org-clear-latex-preview)
            (org-remove-inline-images)
            (org-mode)))


### PR DESCRIPTION
When leaving org-tree-slide-mode, the window fringes are reset via  `set-window-fringes`
`fringe-mode` stores the default fringes and has multiple possible types, including cons cell, which cannot be passed directly to set-window-fringes. So this PR matches on the type of `fringe-mode` to figure out how to properly call `set-window-fringes`, otherwise a `wrong-type-argument` error occurs.