### PR TITLE
fix(dirvish): include dired-x and newer defaults

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -138,12 +138,13 @@ we have to clean it up ourselves."
 
 
 (use-package! dirvish
-  :when (featurep! +dirvish)
   :defer t
-  :init (after! dired (dirvish-override-dired-mode))
-  :hook (dired-mode . dired-omit-mode)
+  :when (featurep! +dirvish)
+  :init (dirvish-override-dired-mode)
   :config
-  (require 'dired-x)
+  (when (featurep! :ui tabs)
+    (after! centaur-tabs
+          (add-hook! 'dirvish-mode-hook 'centaur-tabs-local-mode)))
   (setq dirvish-cache-dir (concat doom-cache-dir "dirvish/")
         dirvish-hide-details nil
         dirvish-attributes '(git-msg vc-state file-size))
@@ -151,8 +152,8 @@ we have to clean it up ourselves."
    '(:left (sort file-time " " file-size symlink) :right (omit yank index)))
   (when (featurep! +icons)
     (push 'all-the-icons dirvish-attributes))
-  (when (featurep! ui: tabs +centaur-tabs)
-    (add-hook! 'dirvish-mode-hook (centaur-tabs-local-mode)))
+  ;; (when (featurep! ui: tabs)
+  ;;   (add-hook! 'dirvish-mode-hook (centaur-tabs-local-mode)))
   (map! :map dirvish-mode-map
         :n "b" #'dirvish-goto-bookmark
         :n "z" #'dirvish-show-history

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -151,6 +151,8 @@ we have to clean it up ourselves."
    '(:left (sort file-time " " file-size symlink) :right (omit yank index)))
   (when (featurep! +icons)
     (push 'all-the-icons dirvish-attributes))
+  (when (featurep! ui: tabs +centaur-tabs)
+    (add-hook! 'dirvish-mode-hook (centaur-tabs-local-mode)))
   (map! :map dirvish-mode-map
         :n "b" #'dirvish-goto-bookmark
         :n "z" #'dirvish-show-history
@@ -159,7 +161,7 @@ we have to clean it up ourselves."
         :n "l" #'dired-find-file
         :n "h" #'dired-up-directory
         :n "?" #'dirvish-dispatch
-        :n "q" #'quit-window
+        :n "q" #'dirvish-quit
         :localleader
         "h" #'dired-omit-mode)
   (global-set-key [remap find-dired] #'dirvish-fd)

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -72,6 +72,7 @@ Fixes #3939: unsortable dired entries on Windows."
 
 
 (use-package! diff-hl
+  :unless (featurep! +dirvish)
   :hook (dired-mode . diff-hl-dired-mode-unless-remote)
   :hook (magit-post-refresh . diff-hl-magit-post-refresh)
   :config
@@ -142,10 +143,12 @@ we have to clean it up ourselves."
   :init (after! dired (dirvish-override-dired-mode))
   :hook (dired-mode . dired-omit-mode)
   :config
+  (require 'dired-x)
   (setq dirvish-cache-dir (concat doom-cache-dir "dirvish/")
         dirvish-hide-details nil
-        dirvish-attributes '(git-msg)
-        dired-omit-files (concat dired-omit-files "\\|^\\..*$"))
+        dirvish-attributes '(git-msg vc-state file-size))
+  (setq dirvish-mode-line-format
+   '(:left (sort file-time " " file-size symlink) :right (omit yank index)))
   (when (featurep! +icons)
     (push 'all-the-icons dirvish-attributes))
   (map! :map dirvish-mode-map
@@ -155,8 +158,12 @@ we have to clean it up ourselves."
         :n "F" #'dirvish-toggle-fullscreen
         :n "l" #'dired-find-file
         :n "h" #'dired-up-directory
+        :n "?" #'dirvish-dispatch
+        :n "q" #'quit-window
         :localleader
-        "h" #'dired-omit-mode))
+        "h" #'dired-omit-mode)
+  (global-set-key [remap find-dired] #'dirvish-fd)
+  (set-popup-rule! "^ \\*Dirvish.*" :ignore t))
 
 
 (use-package! all-the-icons-dired
@@ -184,7 +191,6 @@ we have to clean it up ourselves."
 
 
 (use-package! dired-x
-  :unless (featurep! +dirvish)
   :unless (featurep! +ranger)
   :hook (dired-mode . dired-omit-mode)
   :config
@@ -221,6 +227,7 @@ we have to clean it up ourselves."
 
 (use-package! fd-dired
   :when doom-projectile-fd-binary
+  :unless (featurep! +dirvish)
   :defer t
   :init
   (global-set-key [remap find-dired] #'fd-dired)

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -8,7 +8,7 @@
 (when (featurep! +ranger)
   (package! ranger :pin "2498519cb21dcd5791d240607a72a204d1761668"))
 (when (featurep! +dirvish)
-  (package! dirvish :pin "73dcaa404da9ab84d25f2919e6e3af4b1f8e7f37"))
+  (package! dirvish :pin "0f61b3e3f73bdfebe29ea6cab810f71f8c9d3540"))
 (when (and (featurep! +icons)
            (not (featurep! +dirvish)))
   (package! all-the-icons-dired :pin "5e9b097f9950cc9f86de922b07903a4e5fefc733"))

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -8,7 +8,7 @@
 (when (featurep! +ranger)
   (package! ranger :pin "2498519cb21dcd5791d240607a72a204d1761668"))
 (when (featurep! +dirvish)
-  (package! dirvish :pin "0f61b3e3f73bdfebe29ea6cab810f71f8c9d3540"))
+  (package! dirvish :pin "bf44aa283e6cbb93129d72e5b965bf4bfe8d5f61"))
 (when (and (featurep! +icons)
            (not (featurep! +dirvish)))
   (package! all-the-icons-dired :pin "5e9b097f9950cc9f86de922b07903a4e5fefc733"))

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -8,7 +8,7 @@
 (when (featurep! +ranger)
   (package! ranger :pin "2498519cb21dcd5791d240607a72a204d1761668"))
 (when (featurep! +dirvish)
-  (package! dirvish :pin "bf44aa283e6cbb93129d72e5b965bf4bfe8d5f61"))
+  (package! dirvish :pin "86b7002d3b035b1a314775db5ff1946e29bd33ef"))
 (when (and (featurep! +icons)
            (not (featurep! +dirvish)))
   (package! all-the-icons-dired :pin "5e9b097f9950cc9f86de922b07903a4e5fefc733"))


### PR DESCRIPTION
- Bumps the version to latest as doom is very far behind.
- fixes the void-variable `dired-omit-files` experienced by users who have unpinned dirvish 
- adds a sensible quit binding for fullscreen 
- adds a sensible `dirvish-mode-line-format` consistent with the package authors recommendations (see https://github.com/alexluigit/dirvish/blob/main/CUSTOMIZING.org)
- fixes popup window sizing issue experienced by users who have `+all` enabled for `popup` (see https://github.com/alexluigit/dirvish/issues/18)

This also implements the feedback of the package author in #6397 for the original pull request for this module that includes:
- replaces `fd-dired` with `dirvish-fd`
- removes the `+dired/quit-all` binding
- adds a binding for `dired-dispatch` similar to that of magit and treemacs
- replaces `diff-hl-dired-mode` with dirvish's inbuilt `vc-state`

the `+dirvish` flag is currently undocumented in the modules. But I am assuming this will need to be a separate PR.


Fixes #6562
References #6397
Replaces #6566 #6567

Before:
![image](https://user-images.githubusercontent.com/37862994/179519019-f409f092-c354-41f3-9835-4307560290b0.png)


After:
![image](https://user-images.githubusercontent.com/37862994/179517730-edacd902-7ef7-4a02-b833-af8914f7af17.png)


-----
- [x ] I searched the issue tracker and this hasn't been PRed before.
- [ x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ x] My changes are visual; I've included before and after screenshots.
- [x ] Any relevant issues or PRs have been linked to.
