### PR TITLE
tweak(mu4e): increase human-date width to fit year

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -71,7 +71,7 @@
         ;; remove 'lists' column
         mu4e-headers-fields
         '((:account-stripe . 1)
-          (:human-date . 8)
+          (:human-date . 10)
           (:flags . 6) ; 3 icon flags
           (:from-or-to . 25)
           (:subject)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The date header only includes the first two digits of the year, making it look like all messages were received in 2020.

Before (Messages from February 2022):
![image](https://user-images.githubusercontent.com/8166212/170877329-e68624a1-f196-4f81-80f0-c6d75213b80f.png)

After:
![image](https://user-images.githubusercontent.com/8166212/170877566-8229b357-0414-4853-8964-47199b57e4cd.png)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
