### PR TITLE
fix(org): make last arg of '+org--follow-search-string-a' optional

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -552,7 +552,7 @@ relative to `org-directory', unless it is an absolute path."
   (+org-define-basic-link "doom-modules" 'doom-modules-dir)
 
   ;; TODO PR this upstream
-  (defadvice! +org--follow-search-string-a (fn link arg)
+  (defadvice! +org--follow-search-string-a (fn link &optional arg)
     "Support ::SEARCH syntax for id: links."
     :around #'org-id-open
     :around #'org-roam-id-open


### PR DESCRIPTION
Fixes a regression that disabled org ID links.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off. 
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
