### PR TITLE
refactor!(evil): remove evil-want-C-w-scroll

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -23,7 +23,6 @@ directives. By default, this only recognizes C directives.")
 (defvar evil-want-C-i-jump nil)  ; we do this ourselves
 (defvar evil-want-C-u-scroll t)  ; moved the universal arg to <leader> u
 (defvar evil-want-C-u-delete t)
-(defvar evil-want-C-w-scroll t)
 (defvar evil-want-C-w-delete t)
 (defvar evil-want-Y-yank-to-eol t)
 (defvar evil-want-abbrev-expand-on-insert-exit nil)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Remove the `evil-want-C-w-scroll` variable. It is not used anywhere and appears to have been added accidentally in 8b9d4a94bbe9db38eb2783c73ef9c7edca0cf91a

I was browsing the various `evil-want-` variables (with `M-x helpful-variable`) and this one caught my eye. It sounded out of place and had no documentation. (I hope this isn't considered too trivial a change to warrant a PR, as it caused some genuine confusion for me as a user.)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
