### PR TITLE
fix(mu4e): force the account stripe face to be non-italic

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -134,7 +134,8 @@ a quoted symbol for a alist of current strings and faces provided."
   (put-text-property
    0 (length str)
    'face
-   (if (not unique)
+   (list
+    (if (not unique)
        (+mu4e--str-color-face herring str)
      (let ((unique-alist (eval unique)))
        (unless (assoc herring unique-alist)
@@ -152,6 +153,7 @@ a quoted symbol for a alist of current strings and faces provided."
              (push (cons herring color) unique-alist)))
          (set unique unique-alist))
        (cdr (assoc herring unique-alist))))
+    'default)
    str)
   str)
 


### PR DESCRIPTION
With mu4e came a new face for the header view. While this is nice for
the text, it had the consequence of making the account stripe (the
vertical bar) a bit jarring. This patch fixes that behavior to make the
stripe non-italic by append `'default` to the face.