### PR TITLE
feat(nix): add generic completing-read support to +nix/lookup-option

### DIFF
--- a/modules/lang/nix/autoload.el
+++ b/modules/lang/nix/autoload.el
@@ -42,8 +42,13 @@
                    :initial-input initial-input
                    :action #'+nix--options-action
                    :caller '+nix/options))
-        ;; TODO Add general `completing-read' support
-        ((user-error "No search engine is enabled. Enable helm or ivy!")))
+        ((+nix--options-action (cdr
+                                (assoc
+                                 (completing-read "NixOs options: "
+                                                  nixos-options
+                                                  nil
+                                                  t
+                                                  initial-input) nixos-options)))))
   ;; Tell lookup module to let us handle things from here
   'deferred)
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Before
![image](https://user-images.githubusercontent.com/38893265/168255895-ae4f8833-d620-45fe-a5af-6fd32285ce4c.png)
After
![image](https://user-images.githubusercontent.com/38893265/168256017-54d30d30-1ce2-404e-b295-7be1b4d64d0b.png)

now it works on vertico or any other completion based on completing-read
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).



<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
