### PR TITLE
fix(default): +default/yank-buffer-path echos the file name as nil on Emacs 29 PGTK

### DIFF
--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -38,11 +38,14 @@
   (interactive)
   (if-let (filename (or (buffer-file-name (buffer-base-buffer))
                         (bound-and-true-p list-buffers-directory)))
-      (message "Copied path to clipboard: %s"
-               (kill-new (abbreviate-file-name
-                          (if root
-                              (file-relative-name filename root)
-                            filename))))
+      (let ((path (abbreviate-file-name
+                   (if root
+                       (file-relative-name filename root)
+                     filename))))
+        (kill-new path)
+        (if (string= path (car kill-ring))
+            (message "Copied path: %s" path)
+          (user-error "Couldn't copy filename in current buffer")))
     (error "Couldn't find filename in current buffer")))
 
 ;;;###autoload


### PR DESCRIPTION
Emacs 29 with PGTK's kill-new doesn't return its STRING argument (with the default settings) anymore, so we explicitly pass the file path to prevent "Copied path to clipboard: nil", (the command still correctly copies the path without this patch, though).