### PR TITLE
Update init.example.el with (rust +lsp)

### DIFF
--- a/templates/init.example.el
+++ b/templates/init.example.el
@@ -164,7 +164,7 @@
        ;;rest              ; Emacs as a REST client
        ;;rst               ; ReST in peace
        ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
-       ;;rust              ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;;scala             ; java, but good
        ;;(scheme +guile)   ; a fully conniving family of lisps
        sh                ; she sells {ba,z,fi}sh shells on the C xor


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Today I had tried to setup clean Doom Emacs for rust and got debacle by racer compile errors:

> error: could not compile "racer" due to 3 previous errors
> warning: build failed, waiting for other jobs to finish...
> error: failed to compile "racer v2.2.2"

My software:

- Emacs 28.1
- Doom Core v3.0.0-dev
- Doom Modules v22.08.0-dev
- rustup 1.25.1
- racer v2.2.2 (which wont compiled)
- rust v1.63.0
- rust v1.65.0-nightly

After a quick review of [racer github page](https://github.com/racer-rust/racer), it became clear that racer is no more in active development and racer developers directly sending users to use rust-analyzer or another similar tools.

Summing up my experience with a fresh components which I provided above, it's time to use lsp for rust by default.

Fixes #0000
References #0000
Replaces #0001

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
