### PR TITLE
Fix doom/version (canonicalize filenames in git calls)

### DIFF
--- a/lisp/lib/debug.el
+++ b/lisp/lib/debug.el
@@ -363,7 +363,7 @@ FILL-COLUMN determines the column at which lines will be broken."
                   "Doom core"
                   doom-version
                   (or (cdr (doom-call-process
-                            "git" "-C" doom-emacs-dir
+                            "git" "-C" (expand-file-name doom-emacs-dir)
                             "log" "-1" "--format=%D %h %ci"))
                       "n/a"))
           ;; NOTE This is a placeholder. Our modules will be moved to its own
@@ -373,7 +373,7 @@ FILL-COLUMN determines the column at which lines will be broken."
                   "Doom modules"
                   doom-modules-version
                   (or (cdr (doom-call-process
-                            "git" "-C" doom-modules-dir
+                            "git" "-C" (expand-file-name doom-modules-dir)
                             "log" "-1" "--format=%D %h %ci"))
                       "n/a"))))
 


### PR DESCRIPTION
If `doom-emacs-dir` contains a "~", calling `doom/version` will generate an error like:
```
fatal: cannot change to '~/.config/emacs/': No such file or directory
```
This is because `git` is invoked via `call-process`, so "~" is not expanded as it would be in a shell command.

Fix this by canonicalizing the filename.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
