### PR TITLE
fix(magit): only install forge if asked

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -19,7 +19,7 @@ This module provides Magit, an interface to the Git version control system.
 ** Packages
 - [[doom-package:][evil-magit]] if [[doom-module:][:editor evil +everywhere]]
 - [[doom-package:][forge]] if [[doom-module:][+forge]]
-- [[doom-package:][code-review]]
+- [[doom-package:][code-review]] if [[doom-module:][+forge]]
 - [[doom-package:][magit]]
 - [[doom-package:][magit-gitflow]]
 - [[doom-package:][magit-todos]]

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -4,8 +4,8 @@
 (when (package! magit :pin "c1fb53d3de6390961ccd8dfb1cc135383508d0fc")
   (package! compat :pin "cc1924fd8b3f9b75b26bf93f084ea938c06f9615")
   (when (modulep! +forge)
-    (package! forge :pin "36208c43bf41782cfe81fccc904f8adbe57818e1"))
+    (package! forge :pin "36208c43bf41782cfe81fccc904f8adbe57818e1")
+    (package! code-review :pin "d38fbe59304ed31c759ce733cda16f69a8ef2d8c")
+      :recipe (:files ("graphql" "code-review*.el"))))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "67fd80c2f10aec4d5b2a24b5d3d53c08cc1f05dc")
-  (package! code-review :pin "d38fbe59304ed31c759ce733cda16f69a8ef2d8c"
-    :recipe (:files ("graphql" "code-review*.el"))))


### PR DESCRIPTION
the magit module has an error where a default module package (code review) has forge as a dependency, forge is only meant to be downloaded if one provides the `+forge` flag

now code review is locked behind `+forge` flag, this way the dependencies are in the correct order
<!-- ⚠️ Please do not ignore this template! -->
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
