### PR TITLE
fix(python): edit `pyimport-remove-unused` binding

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -224,7 +224,7 @@
         :localleader
         (:prefix ("i" . "imports")
           :desc "Insert missing imports" "i" #'pyimport-insert-missing
-          :desc "Remove unused imports"  "r" #'pyimport-remove-unused
+          :desc "Remove unused imports"  "R" #'pyimport-remove-unused
           :desc "Optimize imports"       "o" #'+python/optimize-imports)))
 
 


### PR DESCRIPTION
The binding for `pyimport-remove-unused` currently clashes with the binding for `py-isort-region`.

In `python-mode`, these are both triggered by:
- <kbd>leader</kbd><kbd>localleader</kbd><kbd>i</kbd><kbd>r</kbd>

This currently makes only `py-isort-region` accessible through bindings.
To fix this, make `pyimport-remove-unused` to be triggered by capital a `R`:
- <kbd>leader</kbd><kbd>localleader</kbd><kbd>i</kbd><kbd>R</kbd>

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).