### PR TITLE
fix(mu4e): Update to mu 1.8

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -67,7 +67,7 @@ default/fallback account."
     (setq +mu4e--old-wconf (current-window-configuration))
     (delete-other-windows)
     (switch-to-buffer (doom-fallback-buffer)))
-  (mu4e~start 'mu4e~main-view)
+  (mu4e)
   ;; (save-selected-window
   ;;   (prolusion-mail-show))
   )

--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -76,7 +76,7 @@ Else, write to this process' PID to the lock file"
   "Handle another process requesting the Mu4e lock."
   (when (equal (nth 1 event) 'created)
     (when +mu4e-lock-relaxed
-      (mu4e~stop)
+      (mu4e--stop)
       (file-notify-rm-watch +mu4e-lock--file-watcher)
       (message "Someone else wants to use Mu4e, releasing lock")
       (delete-file +mu4e-lock-file)
@@ -90,4 +90,4 @@ Else, write to this process' PID to the lock file"
       (setq +mu4e-lock--file-just-deleted t)
       (when (and +mu4e-lock-greedy (+mu4e-lock-available t))
         (message "Noticed Mu4e lock was available, grabbed it")
-        (run-at-time 0.2 nil #'mu4e~start)))))
+        (run-at-time 0.2 nil #'mu4e--start)))))


### PR DESCRIPTION
Fixes #6511 
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

Attempts to fix mu4e module so that it can work with mu 1.8. This
mostly involves using the replacements for functions that were
removed, i.e changing `mu4e~stop` to `mu4e--stop`. Backward
compatibility is preserved by defining these new functions as
aliases of old ones.

`=mu4e` is fixed by changing a call to `mu4e~start with` `mu4e`.
`mu4e--start` doesn't work due because it should be preceded by
a call to `mu4e--init-handlers` which is new in 1.8. At least at
first glance `mu4e` handles both situations.

The module is now working for me but there might be further problems
especially with `org-msg` integration and notifications since I don't use these.
And someone still on 1.6 should check that it works too.