### PR TITLE
bump: :lang python

### DIFF
--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -26,7 +26,7 @@
 (when (featurep! +pyenv)
   (package! pyenv-mode :pin "b818901b8eac0e260ced66a6a5acabdbf6f5ba99"))
 (when (featurep! +conda)
-  (package! conda :pin "9c28d7a853b4b4bd00215cf7f07856c1563f2ad7"))
+  (package! conda :pin "8aae96771c6cc8139e675f04d96c4d794580c3cd"))
 (when (featurep! +poetry)
   (package! poetry :pin "5b9ef569d629d79820e73b5380e54e443ba90616"))
 


### PR DESCRIPTION
Fix conda env activate
necaris/conda.el@9c28d7a853b4b4bd00215cf7f07856c1563f2ad7 -> necaris/conda.el@8aae96771c6cc8139e675f04d96c4d794580c3cd

The pinned conda.el would not work with the conda 4.13.
Specifically, conda activate env not work.
Luckly the recent version of conda.el fixed this issue.


Fixes #6626

- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
