### PR TITLE
docs/getting_started: emacs installation on arm64

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -294,7 +294,11 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
   brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  if [[ $(uname -m) == 'arm64' ]]; then
+    ln -s /opt/homebrew/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  else
+    ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  fi
   #+END_SRC
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have
@@ -302,7 +306,11 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
   brew install emacs-plus
-  ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  if [[ $(uname -m) == 'arm64' ]]; then
+    ln -s /opt/homebrew/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  else
+    ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  fi
   #+END_SRC
 
 - [[https://formulae.brew.sh/formula/emacs][emacs]] is another acceptable option, **but does not provide a Emacs.app**:


### PR DESCRIPTION
* Make Emacs homebrew installation instructions compatible with Apple
Silicon (arm64) as well as Intel (x86_64)

On the new M1 macs, homebrew is no longer installed under /usr/local so the linking step fails if copy pasting the instructions. I've replaced it with a simple if clause that creates the correct links (for emacs-mac and emacs-plus)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
