### PR TITLE
fix(debugger): dap-go is deprecated, use dap-dlv-go instead

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -19,7 +19,7 @@
 (defvar +debugger--dap-alist
   `(((:lang cc +lsp)         :after ccls        :require (dap-lldb dap-gdb-lldb))
     ((:lang elixir +lsp)     :after elixir-mode :require dap-elixir)
-    ((:lang go +lsp)         :after go-mode     :require dap-go)
+    ((:lang go +lsp)         :after go-mode     :require dap-dlv-go)
     ((:lang java +lsp)       :after java-mode   :require lsp-java)
     ((:lang php +lsp)        :after php-mode    :require dap-php)
     ((:lang python +lsp)     :after python      :require dap-python)


### PR DESCRIPTION

Follow dap-mode doc, dap-go is deprecated, use dap-dlv-go instead.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
