### PR TITLE
nit: remove unused base-specs arg in doom--make-font-specs

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -529,7 +529,7 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
       (cons 'custom-theme-directory
             (delq 'custom-theme-directory custom-theme-load-path)))
 
-(defun doom--make-font-specs (face font &optional base-specs)
+(defun doom--make-font-specs (face font)
   (let* ((base-specs (cadr (assq 'user (get face 'theme-face))))
          (base-specs (or base-specs '((t nil))))
          (attrs '(:family :foundry :slant :weight :height :width))


### PR DESCRIPTION
In `doom--make-font-specs`, the `base-specs` argument is not specified by any callers, but if it were, it would be ignored, since the body of the function binds a value, overriding any value the caller specified.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).