### PR TITLE
tweak(spell): ignore org-inline-src-block

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -98,12 +98,13 @@
            . (org-block
               org-block-begin-line
               org-block-end-line
-              org-code
               org-cite
               org-cite-key
+              org-code
               org-date
               org-footnote
               org-formula
+              org-inline-src-block
               org-latex-and-related
               org-link
               org-meta-line


### PR DESCRIPTION
Inline source blocks shouldn't be spell-checked. I also fixed the alphabetic sorting of org-cite while I'm at it.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
