### PR TITLE
fix(mu4e): Support mu 1.8

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -67,7 +67,7 @@ default/fallback account."
     (setq +mu4e--old-wconf (current-window-configuration))
     (delete-other-windows)
     (switch-to-buffer (doom-fallback-buffer)))
-  (mu4e~start 'mu4e~main-view)
+  (mu4e)
   ;; (save-selected-window
   ;;   (prolusion-mail-show))
   )
@@ -188,6 +188,8 @@ is tomorrow.  With two prefixes, select the deadline."
                   (lev (org-outline-level))
                   (folded-p (invisible-p (point-at-eol)))
                   (from (plist-get msg :from)))
+              (if (consp (car from)) ; Occurs when using mu4e 1.8+.
+                  (setq from (car from)))
               ;; place the subheader
               (when folded-p (show-branches))    ; unfold if necessary
               (org-end-of-meta-data) ; skip property drawer

--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -76,7 +76,7 @@ Else, write to this process' PID to the lock file"
   "Handle another process requesting the Mu4e lock."
   (when (equal (nth 1 event) 'created)
     (when +mu4e-lock-relaxed
-      (mu4e~stop)
+      (mu4e--stop)
       (file-notify-rm-watch +mu4e-lock--file-watcher)
       (message "Someone else wants to use Mu4e, releasing lock")
       (delete-file +mu4e-lock-file)
@@ -90,4 +90,4 @@ Else, write to this process' PID to the lock file"
       (setq +mu4e-lock--file-just-deleted t)
       (when (and +mu4e-lock-greedy (+mu4e-lock-available t))
         (message "Noticed Mu4e lock was available, grabbed it")
-        (run-at-time 0.2 nil #'mu4e~start)))))
+        (run-at-time 0.2 nil #'mu4e)))))


### PR DESCRIPTION
This is basically an iteration on #6549 that should improve compatibility (backwards and forwards).

I've tested this and it seems to work well on 1.8. Ideally, someone could test 1.6 and confirm that this doesn't break anything.

Fixes #6511
Replaces #6549

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

