### PR TITLE
fix(evil): nv mode binding "K" should be "gK"

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -494,7 +494,7 @@ directives. By default, this only recognizes C directives.")
       :v  "g-"    #'evil-numbers/dec-at-pt-incremental
       :v  "g+"    #'evil-numbers/inc-at-pt
       (:when (featurep! :tools lookup)
-       :nv "K"   #'+lookup/documentation
+       :nv "gK"   #'+lookup/documentation
        :nv "gd"  #'+lookup/definition
        :nv "gD"  #'+lookup/references
        :nv "gf"  #'+lookup/file


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
# Changes
Changed `evil +lookup` Keybinding `:nv "K"` to `:nv "gK"`!

# Problem
When typing the letter "`K`" in evil normal or visual mode, evil starts `+lookup/documentation`.

This behavior sometimes overlaps with other major/minor modes and overrides keybindings of other packages.

# Solution
This Keybinding is probably supposed to be "`gK`" originally and should be changed back. This is just a simple character gotten lost.

# Importance
This mistake causes confusion among users (e.g. #5186 and #3055) and should be fixed soon.

# Connected Issues
Fixes #5186
References #3055

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [x] My changes can be tested quickly using the keybindings (with `editor: evil` and `tools: lookup` activated)!
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [x] This is NOT a draft PR; It can be merged fast-forward!

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
