### PR TITLE
fix(org): check WAYLAND_DISPLAY for bin/org-capture

### DIFF
--- a/modules/lang/org/autoload/org-capture.el
+++ b/modules/lang/org/autoload/org-capture.el
@@ -17,7 +17,9 @@
     (transient . t)
     ,@(when IS-LINUX
         `((window-system . ,(if (boundp 'pgtk-initialized) 'pgtk 'x))
-          (display . ,(or (getenv "DISPLAY") ":0"))))
+          (display . ,(or (getenv "WAYLAND_DISPLAY")
+                          (getenv "DISPLAY")
+                          ":0"))))
     ,(if IS-MAC '(menu-bar-lines . 1)))
   "TODO")
 


### PR DESCRIPTION
Check `WAYLAND_DISPLAY` for `+org-capture-frame-parameters`.
PGTK emacsclient also use this logic, see references below.

References https://github.com/masm11/emacs/pull/13

- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

