### PR TITLE
feat(modeline): Add header-line support to +light

### DIFF
--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -585,29 +585,56 @@ lines are selected, or the NxM dimensions of a block selection.")
 ;;
 ;;; Bootstrap
 
-(defvar +modeline--old-format (default-value 'mode-line-format))
+(if (and (featurep! +light)
+         (not (featurep! +headerline)))
+    (progn
+      (defvar +modeline--old-format (default-value 'mode-line-format))
+      (define-minor-mode +modeline-mode
+        "TODO"
+        :init-value nil
+        :global nil
+        (cond
+         (+modeline-mode
+          (setq mode-line-format
+                (cons
+                 "" '(+modeline-bar
+                      +modeline-format-left
+                      (:eval
+                       (propertize
+                        " "
+                        'display
+                        `((space :align-to (- (+ right right-fringe right-margin)
+                                              ,(string-width
+                                                (format-mode-line '("" +modeline-format-right))))))))
+                      +modeline-format-right))))
+         ((setq mode-line-format +modeline--old-format))))
+      (define-global-minor-mode +modeline-global-mode +modeline-mode +modeline-mode)
+      (add-hook '+modeline-global-mode-hook #'size-indication-mode)
+      (add-hook 'doom-init-ui-hook #'+modeline-global-mode)))
 
-(define-minor-mode +modeline-mode
-  "TODO"
-  :init-value nil
-  :global nil
-  (cond
-   (+modeline-mode
-    (setq mode-line-format
-          (cons
-           "" '(+modeline-bar
-                +modeline-format-left
-                (:eval
-                 (propertize
-                  " "
-                  'display
-                  `((space :align-to (- (+ right right-fringe right-margin)
-                                        ,(string-width
-                                          (format-mode-line '("" +modeline-format-right))))))))
-                +modeline-format-right))))
-   ((setq mode-line-format +modeline--old-format))))
-
-(define-global-minor-mode +modeline-global-mode +modeline-mode +modeline-mode)
-
-(add-hook '+modeline-global-mode-hook #'size-indication-mode)
-(add-hook 'doom-init-ui-hook #'+modeline-global-mode)
+(if (featurep! +headerline)
+    (progn
+      (defvar +headerline--old-format (default-value 'header-line-format))
+      (define-minor-mode +headerline-mode
+        "TODO"
+        :init-value nil
+        :global nil
+        (cond
+         (+headerline-mode
+          (setq header-line-format
+                (cons
+                 "" '(+modeline-bar
+                      +modeline-format-left
+                      (:eval
+                       (propertize
+                        " "
+                        'display
+                        `((space :align-to (- (+ right right-fringe right-margin)
+                                              ,(string-width
+                                                (format-mode-line '("" +modeline-format-right))))))))
+                      +modeline-format-right))))
+         ((setq header-line-format +headerline--old-format))))
+      (define-global-minor-mode +headerline-global-mode +headerline-mode +headerline-mode)
+      (add-hook '+headerline-global-mode-hook #'size-indication-mode)
+      (add-hook 'doom-init-ui-hook #'+headerline-global-mode)
+      (global-hide-mode-line-mode 1)))


### PR DESCRIPTION
> This adds the +headerline flag, which when used with +light makes use of
the header-line instead of the mode-line. Using +headerline also
disables the mode-line globally.

This PR "copies" the mode-line onto the header-line, and disables the mode-line when both the `+light` and `+headerline` flags are present under `:ui modeline`.  

It involves a `:s/mode-line/header-line/g` / `:s/modeline/headerline/g` and then enabling `(global-hide-mode-line-mode)`.  It works without any issues for me.

![2022-04-01_17:50:00_1920x1080](https://user-images.githubusercontent.com/25481939/161264826-915bf3ca-53a7-461b-89af-b90af4e796fa.jpg)

I figured this out yesterday and since it just worked, I decided to PR it.

I did think about using a variable instead of a flag, but because it was big change that wouldn't apply until the module was reloaded, I decided to go with a flag. 

I'm sorry if the commit message is inadeqate / wrong.

I haven't modified the README file for the module (as requested in `do-not-pr.md`) but I can add a line for the new flag if necessary.