### PR TITLE
feat(org): bind '<localleader> r R' to org-refile-reverse

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -990,7 +990,8 @@ between the two."
          "o" #'+org/refile-to-other-window
          "O" #'+org/refile-to-other-buffer
          "v" #'+org/refile-to-visible
-         "r" #'org-refile) ; to all `org-refile-targets'
+         "r" #'org-refile
+         "R" #'org-refile-reverse) ; to all `org-refile-targets'
         (:prefix ("s" . "tree/subtree")
          "a" #'org-toggle-archive-tag
          "b" #'org-tree-to-indirect-buffer


### PR DESCRIPTION
Adds `org-file-reverse` keybinding, which puts items at the top of the list

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

