### PR TITLE
fix(macos): void-variable newwindow? error

### DIFF
--- a/modules/os/macos/autoload.el
+++ b/modules/os/macos/autoload.el
@@ -36,7 +36,7 @@
                 "write" "com.googlecode.iterm2" "OpenFileInNewWindows"
                 "-bool" (if bool "true" "false"))))
        (let ((newwindow?
-              (if newwindow? (not (equal (read-newwindows) "1")))))
+              (if ,newwindow? (not (equal (read-newwindows) "1")))))
          (when newwindow?
            (write-newwindows t))
          (unwind-protect (+macos-open-with "iTerm" ,dir)


### PR DESCRIPTION
The symbol `newwindow?` in 39 should be a macro's symbol, not a function's one.
This fixes a bug introduced by #6318.