### PR TITLE
feat(default): bind 'SPC b I' to open ibuffer for workspace

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -349,7 +349,8 @@
        :desc "Next buffer"                 "]"   #'next-buffer
        (:when (featurep! :ui workspaces)
         :desc "Switch workspace buffer" "b" #'persp-switch-to-buffer
-        :desc "Switch buffer"           "B" #'switch-to-buffer)
+        :desc "Switch buffer"           "B" #'switch-to-buffer
+        :desc "ibuffer workspace"       "i" #'+ibuffer/open-for-current-workspace)
        (:unless (featurep! :ui workspaces)
         :desc "Switch buffer"           "b" #'switch-to-buffer)
        :desc "Clone buffer"                "c"   #'clone-indirect-buffer

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -350,7 +350,7 @@
        (:when (featurep! :ui workspaces)
         :desc "Switch workspace buffer" "b" #'persp-switch-to-buffer
         :desc "Switch buffer"           "B" #'switch-to-buffer
-        :desc "ibuffer workspace"       "i" #'+ibuffer/open-for-current-workspace)
+        :desc "ibuffer workspace"       "I" #'+ibuffer/open-for-current-workspace)
        (:unless (featurep! :ui workspaces)
         :desc "Switch buffer"           "b" #'switch-to-buffer)
        :desc "Clone buffer"                "c"   #'clone-indirect-buffer


### PR DESCRIPTION
As `SPC b i` is already bound to `ibuffer`, this new binding is really convenient and consistent with Doom's current default binding.
