### PR TITLE
docs(mu4e): mention variable renamed in mu-1.8

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -159,8 +159,9 @@ mail by disabling this module's backend selection and setting the value of the
 #+end_src
 
 If your command prompts you for a passphrase, you might want to change the value
-of the ~mu4e~get-mail-password-regexp~ such that [[doom-package:][mu4e]] will recognize the prompt
-and let you provide the passphrase from within Emacs.
+of the ~mu4e~get-mail-password-regexp~ variable
+(~mu4e--get-mail-password-regexp~ if =mu= *>=1.8*) such that [[doom-package:][mu4e]] will recognize
+the prompt and let you provide the passphrase from within Emacs.
 
 ** mu and mu4e
 You should have your email downloaded already. If you have not, you need to set


### PR DESCRIPTION
The recent 1.8 release of mu renamed the mu4e~get-mail-password-regexp variable which is mentioned in the module docs. I updated the docs accordingly.

-----
- [ x ] I searched the issue tracker and this hasn't been PRed before.
- [ x ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ x ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ x ] Any relevant issues or PRs have been linked to.
