### PR TITLE
bump: :tools biblio

### DIFF
--- a/modules/tools/biblio/README.org
+++ b/modules/tools/biblio/README.org
@@ -21,7 +21,9 @@ selected so it should be possible to use without modifications.
 
 ** Packages
 - [[doom-package:][bibtex-completion]] if [[doom-module:][:completion ivy]] or [[doom-module:][:completion helm]]
+- [[doom-package:][parsebib]] if [[doom-module:][:completion ivy]] or [[doom-module:][:completion helm]] or [[doom-module:][:completion vertico]]
 - [[doom-package:][citar]] if [[doom-module:][:completion vertico]]
+- [[doom-package:][citar-embark]] if [[doom-module:][:completion vertico]]
 - [[doom-package:][helm-bibtex]] if [[doom-module:][:completion helm]]
 - [[doom-package:][ivy-bibtex]] if [[doom-module:][:completion ivy]]
 

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -24,6 +24,11 @@
         org-cite-follow-processor 'citar
         org-cite-activate-processor 'citar))
 
+(use-package! citar-embark
+  :when (featurep! :completion vertico)
+  :after citar embark
+  :config (citar-embark-mode))
+
 ;; `org-cite' processors
 (use-package! oc-biblatex :after oc)
 (use-package! oc-csl :after oc)

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -8,6 +8,8 @@
   (package! bibtex-completion :pin "ce8c17690ddad73d01531084b282f221f8eb6669")
   (package! helm-bibtex :pin "ce8c17690ddad73d01531084b282f221f8eb6669"))
 (when (featurep! :completion vertico)
-  (package! citar :pin "dd028c6a4d2fb1c7b89082dffa15be01637765c5"))
+  (package! citar :pin "146f2cb5a31d4968ec17f39f189e4ea131ccaf56")
+  (package! citar-embark :pin "146f2cb5a31d4968ec17f39f189e4ea131ccaf56"))
 
-(package! citeproc :pin "ba49516265fa24b138346c4918d39d19b4de8a62")
+(package! parsebib :pin "175a1bdac1eabc7415116c8722795a1155e2d2c9")
+(package! citeproc :pin "406bd9964f1ce531fc45beddcf9ccc44d3456129")


### PR DESCRIPTION
Bump the biblio module, which also requires adding `citar-embark`, which now contains the embark functionality in a separate minor mode package. Also, add an explicit parsebib package line to pin it.

Also, close #6464