### PR TITLE
docs(pdf): fix instructions to build epdfinfo

### DIFF
--- a/modules/tools/pdf/README.org
+++ b/modules/tools/pdf/README.org
@@ -37,11 +37,10 @@ for details and videos.
 * Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-This module requires =epdfinfo=, a program the the [[doom-package:][pdf-tools]] plugin will build
-automatically when you open your first pdf file, unless you're on Windows.
-Windows users must build it themselves.
-
-You can (re)build =epdfinfo= yourself with ~M-x pdf-tools-install~.
+This module requires the =epdfinfo= program. Unless you're on Windows, the
+[[doom-package:][pdf-tools]] plugin will (re)build this program for you, if you issue the ~M-x
+pdf-tools-install~ command. See the next section for instructions on how to
+build the =epdfinfo= program on Windows.
 
 ** Building =epdfinfo= on Windows
 1. [[https://www.msys2.org/][Install MSYS2]] and update the package database and core packages using the


### PR DESCRIPTION
The documentation claimed that epdinfo will be built as soon as a pdf
file is opened. However, support for automatically building epdfinfo was
removed in the commit referenced below.

Ref: daa50557a4f2

- [ x ] I searched the issue tracker and this hasn't been PRed before.
- [ x ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ x ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ x ] Any relevant issues or PRs have been linked to.