### PR TITLE
fix(org): respect org-table-automatic-realign

### DIFF
--- a/modules/lang/org/autoload/org-tables.el
+++ b/modules/lang/org/autoload/org-tables.el
@@ -47,7 +47,7 @@ re-align the table if necessary. (Necessary because org-mode has a
 ;;;###autoload
 (defun +org-realign-table-maybe-h ()
   "Auto-align table under cursor."
-  (when (and (org-at-table-p) org-table-may-need-update)
+  (when (and org-table-automatic-realign (org-at-table-p) org-table-may-need-update)
     (let ((pt (point))
           (inhibit-message t))
       (if org-table-may-need-update (org-table-align))


### PR DESCRIPTION
Fixes unsubmitted bug with org tables autoaligning:

In function for automatically align table on exit of insert state
added check for standard variable ~org-table-automatic-realign~

Documentation
Non-nil means automatically re-align table when pressing TAB or RETURN.

When nil, aligning is only done with M-x org-table-align, or after column
removal/insertion.

Troubleshooted that when attempted to figure out how to stop table that realigned for 11 seconds after exit of insert mode.
Found that there's a variable for that and that doom custom function doesn't respect it


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
