### PR TITLE
fix(lib): add cat to doom-system-distro-version

### DIFF
--- a/lisp/lib/system.el
+++ b/lisp/lib/system.el
@@ -27,7 +27,11 @@
 ;;;###autoload
 (defun doom-system-distro-version ()
   "Return a distro name and version string."
-  (letf! (defun sh (&rest args) (cdr (apply #'doom-call-process args)))
+  (letf! ((defun sh (&rest args) (cdr (apply #'doom-call-process args)))
+          (defun cat (file &optional limit)
+            (with-temp-buffer
+              (insert-file-contents file nil 0 limit)
+              (buffer-string))))
     (let ((distro (doom-system-distro)))
       (cond
        ((eq distro 'windows)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

One of the cond clauses in `doom-system-distro-version` calls a non-existent `cat` function. Referencing a similar pattern in the body of `doom-info`, I added a `(defun cat ...` to the `letf!` bindings in `doom-system-distro-version`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
