### PR TITLE
feat(terraform): support terragrunt

### DIFF
--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -1,18 +1,21 @@
 ;;; tools/terraform/config.el -*- lexical-binding: t; -*-
 
+(defvar +terraform-runner (if (executable-find "terragrunt") "terragrunt" "terraform")
+  "The default runner - terraform or terragrunt")
+
 (when (featurep! +lsp)
   (add-hook 'terraform-mode-local-vars-hook #'lsp! 'append))
-
 
 (after! terraform-mode
   (set-docsets! 'terraform-mode "Terraform")
 
+  (setq-hook! 'terraform-mode-hook compile-command +terraform-runner)
+
   (map! :map terraform-mode-map
         :localleader
-        :desc "terraform apply" "a" (cmd! (compile "terraform apply" t))
-        :desc "terraform init"  "i" (cmd! (compile "terraform init"))
-        :desc "terraform plan"  "p" (cmd! (compile "terraform plan"))))
-
+        :desc "apply" "a" (cmd! (compile (format "%s apply" +terraform-runner) t))
+        :desc "init"  "i" (cmd! (compile (format "%s init" +terraform-runner)))
+        :desc "plan"  "p" (cmd! (compile (format "%s plan" +terraform-runner)))))
 
 (use-package! company-terraform
   :when (featurep! :completion company)


### PR DESCRIPTION
Introduce a variable for the terraform executable and as terragrunt supports everything terraform does, use that instead of terraform if found on the path. 

We should probably also set `compile-command` - comments?

This doesn't touch the formatter in any way (ref https://github.com/hlissner/doom-emacs/issues/3921)
