### PR TITLE
tweak(default): remove M-{-,=,+} and C-- keybinds

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -477,11 +477,6 @@
 
 (map! "C-'" #'imenu
 
-      ;;; Text scaling
-      "M-+" #'doom/reset-font-size
-      "M-=" #'doom/increase-font-size
-      "M--" #'doom/decrease-font-size
-
       ;;; search
       (:when (featurep! :completion ivy)
         "C-S-s"        #'swiper
@@ -540,7 +535,6 @@
 
       ;;; expand-region
       "C-="  #'er/expand-region
-      "C--"  #'er/contract-region
 
       ;;; flycheck
       (:after flycheck


### PR DESCRIPTION
The keybindings `M--`, `M-=`, and `C--` override the built-in commands `negative-argument` and `count-words-region`. Moreover, the `C--` command, `er/contract-region`, is already bound transiently to `expand-region-contract-fast-key` while expanding regions.