### PR TITLE
fix: error caused by typo in doom--recentf-file-truename-fn

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -307,7 +307,7 @@ tell you about it. Very annoying. This prevents that."
   (defun doom--recentf-file-truename-fn (file)
     (if (or (not (file-remote-p file))
             (equal "sudo" (file-remote-p file 'method)))
-        (abbreviate-file-name (file-truename (tramp-file-name-localname tfile)))
+        (abbreviate-file-name (file-truename (tramp-file-name-localname file)))
       file))
 
   ;; Anything in runtime folders


### PR DESCRIPTION
Fix a typo that resulted in a void-variable error.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).