### PR TITLE
feat(macos): add open in new iTerm window

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -261,7 +261,8 @@
         :desc "Send project to Transmit"   "U" #'+macos/send-project-to-transmit
         :desc "Send to Launchbar"          "l" #'+macos/send-to-launchbar
         :desc "Send project to Launchbar"  "L" #'+macos/send-project-to-launchbar
-        :desc "Open in iTerm"              "i" #'+macos/open-in-iterm)
+        :desc "Open in iTerm"              "i" #'+macos/open-in-iterm
+        :desc "Open in new iTerm window"   "I" #'+macos/open-in-iterm-new-window)
        (:when (featurep! :tools docker)
         :desc "Docker" "D" #'docker)
        (:when (featurep! :email mu4e)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -628,7 +628,8 @@
         :desc "Send project to Transmit"   "U" #'+macos/send-project-to-transmit
         :desc "Send to Launchbar"          "l" #'+macos/send-to-launchbar
         :desc "Send project to Launchbar"  "L" #'+macos/send-project-to-launchbar
-        :desc "Open in iTerm"              "i" #'+macos/open-in-iterm)
+        :desc "Open in iTerm"              "i" #'+macos/open-in-iterm
+        :desc "Open in new iTerm window"   "I" #'+macos/open-in-iterm-new-window)
        (:when (featurep! :tools docker)
         :desc "Docker" "D" #'docker)
        (:when (featurep! :email mu4e)

--- a/modules/os/macos/autoload.el
+++ b/modules/os/macos/autoload.el
@@ -19,6 +19,34 @@
     (shell-command command)))
 
 ;;;###autoload
+(defun +macos--enable-in-new-window (bool)
+  (let ((command (format "defaults write com.googlecode.iterm2 OpenFileInNewWindows -bool %s" (if bool
+											       "true"
+											     "false"))))
+    (message "Running: %s" command)
+    (shell-command command)))
+
+;;;###autoload
+(defun +macos--read-new-window-value ()
+  (let ((command "defaults read com.googlecode.iterm2 OpenFileInNewWindows"))
+    (message "Running: %s" command)
+    (let ((value (shell-command command)))
+      (if (eq value 1)
+	  t
+	nil))))
+
+;;;###autoload
+(defmacro +macos--open-with-iterm (id &optional app dir new)
+  `(defun ,(intern (format "+macos/%s" id)) ()
+     (interactive)
+     (let ((original-value (+macos--read-new-window-value)))
+       (if (and ,new (not original-value))
+		(+macos--enable-in-new-window t))
+       (+macos-open-with ,app ,dir)
+       (if (and ,new (not original-value))
+		(+macos--enable-in-new-window nil)))))
+
+;;;###autoload
 (defmacro +macos--open-with (id &optional app dir)
   `(defun ,(intern (format "+macos/%s" id)) ()
      (interactive)
@@ -48,4 +76,7 @@
                    (or (doom-project-root) default-directory))
 
 ;;;###autoload (autoload '+macos/open-in-iterm "os/macos/autoload" nil t)
-(+macos--open-with open-in-iterm "iTerm" default-directory)
+(+macos--open-with-iterm open-in-iterm "iTerm" default-directory)
+
+;;;###autoload (autoload '+macos/open-in-iterm-new-window "os/macos/autoload" nil t)
+(+macos--open-with-iterm open-in-iterm-new-window "iTerm" default-directory t)


### PR DESCRIPTION
By temporarily enabling the `OpenFileInNewWindows` option for iTerm it allows us to open in a new window rather than a new tab. Personally I use windows more often than tabs and thought that others might feel the same way. This is however quite the hack, and might not fit the project so feel free to ignore and dismiss. 