### PR TITLE
Adds org-insert-heading-hook to +org--insert-item

### DIFF
--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -90,6 +90,7 @@
             (org-back-to-heading)
             (insert (make-string level ?*) " ")
             (save-excursion (insert "\n"))))
+         (run-hooks 'org-insert-heading-hook)
          (when-let* ((todo-keyword (org-element-property :todo-keyword context))
                      (todo-type    (org-element-property :todo-type context)))
            (org-todo


### PR DESCRIPTION
Doom replaces [org-insert-heading](https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org.el#n6187) with `+org--insert-item` and leaves no equivalent for [org-insert-heading-hook](https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org.el#n1615).

As discussed on [discord](https://discord.com/channels/406534637242810369/695219268358504458/1012348488085946418) the proposed change adds this hook again, enabling convenient features such as adding a time stamp after inserting a new heading:
```elisp
  (defun my/org-set-creation-date-heading-property ()
    (save-excursion
      (org-back-to-heading)
      (org-set-property "CREATED" (format-time-string "[%Y-%m-%d %T]"))))
  (add-hook 'org-insert-heading-hook #'my/org-set-creation-date-heading-property)
```

<!-- ⚠️ Please do not ignore this template! -->

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
