### PR TITLE
fix(zig): use zig ast-check for flycheck checker

### DIFF
--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -17,8 +17,8 @@
 
   (when (featurep! :checkers syntax)
     (flycheck-define-checker zig
-      "A zig syntax checker using the zig-fmt interpreter."
-      :command ("zig" "fmt" (eval (buffer-file-name)))
+      "A zig syntax checker using zig's `ast-check` command."
+      :command ("zig" "ast-check" (eval (buffer-file-name)))
       :error-patterns
       ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end))
       :modes zig-mode)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

`zig fmt` changes the content of the file, which is very annoying and hard to troubleshoot when someone doesn't want their code formatted (like me).

`zig ast-check` is used instead to locate syntax errors.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
