### PR TITLE
fix(lib): doom-exec-process use doom-print--format

### DIFF
--- a/lisp/lib/process.el
+++ b/lisp/lib/process.el
@@ -31,7 +31,7 @@ Warning: freezes indefinitely on any stdin prompt."
             (set-process-filter
              process (lambda (_process output)
                        (princ output (current-buffer))
-                       (princ (doom--format output))))
+                       (princ (doom-print--format output))))
             (set-process-sentinel
              process (lambda (process _event)
                        (when (memq (process-status process) '(exit stop))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Update `doom-exec-process` to use `doom-print--format` instead of `doom--format`, which was removed in fe16de690418393c4b1dd79277f01a1c72b3be10add5a48022befe35b5f2e89c

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
