### PR TITLE
bump: :lang lua

### DIFF
--- a/modules/lang/lua/packages.el
+++ b/modules/lang/lua/packages.el
@@ -11,7 +11,7 @@
       :pin "fcb99e5efcf31db05f236f02eaa575986a57172d")))
 
 (when (featurep! +fennel)
-  (package! fennel-mode :pin "50ef3c6246f36085cd908cf5432133cadb792304"))
+  (package! fennel-mode :pin "5664357349462d0564c0bb55cb289a6722f0ecbc"))
 
 (when (featurep! :completion company)
   (package! company-lua :pin "29f6819de4d691e5fd0b62893a9f4fbc1c6fcb52"))


### PR DESCRIPTION
https://git.sr.ht/~technomancy/fennel-mode@50ef3c6246f3 -> https://git.sr.ht/~technomancy/fennel-mode@566435734946

A fix was added upstream to fix `fennel-repl` no longer returning the
repl buffer. This fixes `+eval-open-repl` in fennel-mode.

This was fixed for #4263, but there was a regression which was fixed upstream.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
