### PR TITLE
feat(undo): add vundo

### DIFF
--- a/modules/emacs/undo/config.el
+++ b/modules/emacs/undo/config.el
@@ -51,6 +51,18 @@
         filename))))
 
 
+(use-package! vundo
+  :unless (modulep! :emacs undo +tree)
+  :custom
+  (vundo-glyph-alist vundo-unicode-symbols)
+  (vundo-compact-display t)
+  :config
+  (when (featurep! :editor evil)
+    (map! :map vundo-mode-map
+          [remap doom/escape] #'vundo-quit))
+  :defer t)
+
+
 (use-package! undo-tree
   :when (featurep! +tree)
   ;; Branching & persistent undo

--- a/modules/emacs/undo/packages.el
+++ b/modules/emacs/undo/packages.el
@@ -4,4 +4,5 @@
 (if (featurep! +tree)
     (package! undo-tree :pin "e326c6135e62f5fe8536528d3acd5e798f847407")
   (package! undo-fu :pin "ab8bc10e424bccc847800c31ab41888db789d55d")
-  (package! undo-fu-session :pin "3e810c7c9ab75d2b6f92c7c876290abbc164e750"))
+  (package! undo-fu-session :pin "48544cb102fd3d761acf92598076b20bbb4075f9")
+  (package! vundo :pin "16a09774ddfbd120d625cdd35fcf480e76e278bb" :disable (not EMACS28+)))


### PR DESCRIPTION
Added vundo recipe for undo-fu users, so they can't stop being jealous of undo-trees visualizer! Changes are gated behind opting out of the `+tree` flag in the `:emacs undo` module.