### PR TITLE
fix(emacs-lisp): type error in +emacs-lisp-eval

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -12,7 +12,8 @@ to a pop up buffer."
     (condition-case-unless-debug e
         (let ((result
                (let* ((buffer-file-name (buffer-file-name (buffer-base-buffer)))
-                      (buffer-file-truename (file-truename buffer-file-name))
+                      (buffer-file-truename (when buffer-file-name
+                                              (file-truename buffer-file-name)))
                       (doom--current-module
                        (ignore-errors (doom-module-from-path buffer-file-name)))
                       (debug-on-error t))


### PR DESCRIPTION
# fix(emacs-lisp): type error in +emacs-lisp-eval

When evaluating from a buffer not visiting any file, file-truename would error
out since the argument it was fed is nil.

-------

I ran into this quite often in the last couple of month trying to evaluate stuff from the scratch buffer, and was just lazy to fix is on my own. I can't find any issues referencing this, I really thought there would be some.


<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->
