### PR TITLE
fix(graphql): workaround to build company-graphql

### DIFF
--- a/modules/lang/graphql/packages.el
+++ b/modules/lang/graphql/packages.el
@@ -4,4 +4,6 @@
 (package! graphql-mode :pin "9740e4027bd9313697d5cac5caaa5b15626ab1da")
 (package! graphql-doc :pin "6ba7961fc9c5c9818bd60abce6ba9dfef2dad452")
 (when (not (featurep! +lsp))
-  (package! company-graphql :pin "757dfa45ad0cef9b9c362c8993d6474a2426c01c"))
+  (package! company-graphql
+    :recipe (:host github :repo "thaenalpha/company-graphql")
+    :pin "aed9f5109e87..."))


### PR DESCRIPTION
-------

<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->

Fixes timoweave/company-graphql#1

I've changed the `company-graphql` package! `:recipe` and `:pin` to a fix commit from
my fork because of the error **message**:

> **Error**: (error "Could not find package company-graphql. Updating recipe repositories: (org-elpa melpa gnu-elpa-mirror el-get emacsmirror-mirror) with ‘straight-pull-recipe-repositories’ may fix this")

This error happens because the package is not exist in MELPA, so I tried to install it
directly from a github repository and then, I found a bug that prevented it from the
complete of package build.

I have fixed this and make a PR to the package already timoweave/company-graphql#4
and this doomemacs PR is a temporary workaround until my fix was merged to upstream.