### PR TITLE
fix(pdf): remove pdf-tools-install-noverify

### DIFF
--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -28,8 +28,6 @@
       (fundamental-mode)
       (message "Viewing PDFs in Emacs requires epdfinfo. Use `M-x pdf-tools-install' to build it")))
 
-  (pdf-tools-install-noverify)
-
   ;; For consistency with other special modes
   (map! :map pdf-view-mode-map :gn "q" #'kill-current-buffer)
 


### PR DESCRIPTION
It tries to pdf-tools-install-noverify
even if true (file-executable-p pdf-info-epdfinfo-program).
The if already encourages installing it interactively if false
"Viewing PDFs in Emacs requires epdfinfo.
Use `M-x pdf-tools-install' to build it"

Also, errors

```emacs-lisp

Debugger entered--Lisp error: (void-function pdf-occur-global-minor-mode)
  pdf-occur-global-minor-mode(1)
  pdf-tools-install-noverify()
  (progn (use-package-statistics-gather :config 'pdf-tools nil) (progn (defalias '+pdf--install-epdfinfo-a #'(lambda (fn &rest args) "Install epdfinfo after the first PDF file, if need..." (if (file-executable-p pdf-info-epdfinfo-program) (apply fn args) (fundamental-mode) (message "Viewing PDFs in Emacs requires epdfinfo. Use `M-x ...")))) (let ((--dolist-tail-- (list (cons :around (doom-enlist ...))))) (while --dolist-tail-- (let ((targets (car --dolist-tail--))) (let ((--dolist-tail-- ...)) (while --dolist-tail-- (let ... ... ...))) (setq --dolist-tail-- (cdr --dolist-tail--)))))) (pdf-tools-install-noverify) (general-define-key :keymaps '(pdf-view-mode-map) "q" #'kill-current-buffer) (progn (set-default 'pdf-view-display-size 'fit-page)) (progn (setq pdf-view-use-scaling t) (setq pdf-view-use-imagemagick nil)) (set-popup-rules! '(("^\\*Outline*" :side right :size 40 :select nil) ("^\\*Edit Annotation " :quit nil) ("\\(?:^\\*Contents\\|'s annots\\*$\\)" :ignore t))) (add-hook 'pdf-annot-list-mode-hook #'hide-mode-line-mode) (progn (defalias 'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h #'(lambda (&rest _) "evil-normal-state-cursor = (list nil)\n" (set (make-local-variable 'evil-normal-state-cursor) (list nil)))) (remove-hook 'pdf-view-mode-hook #'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h) (add-hook 'pdf-view-mode-hook #'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h)) (defalias '+pdf-reload-midnight-minor-mode-h #'(lambda nil (if pdf-view-midnight-minor-mode (progn (pdf-info-setoptions :render/foreground (car pdf-view-midnight-colors) :render/background (cdr pdf-view-midnight-colors) :render/usecolors t) (pdf-cache-clear-images) (pdf-view-redisplay t))))) (put 'pdf-view-midnight-colors 'custom-set #'(lambda (sym value) (set-default sym value) (let ((--dolist-tail-- (doom-buffers-in-mode ...))) (while --dolist-tail-- (let (...) (save-current-buffer ... ...) (setq --dolist-tail-- ...)))))) (progn (defalias '+pdf-suppress-large-file-prompts-a #'(lambda (fn size op-type filename &optional offer-raw) nil (if (string-match-p "\\.pdf\\'" filename) nil (funcall fn size op-type filename offer-raw)))) (let ((--dolist-tail-- (list (cons :around (doom-enlist ...))))) (while --dolist-tail-- (let ((targets (car --dolist-tail--))) (let ((--dolist-tail-- ...)) (while --dolist-tail-- (let ... ... ...))) (setq --dolist-tail-- (cdr --dolist-tail--)))))) t (use-package-statistics-gather :config 'pdf-tools t))
  (closure (t) nil (progn (use-package-statistics-gather :config 'pdf-tools nil) (progn (defalias '+pdf--install-epdfinfo-a #'(lambda (fn &rest args) "Install epdfinfo after the first PDF file, if need..." (if (file-executable-p pdf-info-epdfinfo-program) (apply fn args) (fundamental-mode) (message "Viewing PDFs in Emacs requires epdfinfo. Use `M-x ...")))) (let ((--dolist-tail-- (list (cons :around ...)))) (while --dolist-tail-- (let ((targets ...)) (let (...) (while --dolist-tail-- ...)) (setq --dolist-tail-- (cdr --dolist-tail--)))))) (pdf-tools-install-noverify) (general-define-key :keymaps '(pdf-view-mode-map) "q" #'kill-current-buffer) (progn (set-default 'pdf-view-display-size 'fit-page)) (progn (setq pdf-view-use-scaling t) (setq pdf-view-use-imagemagick nil)) (set-popup-rules! '(("^\\*Outline*" :side right :size 40 :select nil) ("^\\*Edit Annotation " :quit nil) ("\\(?:^\\*Contents\\|'s annots\\*$\\)" :ignore t))) (add-hook 'pdf-annot-list-mode-hook #'hide-mode-line-mode) (progn (defalias 'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h #'(lambda (&rest _) "evil-normal-state-cursor = (list nil)\n" (set (make-local-variable ...) (list nil)))) (remove-hook 'pdf-view-mode-hook #'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h) (add-hook 'pdf-view-mode-hook #'doom--setq-evil-normal-state-cursor-for-pdf-view-mode-h)) (defalias '+pdf-reload-midnight-minor-mode-h #'(lambda nil (if pdf-view-midnight-minor-mode (progn (pdf-info-setoptions :render/foreground ... :render/background ... :render/usecolors t) (pdf-cache-clear-images) (pdf-view-redisplay t))))) (put 'pdf-view-midnight-colors 'custom-set #'(lambda (sym value) (set-default sym value) (let ((--dolist-tail-- ...)) (while --dolist-tail-- (let ... ... ...))))) (progn (defalias '+pdf-suppress-large-file-prompts-a #'(lambda (fn size op-type filename &optional offer-raw) nil (if (string-match-p "\\.pdf\\'" filename) nil (funcall fn size op-type filename offer-raw)))) (let ((--dolist-tail-- (list (cons :around ...)))) (while --dolist-tail-- (let ((targets ...)) (let (...) (while --dolist-tail-- ...)) (setq --dolist-tail-- (cdr --dolist-tail--)))))) t (use-package-statistics-gather :config 'pdf-tools t)))()
  eval-after-load-helper("/nix/store/2xw4bx8ydz79mmdwrbdzv16zyvqhnhk4-emacs-...")
  do-after-load-evaluation("/nix/store/2xw4bx8ydz79mmdwrbdzv16zyvqhnhk4-emacs-...")
  require(pdf-tools)
  load-with-code-conversion("/home/yuu/.config/emacs/.local/straight/build-29.0..." "/home/yuu/.config/emacs/.local/straight/build-29.0..." nil t)
  require(org-pdftools)
  load-with-code-conversion("/home/yuu/.config/emacs/.local/straight/build-29.0..." "/home/yuu/.config/emacs/.local/straight/build-29.0..." nil t)
  require(org-noter-pdftools nil nil)
  load-with-code-conversion("/home/yuu/.config/doom/config.el" "/home/yuu/.config/doom/config.el" t t)
  load("/home/yuu/.config/doom/config" t nomessage)
  (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage))
  (condition-case e (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name "config" doom-private-dir) doom-private-dir)))
  (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name "config" doom-private-dir) doom-private-dir))) (if custom-file (progn (load custom-file 'noerror (not doom-debug-mode)))))
  (progn (doom-log "Initializing user config") (maphash (doom-module-loader doom-module-init-file) doom-modules) (doom-run-hooks 'doom-before-init-modules-hook) (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name "config" doom-private-dir) doom-private-dir))) (if custom-file (progn (load custom-file 'noerror (not doom-debug-mode))))))
  (if init-p (progn (doom-log "Initializing user config") (maphash (doom-module-loader doom-module-init-file) doom-modules) (doom-run-hooks 'doom-before-init-modules-hook) (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name "config" doom-private-dir) doom-private-dir))) (if custom-file (progn (load custom-file 'noerror (not doom-debug-mode)))))) nil)
  (let* ((init-p (and t (condition-case e (let (file-name-handler-alist) (load (expand-file-name doom-module-init-file doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name doom-module-init-file doom-private-dir) doom-private-dir)))))) (if init-p (progn (doom-log "Initializing user config") (maphash (doom-module-loader doom-module-init-file) doom-modules) (doom-run-hooks 'doom-before-init-modules-hook) (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let (file-name-handler-alist) (load (expand-file-name "config" doom-private-dir) t 'nomessage)) ((debug doom-error) (signal (car e) (cdr e))) ((debug error) (doom--handle-load-error e (expand-file-name "config" doom-private-dir) doom-private-dir))) (if custom-file (progn (load custom-file 'noerror (not doom-debug-mode)))))) nil))
  (progn (setq doom-init-modules-p t) (if no-config-p nil (doom-log "Initializing core modules") (doom-initialize-core-modules)) (let* ((init-p (and t (condition-case e (let (file-name-handler-alist) (load ... t ...)) ((debug doom-error) (signal ... ...)) ((debug error) (doom--handle-load-error e ... doom-private-dir)))))) (if init-p (progn (doom-log "Initializing user config") (maphash (doom-module-loader doom-module-init-file) doom-modules) (doom-run-hooks 'doom-before-init-modules-hook) (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let (file-name-handler-alist) (load ... t ...)) ((debug doom-error) (signal ... ...)) ((debug error) (doom--handle-load-error e ... doom-private-dir))) (if custom-file (progn (load custom-file ... ...))))) nil)))
  (if (or force-p (not doom-init-modules-p)) (progn (setq doom-init-modules-p t) (if no-config-p nil (doom-log "Initializing core modules") (doom-initialize-core-modules)) (let* ((init-p (and t (condition-case e (let ... ...) (... ...) (... ...))))) (if init-p (progn (doom-log "Initializing user config") (maphash (doom-module-loader doom-module-init-file) doom-modules) (doom-run-hooks 'doom-before-init-modules-hook) (if no-config-p nil (maphash (doom-module-loader doom-module-config-file) doom-modules) (doom-run-hooks 'doom-init-modules-hook) (condition-case e (let ... ...) (... ...) (... ...)) (if custom-file (progn ...)))) nil))))
  doom-initialize-modules()
  load-with-code-conversion("/home/yuu/.config/emacs/core/core-start.el" "/home/yuu/.config/emacs/core/core-start.el" t t)
  load("/home/yuu/.config/emacs/core/core-start" noerror nomessage)
  #<subr startup--load-user-init-file>((closure ((args #f(compiled-function () #<bytecode -0x19747cd187cbe0eb>) #f(compiled-function () #<bytecode -0x620187f0337c900>) t) t) nil (expand-file-name "core-start" doom-core-dir)) nil t)
  apply(#<subr startup--load-user-init-file> ((closure ((args #f(compiled-function () #<bytecode -0x19747cd187cbe0eb>) #f(compiled-function () #<bytecode -0x620187f0337c900>) t) t) nil (expand-file-name "core-start" doom-core-dir)) nil t))
  startup--load-user-init-file(#f(compiled-function () #<bytecode -0x19747cd187cbe0eb>) #f(compiled-function () #<bytecode -0x620187f0337c900>) t)
  command-line()
```

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
