### PR TITLE
fix(rss): fix *rss* workspace doesn't exist

### DIFF
--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -98,11 +98,13 @@
         (remove-hook 'kill-buffer-hook #'+rss-cleanup-h :local)
         (kill-buffer b)))
     (mapc #'kill-buffer show-buffers))
-  (if (featurep! :ui workspaces)
+  (if (and (featurep! :ui workspaces)
+           (+workspace-exists-p +rss-workspace-name))
       (+workspace/delete +rss-workspace-name)
     (when (window-configuration-p +rss--wconf)
       (set-window-configuration +rss--wconf))
-    (setq +rss--wconf nil)))
+    (setq +rss--wconf nil)
+    (previous-buffer)))
 
 
 ;;


### PR DESCRIPTION
Change-Id: Ic42528fcda679ff3538db2fad4c7d4dae6fc8d7a

<!-- ⚠️ Please do not ignore this template! -->

This is my first pull request. Hope to merge it in the near future.

If you use in the way M-x elfeed, then quit \*elfeed-search* will show error prompt "\*rss* workspace doesn't exist". As +rss-cleanup-h will always delete \*rss* workspace, i add checker for \*rss* and switch to previous buffer when quit \*elfeed-search*.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
