### PR TITLE
module: add org-roam-bibtex to :tools/biblio

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -13,8 +13,23 @@ following shell commands:
     bin/doom clean
     bin/doom sync -u"
   :bare t
-  (let ((doom-auto-discard force-p))
+  (let ((doom-auto-discard force-p)
+        (default-directory doom-emacs-dir))
     (cond
+     ((equal (replace-regexp-in-string
+              "^\\(?:[^/]+/[^/]+/\\)?\\(.+\\)\\(?:~[0-9]+\\)?$" "\\1"
+              (cdr (doom-call-process "git" "name-rev" "--name-only" "HEAD")))
+             "develop")
+      (print! (warn "Doom's primary branch has changed to 'master'. The develop branch will no\nlonger recieve updates and will eventually be deleted.\n"))
+      (if (not (or force-p (y-or-n-p "Switch to the master branch?")))
+          (error! "Aborting...")
+        (print! (info "Switching to master branch"))
+        (let ((remote
+               (cdr (doom-call-process "git" "config" "--get" "branch.develop.remote"))))
+          (doom-call-process "git" "checkout" "--track" (format "%s/master" remote))
+          (print! (info "Reloading Doom Emacs"))
+          (throw 'exit (list "doom" "upgrade" (if force-p "-f"))))))
+
      (packages-only-p
       (doom-cli-execute "sync" "-u")
       (print! (success "Finished upgrading Doom Emacs")))

--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -26,6 +26,8 @@ following shell commands:
         (print! (info "Switching to master branch"))
         (let ((remote
                (cdr (doom-call-process "git" "config" "--get" "branch.develop.remote"))))
+          (doom-call-process "git" "config" (format "remote.%s.fetch" remote) (format "+refs/heads/*:refs/remotes/%s/*" remote))
+          (doom-call-process "git" "fetch" "--append" remote "master")
           (doom-call-process "git" "checkout" "--track" (format "%s/master" remote))
           (print! (info "Reloading Doom Emacs"))
           (throw 'exit (list "doom" "upgrade" (if force-p "-f"))))))

--- a/modules/tools/biblio/README.org
+++ b/modules/tools/biblio/README.org
@@ -16,6 +16,7 @@
   - [[#org-cite][Org-cite]]
     - [[#processor-configuration][Processor configuration]]
     - [[#other-configuration-options][Other configuration options]]
+  - [[#org-roam-bibtex][org-roam-bibtex]]
   - [[#path-configuration][Path configuration]]
   - [[#templates][Templates]]
 - [[#troubleshooting][Troubleshooting]]
@@ -41,6 +42,8 @@ This module provides no flags.
   + [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]]
 + ~:completion ivy~
   + [[https://github.com/tmalsburg/helm-bibtex][ivy-bibtex]]
++ ~:lang org +roam2~
+  + [[https://github.com/Zaeph/org-roam-bibtex][org-roam-bibtex]]
 
 * Prerequisites
 There are no hard dependencies for this module.
@@ -111,6 +114,11 @@ directory for your CSL styles:
 #+BEGIN_SRC emacs-lisp
 (setq org-cite-csl-styles-dir "~/Zotero/styles")
 #+END_SRC
+
+** org-roam-bibtex
+This package integrates org-ref, org-cite, and bibtex-completion into [[https://github.com/jethrokuan/org-roam][org-roam]] mode,
+which can be enabled via =lang org +roam2=. For academics and those working
+extensively with documents which they need to keep detailed notes on for cross-referencing.
 
 ** Path configuration
 

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -49,3 +49,44 @@
   :defer t
   :config
   (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))
+
+
+(use-package! org-roam-bibtex
+  :when (featurep! :lang org +roam2)
+  :after org-roam
+  :preface
+  ;; if the user has not set a template mechanism set a reasonable one of them
+  ;; The package already tests for nil itself so we define a dummy tester
+  (defvar orb-preformat-keywords
+    '("title" "url" "file" "author-or-editor" "keywords" "citekey" "pdf"))
+  :hook (org-roam-mode . org-roam-bibtex-mode)
+  :custom
+  (orb-note-actions-interface (cond ((featurep! :completion ivy)  'ivy)
+                                    ((featurep! :completion helm) 'helm)
+                                    ((t                           'default))))
+  :config
+  (setq orb-insert-interface (cond ((featurep! :completion ivy)  'ivy-bibtex)
+                                   ((featurep! :completion helm) 'helm-bibtex)
+                                   ((t                           'generic))))
+  (setq orb-process-file-keyword t
+        orb-file-field-extensions '("pdf"))
+
+  (add-to-list 'org-roam-capture-templates
+               '("b" "Bibliography note" plain
+                 "%?
+- keywords :: %^{keywords}
+- related ::
+
+* %^{title}
+:PROPERTIES:
+:Custom_ID: %^{citekey}
+:URL: %^{url}
+:AUTHOR: %^{author-or-editor}
+:NOTER_DOCUMENT: %^{file}
+:NOTER_PAGE:
+:END:\n\n"
+                 :if-new (file+head "${citekey}.org" ":PROPERTIES:
+:ROAM_REFS: cite:${citekey}
+:END:
+#+TITLE: ${title}\n")
+                 :unnarrowed t)))

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -11,3 +11,6 @@
   (package! citar :pin "ee98b94f7f80ae3c11b901ff1bc6212f9e5701a5"))
 
 (package! citeproc :pin "ba49516265fa24b138346c4918d39d19b4de8a62")
+
+(when (featurep! :lang org +roam2)
+  (package! org-roam-bibtex :pin "3ac2445f431bc39aa0ca5abfc80e28c0c06f0738"))


### PR DESCRIPTION
This change adds org-roam-bibtex to the :tools/biblio module. org-roam-bibtex provides deep integration of bibliographic tools into the org-roam workflow.

It is a new module in Doom and this patch is a replacement of https://github.com/hlissner/doom-emacs/pull/2888 which had made some choices, mainly about handling the configuration paths, that were contensious. Following work in orf-ref v3 the multiple paths are no longer required so it may not warrent inclusion.

As such this patch focuses on just adding the org-roam integration.

