### PR TITLE
fix(unicode): fix long startup times on Emacs29

### DIFF
--- a/modules/ui/unicode/packages.el
+++ b/modules/ui/unicode/packages.el
@@ -2,3 +2,8 @@
 ;;; ui/unicode/packages.el
 
 (package! unicode-fonts :pin "47f2397ade28eba621baa865fd69e4efb71407a5")
+(package! pcache
+  ;; Use a fork of `pcache', which has been patched to support Emacs 29 (the
+  ;; original has been abandoned).
+  :recipe (:host github :repo "LemonBreezes/pcache")
+  :pin "2004af4cf978ca8fcbeaa4da6b9b12600a202aeb")


### PR DESCRIPTION
This patch fixes Pcache for users of Emacs29 so that users of Unicode
Fonts on Emacs29 do not have to have 30 seconds plus initialization
times on every startup. 

I am currently trying to get this patch into Pcache but it looks like the package is abandoned. I have PM'd Jonas (Tarsius) on Reddit about this and am waiting for him to reply.