### PR TITLE
fix(window-select): allow Switch Window to work with >6 windows

### DIFF
--- a/modules/ui/window-select/config.el
+++ b/modules/ui/window-select/config.el
@@ -6,8 +6,7 @@
   :init
   (global-set-key [remap other-window] #'switch-window)
   :config
-  (setq switch-window-shortcut-style 'qwerty
-        switch-window-qwerty-shortcuts '("a" "s" "d" "f" "g" "h" "j" "k" "l")))
+  (setq switch-window-shortcut-style 'qwerty))
 
 
 (use-package! ace-window


### PR DESCRIPTION
Currently, when `switch-window` is used with >6 windows, an error is thrown. This was happening to me every time I used `dap-debug` since `dap-ui-mode` creates many windows. Allow me to explain why this happens:

When you execute `switch-window`, `switch-window--enumerate` assigns a single key to each window from `switch-window-qwerty-shortcuts`, which at this point is `'("a" "s" "d" "f" "g" "h" "j" "k" "l")`. However, keys which bound in `switch-window-extra-map` are excluded from being assigned to a window. Therefore, the only keys which can be assigned are `'("a" "s" "d" "f" "g" "h")`, which is only six keys. 

The change I propose in this pull request is to allow `switch-window-qwerty-shortcuts` to keep its default value of `("a" "s" "d" "f" "j" "k" "l" ";" "g" "h" "q" "w" "e" "r" "t" "y" "u" "i" "p" "z" "x" "c" "v" "b" "n" "m")`. This way we have 22 available keys instead. I do not believe anyone will have more than 22 windows open at a time.