### PR TITLE
Chinese module tweaks

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -30,6 +30,12 @@
   :init (setq ace-pinyin-use-avy t)
   :config (ace-pinyin-global-mode t))
 
+(when (featurep! :editor evil)
+  (use-package! evil-pinyin
+    :after evil
+    :config
+    (setq-default evil-pinyin-with-search-rule 'always)
+    (global-evil-pinyin-mode 1)))
 
 ;;
 ;;; Hacks
@@ -46,3 +52,9 @@ when exporting org-mode to html."
              "\\1\\2"
              contents)))
       (list paragraph fixed-contents info))))
+(when (featurep! :editor evil)
+  (use-package! evil-pinyin
+    :after evil
+    :config
+    (setq-default evil-pinyin-with-search-rule 'always)
+    (global-evil-pinyin-mode 1)))

--- a/modules/input/chinese/packages.el
+++ b/modules/input/chinese/packages.el
@@ -5,3 +5,5 @@
 (package! fcitx :pin "12dc2638ddd15c8f6cfaecb20e1f428ab2bb5624")
 (package! ace-pinyin :pin "47662c0b05775ba353464b44c0f1a037c85e746e")
 (package! pangu-spacing :pin "f92898949ba3bf991fd229416f3bbb54e9c6c223")
+(when (featurep! :editor evil)
+  (package! evil-pinyin :pin "3e9e501ded86f88e01a4edec5d526ab0fab879d7"))

--- a/modules/input/chinese/packages.el
+++ b/modules/input/chinese/packages.el
@@ -5,5 +5,6 @@
 (package! fcitx :pin "12dc2638ddd15c8f6cfaecb20e1f428ab2bb5624")
 (package! ace-pinyin :pin "47662c0b05775ba353464b44c0f1a037c85e746e")
 (package! pangu-spacing :pin "f92898949ba3bf991fd229416f3bbb54e9c6c223")
+(package! pinyinlib :pin "1772c79b6f319b26b6a394a8dda065be3ea4498d")
 (when (featurep! :editor evil)
   (package! evil-pinyin :pin "3e9e501ded86f88e01a4edec5d526ab0fab879d7"))


### PR DESCRIPTION
I'm Chinese and use doom daily. This Pr comes from my private doom config and is stable enough for me. Usually, Chinese people use pinyin as input method. 

Pinyin is adopted to the [a-z], which people can input Chinese characters like 汉字 by 'han zi' with common keyboard. I use these settings daily to search in Chinese documents and narrowing Chinese named files. 

This is using [evil-pinyin](https://github.com/laishulu/evil-pinyin/] to do evil search by pinyin('关系', which is 'relation' in English, is 'guan xi' in pinyin so 'gx' filters '关系'. Similar to isearch by 'gx'.
<img width="1552" alt="图片" src="https://user-images.githubusercontent.com/45593614/166637740-9b86b71b-24c3-44d1-a54b-09c3f07c4884.png">

The following is narrowing by 'mx'. '模型'(model) in pinyin is 'mo xing', vertico works quite well with it.
<img width="1552" alt="图片" src="https://user-images.githubusercontent.com/45593614/166637939-627bd49f-121b-4cfb-8c30-168601982ea3.png">

helm is hard to add pinyin support as far as I know. I haven't been using ivy quite long, but ivy can be adapted with pinyin , too.

There are also deft filters. But it's somehow "intrusive". So I didn't commit it