### PR TITLE
fix(emacs-lisp): don't expect all buffers to be files

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -12,7 +12,8 @@ to a pop up buffer."
     (condition-case-unless-debug e
         (let ((result
                (let* ((buffer-file-name (buffer-file-name (buffer-base-buffer)))
-                      (buffer-file-truename (file-truename buffer-file-name))
+                      (buffer-file-truename
+                       (and buffer-file-name (file-truename buffer-file-name)))
                       (doom--current-module
                        (ignore-errors (doom-module-from-path buffer-file-name)))
                       (debug-on-error t))


### PR DESCRIPTION
As noted in #6181, 7290f85cfd35acdee1ed9053627dcdd93c23179f introduced an issue with `+eval/*` in non-file elisp buffers. Let's fix that.

Fixes #6181

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

