### PR TITLE
notmuch: improve update

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -60,18 +60,20 @@
 (defun +notmuch/update ()
   "Sync notmuch emails with server."
   (interactive)
-  (with-current-buffer (compile (+notmuch-get-sync-command))
-    (add-hook
-     'compilation-finish-functions
-     (lambda (buf status)
-       (if (equal status "finished\n")
-           (progn
-             (kill-buffer buf)
-             (notmuch-refresh-all-buffers)
-             (message "Notmuch sync successful"))
-         (user-error "Failed to sync notmuch data")))
-     nil
-     'local)))
+  (let ((compilation-buffer-name-function (lambda (_) (format "*notmuch update*"))))
+   (with-current-buffer (compile (+notmuch-get-sync-command))
+     (add-hook
+      'compilation-finish-functions
+      (lambda (buf status)
+        (if (equal status "finished\n")
+            (progn
+              (delete-windows-on buf)
+              (bury-buffer buf)
+              (notmuch-refresh-all-buffers)
+              (message "Notmuch sync successful"))
+          (user-error "Failed to sync notmuch data")))
+      nil
+      'local))))
 
 ;;;###autoload
 (defun +notmuch/search-delete ()


### PR DESCRIPTION
Currently, update buffer creates an additional window that stays on. I
think it's better to delete the window and bury the buffer. That way
user still can open the buffer later to check the update status.
