### PR TITLE
fix: strip './' from projectile file list produced by fd

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -174,7 +174,7 @@ And if it's a function, evaluate it."
                          (cl-find-if (doom-rpartial #'executable-find t)
                                      (list "fdfind" "fd"))
                        doom-projectile-fd-binary))
-              (concat (format "%s . -0 -H --color=never --type file --type symlink --follow --exclude .git"
+              (concat (format "%s . -0 -H --color=never --type file --type symlink --follow --exclude .git --strip-cwd-prefix"
                               bin)
                       (if IS-WINDOWS " --path-separator=/"))))
            ;; Otherwise, resort to ripgrep, which is also faster than find


### PR DESCRIPTION
The referenced commit incorporates https://github.com/bbatsov/projectile/pull/1784 to fix #6504.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
