### PR TITLE
docs(tree-sitter): document +tree-sitter flag in :lang readmes

### DIFF
--- a/modules/editor/fold/README.org
+++ b/modules/editor/fold/README.org
@@ -20,6 +20,8 @@ marker, indent and syntax-based code folding for as many languages as possible.
 ** Packages
 - [[doom-package:][evil-vimish-fold]]
 - [[doom-package:][vimish-fold]]
+- if [[doom-module:][:tools tree-sitter]]
+  - [[doom-package:][ts-fold]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/lang/agda/README.org
+++ b/modules/lang/agda/README.org
@@ -15,6 +15,9 @@ exists directly in the agda repository, but not in melpa.
 ** Module flags
 - +local ::
   Use the =agda-mode= executable that comes with your local =agda= install.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - unless [[doom-module:][+local]]

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -26,6 +26,9 @@ This module adds support for the C-family of languages: C, C++, and Objective-C.
   Enable LSP support for ~c-mode~, ~c++-mode~, and ~objc-mode~. Requires [[doom-module:][:tools
   lsp]] and a langserver (supports ccls, clangd, and cquery). Replaces irony &
   rtags.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][cmake-mode]]

--- a/modules/lang/csharp/README.org
+++ b/modules/lang/csharp/README.org
@@ -18,6 +18,9 @@ LSP).
 - +lsp ::
   Enable LSP support for ~csharp-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports =omnisharp-roslyn=).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 - +unity ::
   Enable special support for the [[https://unity.com/][Unity game engine]] (particularly, support for
   HLSL shaders).

--- a/modules/lang/elixir/README.org
+++ b/modules/lang/elixir/README.org
@@ -16,6 +16,9 @@ This module provides support for [[https://elixir-lang.org/][Elixir programming 
 - +lsp ::
   Enable LSP support for ~elixir-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]]).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][alchemist]]

--- a/modules/lang/elm/README.org
+++ b/modules/lang/elm/README.org
@@ -15,6 +15,9 @@ This module adds [[https://elm-lang.org/][Elm]] support to Doom Emacs.
 - +lsp ::
   Enable LSP support for ~elm-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports [[https://github.com/elm-tooling/elm-language-server][elm-language-server]]).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][elm-mode]]

--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -29,6 +29,9 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
   Enable LSP support for ~go-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports gopls). Highly recommended, as the non-LSP experience is deprecated
   (and poor).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][company-go]] if [[doom-module:][:completion company]] (DEPRECATED)

--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -18,6 +18,9 @@ This module adds [[https://www.java.com][Java]] support to Doom Emacs, including
   (supports eclipse.jdt.ls). *Incompatible with [[doom-module:][+meghanada]].*
 - +meghanada ::
   Enable [[doom-package:][meghanada-mode]]. *Incompatible with [[doom-module:][+lsp]].*
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][android-mode]]

--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -26,6 +26,9 @@ This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.t
   Enable LSP support for ~js2-mode~, ~rjsx-mode~, JS in ~web-mode~, and
   ~typescript-mode~. Requires [[doom-module:][:tools lsp]] and a langserver (supports ts-ls and
   deno-ls).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][js2-refactor]]

--- a/modules/lang/json/README.org
+++ b/modules/lang/json/README.org
@@ -15,6 +15,9 @@ This module adds [[https://www.json.org/json-en.html][JSON]] support to Doom Ema
 - +lsp ::
   Enable LSP support for ~json-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports [[https://github.com/vscode-langservers/vscode-json-languageserver][vscode-json-languageserver]]).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][counsel-jq]] if [[doom-module:][:completion ivy]]

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -19,6 +19,9 @@ This module adds support for [[https://julialang.org/][the Julia language]] to D
 - +lsp ::
   Enable LSP support for ~julia-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports LanguageServer.jl).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][julia-mode]]

--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -21,7 +21,9 @@ Includes:
 [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-/This module has no flags./
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][company-nixos-options]] if [[doom-module:][:completion company]]

--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -24,6 +24,9 @@ This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by
 - +lsp ::
   Enable LSP support for ~tuareg-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports [[https://github.com/freebroccolo/ocaml-language-server][ocaml-language-server]]).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][dune]]

--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -36,6 +36,9 @@ This module adds support for PHP 5.3+ (including PHP7) to Doom Emacs.
 - +lsp ::
   Enable LSP support for ~php-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports [[https://phpactor.readthedocs.io/en/develop/usage/standalone.html][phpactor]] and intelephense).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][async]]

--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -34,6 +34,9 @@ This module adds [[https://www.python.org/][Python]] support to Doom Emacs.
   Enable Python virtual environment support via [[https://github.com/pyenv/pyenv][pyenv]]
 - +pyright ::
   Use the pyright LSP server instead of mspyls or pyls (requires [[doom-module:][+lsp]]).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][anaconda-mode]]

--- a/modules/lang/ruby/README.org
+++ b/modules/lang/ruby/README.org
@@ -31,6 +31,9 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
   Enable rbenv integration.
 - +rvm ::
   Enable RVM (Ruby Version Manager) integration.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][bundler]]

--- a/modules/lang/scala/README.org
+++ b/modules/lang/scala/README.org
@@ -30,6 +30,9 @@ Through the power of [[https://scalameta.org/metals/docs/editors/overview.html][
 - +lsp ::
   Enable LSP support for ~scala-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports metals).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][sbt-mode]]

--- a/modules/lang/sh/README.org
+++ b/modules/lang/sh/README.org
@@ -25,6 +25,9 @@ Fish script) to Doom Emacs.
   (supports bash-language-server).
 - +powershell ::
   Add syntax highlighting for Powershell script files (=.ps1= and =.psm1=).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
  
 ** Packages
 - [[doom-package:][company-shell]] if [[doom-module:][:completion company]]

--- a/modules/lang/swift/README.org
+++ b/modules/lang/swift/README.org
@@ -15,6 +15,9 @@ This module adds support for the [[https://developer.apple.com/swift/][Swift pro
 - +lsp ::
   Enable LSP support for ~swift-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
   (supports sourcekit).
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][swift-mode]]

--- a/modules/lang/web/README.org
+++ b/modules/lang/web/README.org
@@ -19,6 +19,9 @@ ReactJS, Wordpress, Jekyll, Phaser, AngularJS, Djano, and more.
 - +lsp ::
   Enable LSP support for ~web-mode~ and ~css-mode~. Requires [[doom-module:][:tools lsp]] and a
   langserver.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][company-web]] if [[doom-module:][:completion company]]

--- a/modules/lang/zig/README.org
+++ b/modules/lang/zig/README.org
@@ -22,6 +22,9 @@ This module adds [[https://ziglang.org/][Zig]] support, with optional (but recom
 - +lsp ::
   Enables integration for the zls LSP server. It is highly recommended you use
   this.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and structural text
+  editing. Requires [[doom-module:][:tools tree-sitter]].
 
 ** Packages
 - [[doom-package:][zig-mode]]


### PR DESCRIPTION
Companion PR to #5401. Currently fails the CI because `tree-sitter` isn't a valid scope.

cc @jeetlongname