### PR TITLE
fix(csharp): add dep pkg for sln-mode

### DIFF
--- a/modules/lang/csharp/packages.el
+++ b/modules/lang/csharp/packages.el
@@ -4,6 +4,8 @@
 (package! csharp-mode :pin "856ecbc0a78ae3bdc2db2ae4d16be43e2d9d9c5e")
 (package! csproj-mode :pin "a7f0f4610c976a28c41b9b8299892f88b5d0336c")
 (package! sln-mode :pin "0f91d1b957c7d2a7bab9278ec57b54d57f1dbd9c")
+;; sln-mode depends on font-lock-ext
+(package! font-lock-ext :pin "b6c82e8ac7996d96494a54454015a98ceb883feb")
 (when (modulep! +unity)
   (package! shader-mode :pin "d7dc8d0d6fe8914e8b6d5cf2081ad61e6952359c"))
 (when (modulep! +dotnet)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I didn't see any relevant issues/PRs when searching a few things like `sln`, `csharp`, etc, but maybe I missed something

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions). I think. I really didn't read them that long.
- ~My changes are visual; I've included before and after screenshots.~
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
-  ~This a draft PR; I need more time to finish it.~

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->

-----------------------

While trying to use sln-mode via the csharp module, I noticed that it would not load because it was missing a dependency `font-lock-ext`. Examining the source of sln-mode, we see

```
(require 'font-lock-ext) ; https://github.com/sensorflo/font-lock-ext/
```
Now this is a trivial & tiny package (see for yourself), but as I don't want to rewrite any of the packages involved, the simplest fix for this is just to add this package to the module.

On a slightly separate note: I actually originally was trying to enable support for fsharp, not csharp. However, the fsharp module does not add support for .sln or .fsproj. However, the csharp module does add support for csproj-mode, which itself supports .fsproj (since both are just xml anyhow). I'm not sure how this sort of issue should be handled in general. Should we just add all the ancillary modes to fsharp as well? Should we create a `csharp-aux-tools` (or something) module which users of either the csharp or fsharp module would use as well? (Can modules depend on other modules?) Some 3rd option? I dunno, this should probably be a separate issue, but I thought I'd mention it.