### PR TITLE
fix(file-templates): better recognize shell types

### DIFF
--- a/modules/editor/file-templates/templates/sh-mode/__
+++ b/modules/editor/file-templates/templates/sh-mode/__
@@ -1,3 +1,3 @@
-#!/usr/bin/env `(if (equal (file-name-extension buffer-file-name) "zsh") "zsh" "bash")`
+#!/usr/bin/env `(format "%s" sh-shell)`
 
 $0


### PR DESCRIPTION
There are some conventional files strongly associated with a non-bash
shell which do not use an explicit `.zsh` file extension (e.g.
`.zprofile`); the old logic would always use the `#!/usr/bin/env bash`
shebang in these cases, which is a tiny little bummer.

Some tests with the new template: 
| filename | `#!/usr/bin/env ???` |
|---|---|
| `~/.profile` | `sh` |
| `~/.zprofile | `zsh` |
| `~/.zshenv` | `zsh` |
| `~/.bash_login` | `bash` |
| `~/.bash_logout` | `bash` |

Explicit `.{,ba,z}sh` extensions get the corresponding `sh`, `bash`, and `zsh` extensions; `.fish` didn't get recognized as `sh-mode` on my installation, so they're not getting an auto-inserted shebang from either version of this snippet.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
References #0000
Replaces #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
