### PR TITLE
tweak(mu4e): change icon for reply flagged mails

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -113,7 +113,7 @@ will also be the width of all other printable characters."
         mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "flag"))
         mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "sync" :set "material" :height 0.8 :v-adjust -0.10))
         mu4e-headers-passed-mark     (cons "P" (+mu4e-normalised-icon "arrow-right"))
-        mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "arrow-right"))
+        mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "reply"))
         mu4e-headers-seen-mark       (cons "S" "") ;(+mu4e-normalised-icon "eye" :height 0.6 :v-adjust 0.07 :color "dsilver"))
         mu4e-headers-trashed-mark    (cons "T" (+mu4e-normalised-icon "trash"))
         mu4e-headers-attach-mark     (cons "a" (+mu4e-normalised-icon "file-text-o" :color "silver"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The current config is kinda confusing, it uses the same symbol for both forwarded/passed mails and replied mails. FontAwesome provides a nice icon for "reply", why not use it!

## Before

![Screenshot_20220808_024138](https://user-images.githubusercontent.com/3716399/183318168-8cbd129a-b40c-4d1e-8b05-1e1ca0597b26.png)

## After
![Screenshot_20220808_024006](https://user-images.githubusercontent.com/3716399/183318172-6852476f-1e60-42f3-ae33-bbaed9d9af1d.png)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
