### PR TITLE
fix(vertico): load consult after embark

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -98,7 +98,7 @@ orderless."
 
 
 (use-package! consult
-  :defer t
+  :after (embark)
   :init
   (define-key!
     [remap apropos]                       #'consult-apropos


### PR DESCRIPTION
Currently, embark-consult bindings don't get loaded if consult hasn't
been loaded yet, leading to missing embark actions until the first
manual consult load