### PR TITLE
tweak: add support for symlinked config.org

### DIFF
--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -136,7 +136,11 @@ This is performed with an asyncronous Emacs process, except when
 
 We assume any org file in `doom-user-dir' is connected to your literate
 config, and should trigger a recompile if changed."
-  (and (file-in-directory-p
-        (buffer-file-name (buffer-base-buffer))
-        (file-name-directory +literate-config-file))
+  (and
+   (if (file-symlink-p +literate-config-file)
+       (string= (buffer-file-name (buffer-base-buffer))
+                (file-truename +literate-config-file))
+     (file-in-directory-p
+      (buffer-file-name (buffer-base-buffer))
+      (file-name-directory +literate-config-file)))
        (+literate-tangle-h)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

All my dotfiles are in git and are symlinked to $HOME. This causes doom to ignore my config.org (automatic tangling on save).
This change adds support for symlinked config.org.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
