### PR TITLE
Feat/add ltex grammar

### DIFF
--- a/modules/checkers/grammar/README.org
+++ b/modules/checkers/grammar/README.org
@@ -11,11 +11,15 @@ This module adds grammar checking to Emacs to aid your writing by combining
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-/This module has no flags./
+- +lsp ::
+  Use [[doom-package:][lsp-ltex]] to provide on the fly corrections via [[https://valentjn.github.io/ltex/index.html][LTeX LS]].
 
 ** Packages
-- [[doom-package:][langtool]]
 - [[doom-package:][writegood-mode]]
+- if [[doom-module:][+lsp]]
+  - [[doom-package:][lsp-ltex]]
+- else
+  - [[doom-package:][langtool]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -27,7 +31,8 @@ This module adds grammar checking to Emacs to aid your writing by combining
 * Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-This module requires [[https://languagetool.org/][LanguageTool]] (which requires =Java 1.8+=).
+When using [[doom-package:][langtool]], this module requires [[https://languagetool.org/][LanguageTool]] (which requires =Java
+1.8+=).
 
 It is available from either https://languagetool.org/ or your OS's package
 manager. E.g.
@@ -37,6 +42,10 @@ manager. E.g.
 This module tries to guess the location of =languagetool-commandline.jar=. If
 you get a warning that Doom ~couldn't find languagetool-commandline.jar~, you
 will need to set ~langtool-language-tool-jar~ to its location.
+
+When configured with the [[doom-module:][+lsp]] flag, the [[doom-package:][lsp-ltex]] package will automatically
+install the LSP server which comes with bundled with LanguageTool and a Java
+distribution.
 
 * TODO Usage
 #+begin_quote
@@ -52,8 +61,16 @@ stylistic issues in your writing. This requires Java 1.8+.
 #+end_quote
 
 *** Commands
+**** For [[doom-package:][langtool]] users
 - ~M-x langtool-check~
 - ~M-x langtool-correct-buffer~
+
+**** For [[doom-package:][lsp-ltex]] users
+Doom automatically enables ~lsp-ltex~ for ~text-mode~, ~latex-mode~, ~org-mode~, and
+~markdown-mode~.
+
+- Use ~M-x +lsp-ltex-toggle~ or ~SPC localleadr G~ to enable or disable ~lsp-ltex~ in the current
+buffer.
 
 ** writegood-mode
 This minor mode highlights weasel words, duplication and passive voice.
@@ -62,6 +79,32 @@ This minor mode highlights weasel words, duplication and passive voice.
 #+begin_quote
  🔨 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
 #+end_quote
+
+
+** For [[doom-package:][lsp-ltex]] users
+You can enhance your LanguageTool experience by customizing ~lsp-ltex~.
+
+#+begin_src emacs-lisp
+(setq lsp-ltex-language "fr" ;; Set your default (most used) language
+      lsp-ltex-mother-tongue "ar") ;; Set your mother longue
+#+end_src
+
+LanguageTool can make use of large n-gram data sets to detect errors with words
+that are often confused, like /their/ and /there/. The n-gram data set is huge and
+thus not part of the LanguageTool package. To make use of it, you have two
+choices:
+
+- Download it form [[https://languagetool.org/download/ngram-data/][languagetool.org]]
+- Install it from your distribution package manager
+  - For Arch-based distros, there is AUR packages (~languagetool-ngrams-<lang>~
+    for languages: en, fr, de, es, he, it, nl, ru or zh.
+
+Doom will automatically use n-grams if found in =/usr/share/ngrams=, however, if
+you downloaded them to another directory, you can set the following variable:
+
+#+begin_src emacs-lisp
+(setq lsp-ltex-additional-rules-language-model "path/to/ngrams")
+#+end_src
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]

--- a/modules/checkers/grammar/doctor.el
+++ b/modules/checkers/grammar/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; checkers/grammar/doctor.el
+
+(assert! (or (not (modulep! +lsp))
+             (modulep! :tools lsp))
+         "This module requires (:tools lsp)")

--- a/modules/checkers/grammar/packages.el
+++ b/modules/checkers/grammar/packages.el
@@ -1,5 +1,9 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; checkers/grammar/packages.el
 
-(package! langtool :pin "8276eccc5587bc12fd205ee58a7a982f0a136e41")
+(when (and (modulep! +lsp)
+           (not (modulep! :tools lsp +eglot)))
+  (package! lsp-ltex :pin "18b0e8608408f9e913d89075e78c2b4e3f69cf1c"))
+(unless (modulep! +lsp)
+  (package! langtool :pin "8276eccc5587bc12fd205ee58a7a982f0a136e41"))
 (package! writegood-mode :pin "ed42d918d98826ad88928b7af9f2597502afc6b0")


### PR DESCRIPTION
Enable fast grammar checking using `lsp-ltex`, which provides integration with the LTeX LS, this last uses LanguageTool to correct grammar. This is way faster and responsive than the currently used `langtool` package.

The configuration can be used enabling `+lsp` for the `grammar` module.

### Example Org document after enabling `:checkers (grammar +lsp)`
![Screenshot_20220816_153750](https://user-images.githubusercontent.com/3716399/184894756-2c48043b-6c7d-41b8-832d-d7813323b28a.png)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).