### PR TITLE
Add override to reflect breaking `fd` change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Check out [the FAQ][FAQ] for answers to common questions about the project.
 + Emacs 27.1+ (*28.1 is recommended*, or [native-comp](https://www.emacswiki.org/emacs/GccEmacs). **29+ is not supported**).
 + [ripgrep] 11.0+
 + GNU `find`
-+ *OPTIONAL:* [fd] 7.3.0+ (improves file indexing performance for some commands)
++ *OPTIONAL:* [fd] 8.3.0+ (improves file indexing performance for some commands)
   
 Doom is comprised of [~150 optional modules][Modules], some of which may have
 additional dependencies. [Visit their documentation][Modules] or run `bin/doom


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

`v8.3.0` of `fd` introduced a breaking change to how paths are displayed; see https://github.com/sharkdp/fd/issues/760 and https://github.com/sharkdp/fd/pull/861. #6535 introduced a new `fd` flag that reverts the new behavior, but it is only compatible with `>=v8.3.0`. 

This pull request adds an optional override to use a binary other than `fd` for users with older versions, and reflects the new minimum version in the README.

References #6535

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
