### PR TITLE
Feat(:lang ess): add company-R-library backend

### DIFF
--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -33,7 +33,7 @@
   (set-eval-handler! 'ess-r-help-mode #'ess-eval-region-and-go)
 
   (set-company-backend! 'ess-r-mode
-    '(company-R-args company-R-objects company-dabbrev-code :separate))
+    '(company-R-args company-R-objects company-R-library company-dabbrev-code :separate))
 
   (setq-hook! 'ess-r-mode-hook
     ;; HACK Fix #2233: Doom continues comments on RET, but ess-r-mode doesn't


### PR DESCRIPTION
https://github.com/emacs-ess/ESS/pull/509 includes a R-company-library backend which supports completions for importing packages, I think taking this in accompany with other `R-company` backend like `R-company-objects` and `company-R-args` as the default company backend for R-mode is just reasonable default.