### PR TITLE
nit(vertico): fix typo and docstring

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -58,7 +58,7 @@
 
 ;;;###autoload
 (defun +vertico/project-search (&optional arg initial-query directory)
-  "Peforms a live project search from the project root using ripgrep.
+  "Performs a live project search from the project root using ripgrep.
 If ARG (universal argument), include all files, even hidden or compressed ones,
 in the search."
   (interactive "P")

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -73,6 +73,7 @@ If ARG (universal argument), include all files, even hidden or compressed ones."
 
 ;;;###autoload
 (defun +vertico/search-symbol-at-point ()
+  "Performs a search in the current buffer for thing at point."
   (interactive)
   (consult-line (thing-at-point 'symbol)))
 


### PR DESCRIPTION
Fix a typo and add a missing function docstring in the vertico module.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).