### PR TITLE
fix(pass): enable evil-collection bindings

### DIFF
--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -18,14 +18,14 @@
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)
 
   ;; FIXME This needs to be upstreamed to evil-collection.
-  (add-to-list  'evil-collection-pass-command-to-label '(pass-update-buffer . "gr"))
+  (add-to-list 'evil-collection-pass-command-to-label '(pass-update-buffer . "gr"))
 
   (map! :map pass-mode-map
-    :n "j"    #'pass-next-entry
-    :n "k"    #'pass-prev-entry
-    :n "d"    #'pass-kill
-    :n "C-j" #'pass-next-directory
-    :n "C-k" #'pass-prev-directory))
+        :n "j"   #'pass-next-entry
+        :n "k"   #'pass-prev-entry
+        :n "d"   #'pass-kill
+        :n "C-j" #'pass-next-directory
+        :n "C-k" #'pass-prev-directory))
 
 
 ;; Is built into Emacs 26+

--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -26,6 +26,10 @@
 (after! pass
   (set-evil-initial-state! 'pass-mode 'normal)
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)
+
+  ;; FIXME This needs to be upstreamed to evil-collection.
+  (add-to-list  'evil-collection-pass-command-to-label '(pass-update-buffer . "gr"))
+
   (map! :map pass-mode-map
     :n "j"    #'pass-next-entry
     :n "k"    #'pass-prev-entry

--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -24,7 +24,7 @@
 
 
 (after! pass
-  (set-evil-initial-state! 'pass-mode 'emacs)
+  (set-evil-initial-state! 'pass-mode 'normal)
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)
   (define-key! pass-mode-map
     "j"    #'pass-next-entry

--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -13,16 +13,6 @@
 ;;;###package password-store
 (setq password-store-password-length 12)
 
-;; Fix hard-coded password-store location; respect PASSWORD_STORE_DIR envvar
-(defadvice! +pass--respect-pass-dir-envvar-a (entry)
-  "Return a string with the file content of ENTRY."
-  :override #'auth-source-pass--read-entry
-  (with-temp-buffer
-    (insert-file-contents
-     (expand-file-name (format "%s.gpg" entry) (password-store-dir)))
-    (buffer-substring-no-properties (point-min) (point-max))))
-
-
 (after! pass
   (set-evil-initial-state! 'pass-mode 'normal)
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)

--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -26,12 +26,12 @@
 (after! pass
   (set-evil-initial-state! 'pass-mode 'normal)
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)
-  (define-key! pass-mode-map
-    "j"    #'pass-next-entry
-    "k"    #'pass-prev-entry
-    "d"    #'pass-kill
-    "\C-j" #'pass-next-directory
-    "\C-k" #'pass-prev-directory))
+  (map! :map pass-mode-map
+    :n "j"    #'pass-next-entry
+    :n "k"    #'pass-prev-entry
+    :n "d"    #'pass-kill
+    :n "C-j" #'pass-next-directory
+    :n "C-k" #'pass-prev-directory))
 
 
 ;; Is built into Emacs 26+

--- a/modules/tools/pass/config.el
+++ b/modules/tools/pass/config.el
@@ -13,13 +13,13 @@
 ;;;###package password-store
 (setq password-store-password-length 12)
 
+(after! evil-collection-pass
+  ;; FIXME This needs to be upstreamed to evil-collection.
+  (add-to-list 'evil-collection-pass-command-to-label '(pass-update-buffer . "gr")))
+
 (after! pass
   (set-evil-initial-state! 'pass-mode 'normal)
   (set-popup-rule! "^\\*Password-Store" :side 'left :size 0.25 :quit nil)
-
-  ;; FIXME This needs to be upstreamed to evil-collection.
-  (add-to-list 'evil-collection-pass-command-to-label '(pass-update-buffer . "gr"))
-
   (map! :map pass-mode-map
         :n "j"   #'pass-next-entry
         :n "k"   #'pass-prev-entry


### PR DESCRIPTION
This enables `evil-collection` support for `tools/pass`, making sure the bindings are displayed properly in the `pass` header.
Originally, `pass` was launched in `emacs-state` because `evil-collection` didn't support `pass` when the module was written, but it does now.
It also removes stale code relative to the `PASSWORD_STORE_DIR` environment variable, since the password store path is not hardcoded in `pass.el` anymore.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
