### PR TITLE
`:completion vertico` updates

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -207,43 +207,6 @@ targets."
                    (not (string-suffix-p "-argument" (cdr binding))))))))
 
 ;;;###autoload
-(defun +vertico/crm-select ()
-  "Toggle selection of current candidate in `consult-completing-read-multiple'.
-If the candidate has been selected, move the index up by one, to allow for quick
-selection of multiple subsequent candidates."
-  (interactive)
-  (let* ((selected-p (get-text-property 0 'consult--crm-selected (vertico--candidate)))
-         (goto-idx (+ vertico--index (if selected-p 0 1))))
-    (run-at-time 0 nil (cmd! (vertico--goto goto-idx) (vertico--exhibit))))
-  (vertico-exit))
-
-;;;###autoload
-(defun +vertico/crm-select-keep-input ()
-  "Like `+vertico/crm-select', but keeps the current minibuffer input."
-  (interactive)
-  (let* ((input (substring-no-properties (car vertico--input)))
-         (selected-p (get-text-property 0 'consult--crm-selected (vertico--candidate)))
-         (goto-idx (+ vertico--index (if selected-p 0 1))))
-    (run-at-time 0 nil (cmd! (insert input) (vertico--exhibit) (vertico--goto goto-idx) (vertico--exhibit))))
-  (vertico-exit))
-
-;;;###autoload
-(defun +vertico/crm-exit ()
-  "Exit `consult-completing-read-multiple' session in a dwim way.
-If there are no selected candidates, select the current candidate and exit.
-If there are selected candidates, disregard the current candidate and exit."
-  (interactive)
-  (if (consult--crm-selected)
-      (progn
-        (when (minibuffer-contents)
-          (delete-minibuffer-contents)
-          (vertico--exhibit))
-        (vertico--goto -1)
-        (vertico-exit))
-    (run-at-time 0 nil #'vertico-exit)
-    (vertico-exit)))
-
-;;;###autoload
 (defun +vertico--consult--fd-builder (input)
   (pcase-let* ((cmd (split-string-and-unquote +vertico-consult-fd-args))
                (`(,arg . ,opts) (consult--command-split input))

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -29,7 +29,14 @@ overrides `completion-styles' during company completion sessions.")
   ;; cleans ~/foo/bar/// to /, and ~/foo/bar/~/ to ~/.
   (add-hook 'rfn-eshadow-update-overlay-hook #'vertico-directory-tidy)
   (add-hook 'minibuffer-setup-hook #'vertico-repeat-save)
-  (map! :map vertico-map "DEL" #'vertico-directory-delete-char))
+  (map! :map vertico-map "DEL" #'vertico-directory-delete-char)
+
+  ;; These commands are problematic and automatically show the *Completions* buffer
+  (advice-add #'tmm-add-prompt :after #'minibuffer-hide-completions)
+  (defadvice! +vertico--suppress-completion-help-a (fn &rest args)
+    :around #'ffap-menu-ask
+    (letf! ((#'minibuffer-completion-help #'ignore))
+      (apply fn args))))
 
 
 (use-package! orderless

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -101,7 +101,6 @@ orderless."
     [remap switch-to-buffer-other-frame]  #'consult-buffer-other-frame
     [remap yank-pop]                      #'consult-yank-pop
     [remap persp-switch-to-buffer]        #'+vertico/switch-workspace-buffer)
-  (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
   (advice-add #'multi-occur :override #'consult-multi-occur)
   :config
   (defadvice! +vertico--consult-recent-file-a (&rest _args)
@@ -145,11 +144,7 @@ orderless."
         :category buffer
         :state    ,#'consult--buffer-state
         :items    ,(lambda () (mapcar #'buffer-name (org-buffer-list)))))
-    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append))
-  (map! :map consult-crm-map
-        :desc "Select candidate" [tab] #'+vertico/crm-select
-        :desc "Select candidate and keep input" [backtab] #'+vertico/crm-select-keep-input
-        :desc "Enter candidates" "RET" #'+vertico/crm-exit))
+    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append)))
 
 
 (use-package! consult-dir

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -54,7 +54,7 @@ orderless."
     (cond
      ;; Ensure $ works with Consult commands, which add disambiguation suffixes
      ((string-suffix-p "$" pattern)
-      `(orderless-regexp . ,(concat (substring pattern 0 -1) "[\x100000-\x10FFFD]*$")))
+      `(orderless-regexp . ,(concat (substring pattern 0 -1) "[\x200000-\x300000]*$")))
      ;; Ignore single !
      ((string= "!" pattern) `(orderless-literal . ""))
      ;; Without literal

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -15,6 +15,15 @@ overrides `completion-styles' during company completion sessions.")
 
 (use-package! vertico
   :hook (doom-first-input . vertico-mode)
+  :init
+  (defadvice! +vertico-crm-indicator-a (args)
+    :filter-args #'completing-read-multiple
+    (cons (format "[CRM%s] %s"
+                  (replace-regexp-in-string
+                   "\\`\\[.*?]\\*\\|\\[.*?]\\*\\'" ""
+                   crm-separator)
+                  (car args))
+          (cdr args)))
   :config
   (setq vertico-resize nil
         vertico-count 17

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -86,7 +86,7 @@ orderless."
      +vertico-basic-remote-try-completion
      +vertico-basic-remote-all-completions
      "Use basic completion on remote files only"))
-  (setq completion-styles '(orderless)
+  (setq completion-styles '(orderless basic)
         completion-category-defaults nil
         ;; note that despite override in the name orderless can still be used in
         ;; find-file etc.

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -136,14 +136,30 @@ orderless."
   (consult-customize
    consult-theme
    :preview-key (list (kbd "C-SPC") :debounce 0.5 'any))
-  (after! org
+  (when (featurep! :lang org)
     (defvar +vertico--consult-org-source
-      `(:name     "Org"
-        :narrow   ?o
-        :hidden t
-        :category buffer
-        :state    ,#'consult--buffer-state
-        :items    ,(lambda () (mapcar #'buffer-name (org-buffer-list)))))
+      (list :name     "Org Buffer"
+            :category 'buffer
+            :narrow   ?o
+            :hidden   t
+            :face     'consult-buffer
+            :history  'buffer-name-history
+            :state    #'consult--buffer-state
+            :new
+            (lambda (name)
+              (with-current-buffer (get-buffer-create name)
+                (insert "#+title: " name "\n\n")
+                (org-mode)
+                (consult--buffer-action (current-buffer))))
+            :items
+            (lambda ()
+              (mapcar #'buffer-name
+                      (if (featurep 'org)
+                          (org-buffer-list)
+                        (seq-filter
+                         (lambda (x)
+                           (eq (buffer-local-value 'major-mode x) 'org-mode))
+                         (buffer-list)))))))
     (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append)))
 
 

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,19 +4,19 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "46e8e0565079b7161ada4beb94c8938ee9c04bfb")
+  :pin "cc5f5421c6270b8fdd12265ccdaffc3cd297d0d8")
 
-(package! orderless :pin "8f64537f556f26492fe5ee401d8d578d7d88684b")
+(package! orderless :pin "75eeae21971d86b51a712ed8ecd6434463b2d866")
 
-(package! consult :pin "d30213aa209391e03b1c1011df92d91a1fc5ef32")
-(package! consult-dir :pin "08f543ae6acbfc1ffe579ba1d00a5414012d5c0b")
+(package! consult :pin "822928a8609730e8c22e068b04d7908312706cfd")
+(package! consult-dir :pin "d397ca6ea67af4d3c59a330a778affd825f0efd9")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "9b40f136c017fadf6239d7602d16bf73b4ad5198"))
 
-(package! embark :pin "2890e535f55b1f08f379fd761b263fa337a72185")
-(package! embark-consult :pin "2890e535f55b1f08f379fd761b263fa337a72185")
+(package! embark :pin "d88478b45f2d589339334dc8d40b07bce28aab0e")
+(package! embark-consult :pin "d88478b45f2d589339334dc8d40b07bce28aab0e")
 
-(package! marginalia :pin "dbc37b373e734269bd75d1763e7309863508bf10")
+(package! marginalia :pin "26f2bd9ee7b63bcad6604108e2f565b34bc6083b")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,17 +4,17 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "cc5f5421c6270b8fdd12265ccdaffc3cd297d0d8")
+  :pin "e5935b5bbfc0d820c54ed1ad52e36e8c48248fd7")
 
 (package! orderless :pin "75eeae21971d86b51a712ed8ecd6434463b2d866")
 
-(package! consult :pin "822928a8609730e8c22e068b04d7908312706cfd")
+(package! consult :pin "b15c81f7766a8981f2f022fc47bbeb7000696caf")
 (package! consult-dir :pin "d397ca6ea67af4d3c59a330a778affd825f0efd9")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "9b40f136c017fadf6239d7602d16bf73b4ad5198"))
 
-(package! embark :pin "d88478b45f2d589339334dc8d40b07bce28aab0e")
-(package! embark-consult :pin "d88478b45f2d589339334dc8d40b07bce28aab0e")
+(package! embark :pin "97270d725761ee02db461b45b18ec16ae31f203e")
+(package! embark-consult :pin "97270d725761ee02db461b45b18ec16ae31f203e")
 
 (package! marginalia :pin "26f2bd9ee7b63bcad6604108e2f565b34bc6083b")
 

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -86,10 +86,6 @@ variable accordingly.")
 
   (advice-add #'notmuch-start-notmuch-sentinel :around #'+notmuch-dont-confirm-on-kill-process-a)
 
-  ;;HACK temporary fix until notmuch stops abusing the completing-read-multiple api upstream
-  (when (featurep! :completion vertico)
-    (advice-add #'notmuch-read-tag-changes :filter-return (lambda (x) (mapcar #'string-trim x))))
-
   ;; modeline doesn't have much use in these modes
   (add-hook! '(notmuch-show-mode-hook
                notmuch-tree-mode-hook


### PR DESCRIPTION
bump: :completion vertico
(... -> ...)
- Remove everything related to `consult-completing-read-multiple` since
the function has been deprecated upstream due to implementation issues

Ref: minad/consult#567
Close: #6352
#
tweak(vertico): improve org consult source

- only add if :lang org is on
- have a version that works before org is loaded
#
feat(vertico): add workarounds for problematic commands
#
fix(vertico): consult tofu regex range