### PR TITLE
DRAFT: remove advice for org-bable-tangle for emacs 28+

### DIFF
--- a/bin/org-tangle
+++ b/bin/org-tangle
@@ -107,8 +107,10 @@ trees with the :notangle: tag."
                      (push (cons src-lang (list block)) blocks))))))))
     ;; Ensure blocks are in the correct order.
     (mapcar (lambda (b) (cons (car b) (nreverse (cdr b)))) blocks)))
-(advice-add #'org-babel-tangle-collect-blocks
-            :override #'*org-babel-tangle-collect-blocks)
+;; Signature changed in emacs 28+ / disable for 28+, allow for previous versions
+(if (version< emacs-version "28.0")
+  (advice-add #'org-babel-tangle-collect-blocks
+              :override #'*org-babel-tangle-collect-blocks))
 
 (defvar all-blocks nil)
 (defvar and-tags nil)


### PR DESCRIPTION
`org-tangle` has an updated function that attempts to add some advice with an by over-riding `org-tangle-collect-blocks`. It seems that function arguments may have changed. 

Fixes #6267

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to finish it.
