### PR TITLE
feat(emacs-lisp): recognize ";;* ..." headlines

### DIFF
--- a/modules/editor/lispy/autoload.el
+++ b/modules/editor/lispy/autoload.el
@@ -1,0 +1,7 @@
+;;; editor/lispy/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +lispy-restore-elisp-outline-settings ()
+  (when (derived-mode-p 'emacs-lisp-mode)
+    (setq-local outline-regexp +emacs-lisp-outline-regexp
+                outline-level #'+emacs-lisp-outline-level)))

--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -22,7 +22,10 @@
       (local-set-key (vector 'remap (lookup-key lispy-mode-map (kbd "TAB"))) #'completion-at-point)))
   :config
   (setq lispy-close-quotes-at-end-p t)
-  (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode))
+  (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode)
+
+  (when (modulep! :lang emacs-lisp)
+    (add-hook 'lispy-mode-hook #'+lispy-restore-elisp-outline-settings)))
 
 
 (use-package! lispyville

--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -24,11 +24,6 @@
   (setq lispy-close-quotes-at-end-p t)
   (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode)
 
-  ;; We recommend `outline-minor-faces-mode' from
-  ;; https://github.com/tarsius/outline-minor-faces as an alternative which
-  ;; respects `outline-regexp' and `outline-level'.
-  (setq lispy-font-lock-keywords nil)
-
   (when (modulep! :lang emacs-lisp)
     (add-hook 'lispy-mode-hook #'+lispy-restore-elisp-outline-settings)))
 

--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -24,6 +24,11 @@
   (setq lispy-close-quotes-at-end-p t)
   (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode)
 
+  ;; We recommend `outline-minor-faces-mode' from
+  ;; https://github.com/tarsius/outline-minor-faces as an alternative which
+  ;; respects `outline-regexp' and `outline-level'.
+  (setq lispy-font-lock-keywords nil)
+
   (when (modulep! :lang emacs-lisp)
     (add-hook 'lispy-mode-hook #'+lispy-restore-elisp-outline-settings)))
 

--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -228,7 +228,7 @@ https://emacs.stackexchange.com/questions/10230/how-to-indent-keywords-aligned"
 (defun +emacs-lisp-extend-imenu-h ()
   "Improve imenu support in `emacs-lisp-mode', including recognition for Doom's API."
   (setq imenu-generic-expression
-        `(("Section" "^[ \t]*;;;;*[ \t]+\\([^\n]+\\)" 1)
+        `(("Section" "^[ \t]*;;[;*]+[ \t]+\\([^\n]+\\)" 1)
           ("Evil commands" "^\\s-*(evil-define-\\(?:command\\|operator\\|motion\\) +\\(\\_<[^ ()\n]+\\_>\\)" 1)
           ("Unit tests" "^\\s-*(\\(?:ert-deftest\\|describe\\) +\"\\([^\")]+\\)\"" 1)
           ("Package" "^\\s-*\\(?:;;;###package\\|(\\(?:package!\\|use-package!?\\|after!\\)\\) +\\(\\_<[^ ()\n]+\\_>\\)" 1)

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -61,7 +61,7 @@ employed so that flycheck still does *some* helpful linting.")
     ;; Don't treat autoloads or sexp openers as outline headers, we have
     ;; hideshow for that.
     outline-regexp +emacs-lisp-outline-regexp
-    ;; As we are changing `outline-regexp', we also set a few `outline-level'
+    ;; As we are changing `outline-regexp', we also set a new `outline-level'
     ;; function for that.
     outline-level #'+emacs-lisp-outline-level
     ;; Fixed indenter that intends plists sensibly.

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -61,8 +61,6 @@ employed so that flycheck still does *some* helpful linting.")
     ;; Don't treat autoloads or sexp openers as outline headers, we have
     ;; hideshow for that.
     outline-regexp +emacs-lisp-outline-regexp
-    ;; As we are changing `outline-regexp', we also set a new `outline-level'
-    ;; function for that.
     outline-level #'+emacs-lisp-outline-level
     ;; Fixed indenter that intends plists sensibly.
     lisp-indent-function #'+emacs-lisp-indent-function)

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -3,9 +3,13 @@
 (defvar +emacs-lisp-enable-extra-fontification t
   "If non-nil, highlight special forms, and defined functions and variables.")
 
-(defvar +emacs-lisp-outline-regexp "[ \t]*;;;;* [^ \t\n]"
+(defvar +emacs-lisp-outline-regexp "[ \t]*;;\\([;*]+\\) [^ \t\n]"
   "Regexp to use for `outline-regexp' in `emacs-lisp-mode'.
 This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
+
+(defvar +emacs-lisp-outline-level-function
+  (defun +emacs-lisp-outline-level () (- (match-end 1) (match-beginning 1)))
+  "See the documentation of `outline-level'.")
 
 (defvar +emacs-lisp-disable-flycheck-in-dirs
   (list doom-emacs-dir doom-user-dir)
@@ -57,6 +61,9 @@ employed so that flycheck still does *some* helpful linting.")
     ;; Don't treat autoloads or sexp openers as outline headers, we have
     ;; hideshow for that.
     outline-regexp +emacs-lisp-outline-regexp
+    ;; As we are changing `outline-regexp', we also set a few `outline-level'
+    ;; function for that.
+    outline-level #'+emacs-lisp-outline-level
     ;; Fixed indenter that intends plists sensibly.
     lisp-indent-function #'+emacs-lisp-indent-function)
 


### PR DESCRIPTION
Here we patch `:lang emacs-lisp` so that `;;* ...` headings are recognized by Imenu and Outline's functions. We also patch `:editor lispy` so that Lispy does not override these settings and does not introduce its own font-lock keywords for Outline headings.
