### PR TITLE
feat(org): add org-media-note

### DIFF
--- a/modules/lang/org/doctor.el
+++ b/modules/lang/org/doctor.el
@@ -28,3 +28,9 @@
   (when IS-WINDOWS
     (unless (executable-find "convert")
       (warn! "Couldn't find the convert program (from ImageMagick). org-download-clipboard will not work."))))
+
+(when (featurep! +media-note)
+  (unless (executable-find "mpv")
+    (warn! "Couldn't find the mpv executable. org-media-note will not be able to play media files."))
+  (unless (executable-find "youtube-dl")
+    (warn! "Couldn't find the youtube-dl executable. mpv will not be able to play online media files properly. You can install youtuble-dl using pip or OS package managers like homebrew, apt, dnf(yum), yay and etc.")))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -69,6 +69,10 @@
   (package! org-noter :pin "9ead81d42dd4dd5074782d239b2efddf9b8b7b3d"))
 (when (featurep! +pomodoro)
   (package! org-pomodoro :pin "3f5bcfb80d61556d35fc29e5ddb09750df962cc6"))
+(when (featurep! +media-note)
+  (package! org-media-note
+    :recipe (:host github :repo "yuchen-lea/org-media-note")
+    :pin "dd458c3260530d1866eaa0cde4b1bb71c6f8cf0e"))
 (when (featurep! +pretty)
   (package! org-appear :pin "8dd1e564153d8007ebc4bb4e14250bde84e26a34")
   (package! org-superstar :pin "03be6c0a3081c46a59b108deb8479ee24a6d86c0")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Add yuchen-lea/org-media-note to doomemacs.
this feature was not one of doomemacs.
I think this mode helps others video and audio note taking job much easier.

`org-media-note` uses `mpv` strongly and mpv uses `youtube-dl`. mpv.el doesn't have any option of video quality selection.
 I added `+mpv/select-profiles` and `+mpv-options` for quality profile selection.

Ref: https://github.com/yuchen-lea/org-media-note

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
