### PR TITLE
tweak(vertico): use setq-default to set completion-in-region-function (for Corfu)

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -18,13 +18,13 @@ overrides `completion-styles' during company completion sessions.")
   :config
   (setq vertico-resize nil
         vertico-count 17
-        vertico-cycle t
-        completion-in-region-function
-        (lambda (&rest args)
-          (apply (if vertico-mode
-                     #'consult-completion-in-region
-                   #'completion--in-region)
-                 args)))
+        vertico-cycle t)
+  (setq-default completion-in-region-function
+                (lambda (&rest args)
+                  (apply (if vertico-mode
+                             #'consult-completion-in-region
+                           #'completion--in-region)
+                         args)))
   ;; Cleans up path when moving directories with shadowed paths syntax, e.g.
   ;; cleans ~/foo/bar/// to /, and ~/foo/bar/~/ to ~/.
   (add-hook 'rfn-eshadow-update-overlay-hook #'vertico-directory-tidy)


### PR DESCRIPTION
Corfu makes completion-in-region-function a local variable in buffers
where it is enabled, so when this form is evaluated in one of those said
buffers (such as opening a file with Emacs before accessing the
minibuffer), completion-in-region-function will just be set locally
there.

This is currently not a problem for `company` users, but ones who try `corfu` will notice that where `corfu` isn't used (such as `M-:`), `vertico` should step in but the `*Completions*` buffer is presented instead.