### PR TITLE
bump(rss): :category app :module rss

### DIFF
--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; app/rss/packages.el
 
-(package! elfeed :pin "162d7d545ed41c27967d108c04aa31f5a61c8e16")
-(package! elfeed-goodies :pin "8e4c1fbfb86226d867b524fd0f8ae78b4b602f1b")
+(package! elfeed :pin "0ccd59aaace34546017a1a0d7c393749747d5bc6")
+(package! elfeed-goodies :pin "6711de66c22360f80fcfd9730293e5f3d419f787")
 (when (featurep! +org)
-  (package! elfeed-org :pin "268efdd0121fa61f63b722c30e0951c5d31224a4"))
+  (package! elfeed-org :pin "e6bf4268485703907a97896fb1080f59977c9e3d"))


### PR DESCRIPTION
+ updated elfeed package
+ updated elfeed-goodies
+ updated elfeed-org

<!-- ⚠️ Please do not ignore this template! -->

Usage of rss App warn about package CL DEPRECATED.
Updated the package.el to the last commit fix it.

Fixes #6410
References #6410


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.

