### PR TITLE
fix: defer-feature! fallback FNS

### DIFF
--- a/lisp/doom-lib.el
+++ b/lisp/doom-lib.el
@@ -595,14 +595,15 @@ serve as a predicated alternative to `after!'."
            (add-hook 'after-load-functions #',fn)))))
 
 (defmacro defer-feature! (feature &rest fns)
-  "Pretend FEATURE hasn't been loaded yet, until FEATURE-hook or FN runs.
+  "Pretend FEATURE hasn't been loaded yet, until FEATURE-hook or FNS run.
 
 Some packages (like `elisp-mode' and `lisp-mode') are loaded immediately at
 startup, which will prematurely trigger `after!' (and `with-eval-after-load')
 blocks. To get around this we make Emacs believe FEATURE hasn't been loaded yet,
-then wait until FEATURE-hook (or MODE-hook, if FN is provided) is triggered to
-reverse this and trigger `after!' blocks at a more reasonable time."
-  (let ((advice-fn (intern (format "doom--defer-feature-%s-a" feature))))
+then wait until FEATURE-hook (or any of FNS, if FNS are provided) is triggered
+to reverse this and trigger `after!' blocks at a more reasonable time."
+  (let ((advice-fn (intern (format "doom--defer-feature-%s-a" feature)))
+        (fns (or fns (list feature))))
     `(progn
        (delq! ',feature features)
        (defadvice! ,advice-fn (&rest _)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Fix the behavior of `defer-feature!` when called with one argument.

If `defer-feature!` was called with one argument (as is the case in the `:lang common-lisp` module), `FNS` defaulted to an empty list. As a result, `FEATURE` would be deferred but never added back to the features list, and `after!` blocks would never trigger for `FEATURE`.

Instead of defaulting to an empty list, fallback to a singleton list `(FEATURE)`. This aligns with the behavior the macro had prior to 5b8b04f0c8b6458a3ac4b41417c69413a3bae92e, which generalized `FNS` to support a list of functions rather than just one.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).