### PR TITLE
docs(:magit): replace github-review with code-review

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -33,7 +33,7 @@ This module has no dedicated maintainers.
 + [[https://github.com/magit/forge][forge]]* (=+forge=)
 + [[https://github.com/jtatarik/magit-gitflow][magit-gitflow]]
 + [[https://github.com/alphapapa/magit-todos][magit-todos]]
-+ [[https://github.com/charignon/github-review][github-review]]
++ [[https://github.com/wandersoncferreira/code-review][code-review]]
 + [[https://github.com/emacs-evil/evil-magit][evil-magit]]* (=:editor evil +everywhere=)
 
 ** Hacks


### PR DESCRIPTION
"github-review" has been replaced by the "code-review" package, so just updating the `:magit` README to reflect that.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
