### PR TITLE
tweak(mu4e): set last-child thread symbol

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -103,10 +103,11 @@ is non-nil."
         ;; no need to ask
         mu4e-confirm-quit nil
         mu4e-headers-thread-single-orphan-prefix '("─>" . "─▶")
-        mu4e-headers-thread-orphan-prefix '("┬>" . "┬▶ ")
-        mu4e-headers-thread-last-child-prefix '("└>" . "╰▶")
-        mu4e-headers-thread-child-prefix '("├>" . "├▶")
-        mu4e-headers-thread-connection-prefix '("│" . "│ ")
+        mu4e-headers-thread-orphan-prefix        '("┬>" . "┬▶ ")
+        mu4e-headers-thread-connection-prefix    '("│ " . "│ ")
+        mu4e-headers-thread-first-child-prefix   '("├>" . "├▶")
+        mu4e-headers-thread-child-prefix         '("├>" . "├▶")
+        mu4e-headers-thread-last-child-prefix    '("└>" . "╰▶")
         ;; remove 'lists' column
         mu4e-headers-fields
         '((:account-stripe . 1)


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/20903656/185680956-9ac4117b-d99a-4411-b8c4-4c0f2c7c5b03.png)

**After**

![image](https://user-images.githubusercontent.com/20903656/185680832-50a69329-86da-46d3-9246-7153fb52ec72.png)

I also tweak the line order and whitespace while I'm at it, to show the
overall styling more clearly.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
