### PR TITLE
tweak(mu4e): increase human-date to fit full time

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -71,7 +71,7 @@
         ;; remove 'lists' column
         mu4e-headers-fields
         '((:account-stripe . 1)
-          (:human-date . 10)
+          (:human-date . 12)
           (:flags . 6) ; 3 icon flags
           (:from-or-to . 25)
           (:subject)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Messages from the current day do not fit with the current width since they are formatted as times (Ex: "05:17:23 PM"). It seems that 11 is a sufficient width for this but the increase to 12 matches the [mu4e defaults](https://github.com/djcb/mu/commit/0276ea04089106e77d4c0f65d83cc7bd3f6a49b9).

This was recently increased already (#6427), but I missed that the formatting is different for messages from the current day. Sorry about that!

Before:
![human-date-10](https://user-images.githubusercontent.com/8166212/175792091-c79da5de-798c-4bba-9cd1-96c836d2b787.png)

After:
![human-date-12](https://user-images.githubusercontent.com/8166212/175792097-93e7ca49-c4c3-4bc4-b418-2dfa5ec183bd.png)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
