### PR TITLE
fix(go): exactly match test function name

### DIFF
--- a/modules/lang/go/autoload.el
+++ b/modules/lang/go/autoload.el
@@ -38,7 +38,7 @@
   (if (string-match "_test\\.go" buffer-file-name)
       (save-excursion
         (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Test[[:alnum:]_]+\\)(.*)")
-        (+go--run-tests (concat "-run" "='" (match-string-no-properties 2) "'")))
+        (+go--run-tests (concat "-run" "='^\\Q" (match-string-no-properties 2) "\\E$'")))
     (error "Must be in a _test.go file")))
 
 ;;;###autoload
@@ -52,7 +52,7 @@
   (if (string-match "_test\\.go" buffer-file-name)
       (save-excursion
         (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Benchmark[[:alnum:]_]+\\)(.*)")
-        (+go--run-tests (concat "-test.run=NONE -test.bench" "='" (match-string-no-properties 2) "'")))
+        (+go--run-tests (concat "-test.run=NONE -test.bench" "='^\\Q" (match-string-no-properties 2) "\\E$'")))
     (error "Must be in a _test.go file")))
 
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

When specifying a specific test to run using `go test`, the function name is accepted as a regex, not an exact string match. Previously, the `+go/test-single` and `+go/bench-single` functions specified the function name as a raw strings; this meant that these functions could sometimes test/benchmark other functions that contained the name of the intended test.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
