### PR TITLE
docs(mu4e): fix incorrect variable name in snippet

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -248,7 +248,7 @@ With the [[doom-module:][+org]] flag, [[doom-package:][org-msg]] is installed, a
 composing the first message. To disable ~org-msg-mode~ by default:
 #+begin_src emacs-lisp
 ;; add to $DOOMDIR/config.el
-(setq mu4e-compose--org-msg-toggle-next nil)
+(setq +mu4e-compose-org-msg-toggle-next nil)
 #+end_src
 
 To toggle org-msg for a single message, just apply the universal argument to the


### PR DESCRIPTION
The variable name for toggling org-msg by default was changed in commit 6118ad5c124c2fa436abd19fe087de0f836c59d7, leading to the provided snippet not actually disabling org-msg.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
