### PR TITLE
fix(lsp): add a bypass for magit-find-file

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -67,6 +67,13 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
     :implementations '(lsp-find-implementation :async t)
     :type-definition #'lsp-find-type-definition)
 
+  (defadvice! +lsp--skip-during-magit-preview (fn &rest args)
+    "Ensure that `lsp' is not initialized when user opens the buffer through
+`magit-find-file' and friends."
+    :around #'lsp
+    (unless (bound-and-true-p magit-buffer-revision)
+      (apply fn args)))
+
   (defadvice! +lsp--respect-user-defined-checkers-a (fn &rest args)
     "Ensure user-defined `flycheck-checker' isn't overwritten by `lsp'."
     :around #'lsp-diagnostics-flycheck-enable


### PR DESCRIPTION
Fixes https://github.com/hlissner/doom-emacs/issues/6144.

# The Bug

`magit-find-file` is a handy function that creates a new buffer containing an older revision of the currently viewed file inside of it.

For that newly-opened buffer to have syntax coloring and stuff, Magit briefly [sets `buffer-file-name`](https://github.com/magit/magit/blob/3cfc8458e14c705afdfbeb7dcd3d3f43d7479344/lisp/magit-files.el#L181) and performs [`(normal-mode t)`](https://github.com/magit/magit/blob/3cfc8458e14c705afdfbeb7dcd3d3f43d7479344/lisp/magit-files.el#L185). This, in turn, triggers related major-mode hooks, such as those which activate lsp -- and you can probably guess where this is going.

Becuase Magit doesn't know about lsp (and vice versa), after the buffer gets opened, lsp - being unaware that the buffer is merely a "temporary preview" - thinks the entire file got suddenly replaced with some new content; among others, this misplaces inlay hints and can even make the original buffer unnavigable (since the original buffer's contents are not actually replaced, but lsp thinks otherwise).

# The Fix

When you use `magit-find-file`, that newly-opened buffer gets created a local variable called `magit-buffer-revision`, which contains a Git revision used to read that file; the fix creates an advice around lsp's entry point and exploits that fact, skipping lsp initialization when that variable is present.

# Drawbacks

Taking a brief look through Magit's code suggests that `magit-buffer-revision` _is_ the correct variable to lay on, but I ain't no Magit hacker - it might be the case that sometimes it's set for regular, file-backed buffers (a bit of testing shows otherwise for the time being, though).

# Alternatives

## `magit-preview-mode`

Magit could implement a minor mode called `magit-preview-mode` and activate it for all "preview-like" actions; the lsp advice could then exploit the existence of `magit-preview-mode` instead of hacking around `magit-buffer-revision`.

## `lsp-deferred`

This whole issue is caused by the fact that Magit has to set `buffer-file-name`, at least for a nanosecond for `(normal-mode 1)` to figure out which major mode to activate - in the next tick, `buffer-file-name` gets set to `nil` anyway.

So if we delayed initializing lsp by a single tick - e.g. by calling/hooking `lsp-deferred` instead of `lsp` - the issue would be solved, too (since by the time lsp is initialized then, `buffer-file-name` would be empty, and lsp itself already has a check for that).

Unfortunately, even a single-tick delay introduces nasty UI artifacts - e.g. it makes lsp-headerline appear after that next tick, and this Drives Me Mad ™️  (yes, I've checked it).