### PR TITLE
refactor(lib): remove unreachable code in doom-print-class-alist

### DIFF
--- a/lisp/lib/print.el
+++ b/lisp/lib/print.el
@@ -58,9 +58,6 @@ and `format!' into colored output, where COLOR is any car of this list.")
     (rtrim   . string-trim-right)
     (ltrim   . string-trim-left)
     (p       . doom-print--paragraph)
-    (buffer  . (lambda (buffer)
-                 (with-current-buffer buffer
-                   (buffer-string))))
     (truncate . doom-print--truncate)
     (success . (lambda (str &rest args)
                  (apply #'doom-print--style 'green


### PR DESCRIPTION
Remove an unreachable `buffer` element from `doom-print-class-alist`. An earlier element in this alist associates buffer with `doom-print--buffer`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).