### PR TITLE
docs(spell): can't add word to personal dict

### DIFF
--- a/modules/checkers/spell/README.org
+++ b/modules/checkers/spell/README.org
@@ -208,6 +208,24 @@ installed, it will generate an empty word list, causing it to highlight all
 words as incorrect. Delete its cache files in =$EMACSDIR/.local/etc/spell-fu/=
 to fix this.
 
+** Cannot add [word] to any active dictionary
+*** Aspell
+If ~M-x +spell/add-word~ results in the above error this mean that the
+personal dictionary file was not created for some reason. This can be
+fixed by creating the required file manually.
+#+begin_example shell
+mkdir -p ~/.emacs.d/.local/etc/ispell
+echo personal_ws-1.1 en 0 > ~/.emacs.d/.local/etc/ispell/.pws
+#+end_example
+
+Where ~personal_ws-1.1 en 0~ is the required header format for the personal
+dictionary file. ~en~ is the language you're writing in and have a dict
+installed and ~0~ is the number of added words in the dictionary. If you are
+planning of updating the file with the list of words, update the number
+accordingly.
+
+After the file is created, restart emacs and adding words should work.
+
 * Frequently asked questions
 /This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
 


### PR DESCRIPTION
Adding `Cannot add [word] to any active dictionary` error to the
troubleshooting section.

I have had this problem multiple times now when I break my emacs and
wipe the `~/.config/emacs` directory and I can never remember what file
to create to get my spell check working properly.

Even though this is a bug and might be fixed in the future, I feel like
having it documented can be helpful in the short term and in the future.

I am not sure though whether this is only relevant to `aspell` or to all of
them so happy to have some stuff reworded.

References: #6246

-----
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
