### PR TITLE
fix(magit): evil keybinds for magit-worktree

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -242,7 +242,7 @@ ensure it is built when we actually use Forge."
 
   ;; Some extra vim-isms I thought were missing from upstream
   (evil-define-key* '(normal visual) magit-mode-map
-    "%"  #'magit-gitflow-popup
+    "*"  #'magit-worktree
     "zt" #'evil-scroll-line-to-top
     "zz" #'evil-scroll-line-to-center
     "zb" #'evil-scroll-line-to-bottom
@@ -283,11 +283,10 @@ ensure it is built when we actually use Forge."
       "gk" #'git-rebase-move-line-up))
 
   (after! magit-gitflow
-    (transient-replace-suffix 'magit-dispatch 'magit-worktree
-      '("%" "Gitflow" magit-gitflow-popup)))
-
-  (transient-append-suffix 'magit-dispatch '(0 -1 -1)
-    '("*" "Worktree" magit-worktree)))
+    (evil-define-key* '(normal visual) magit-mode-map
+      "%" #'magit-gitflow-popup)
+    (transient-append-suffix 'magit-dispatch 'magit-worktree
+      '("%" "Gitflow" magit-gitflow-popup))))
 
 
 (use-package! evil-collection-magit-section


### PR DESCRIPTION
For some reason, the transient-append-suffix adding magit-worktree back
to magit-dispatch — after its potential replacement by
magit-gitflow-popup — was having no effect. (It does when moved into
(after! magit-gitflow), so the issue must have something to do with when
transient-append-suffix is called.) magit-worktree wasn't appearing in
the magit-dispatch popup when magit-gitflow was enabled, nor was the '*'
keybind for magit-worktree in effect outside (or inside) the popup,
unlike '%' for magit-gitflow-popup.

Replace the ineffectual transient-append-suffix with a normal and visual
mode keybind for magit-worktree in magit-mode-map (and move the
unconditionally defined keybind for magit-gitflow-popup into (after!
magit-gitflow)). Also, append the magit-gitflow-popup transient suffix
to magit-worktree instead of replacing it, so that the latter still
appears in magit-dispatch (though under the original keybind 'Z' — which
isn't really an issue, since evil-collection-magit doesn't seem to
update the keybinds of any of the other commands accessible from
magit-dispatch — but also callable with '*').