### PR TITLE
DWIM for most app-switching commands (=mu4e, =elfeed, =calendar)

### DIFF
--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -1,6 +1,8 @@
 ;;; app/calendar/autoload.el -*- lexical-binding: t; -*-
 
 (defvar +calendar--wconf nil)
+(defvar +calendar-workspace-name "*calendar*"
+  "Name of the workspace created by `=calendar', dedicated to the calendar.")
 
 (defun +calendar--init ()
   (if-let (win (cl-find-if (lambda (b) (string-match-p "^\\*cfw:" (buffer-name b)))
@@ -15,7 +17,7 @@
   (interactive)
   (if (modulep! :ui workspaces)
       (progn
-        (+workspace-switch "Calendar" t)
+        (+workspace-switch +calendar-workspace-name t)
         (doom/switch-to-scratch-buffer)
         (+calendar--init)
         (+workspace/display))
@@ -29,8 +31,8 @@
   "TODO"
   (interactive)
   (if (modulep! :ui workspaces)
-      (when (+workspace-exists-p "Calendar")
-        (+workspace/delete "Calendar"))
+      (when (+workspace-exists-p +calendar-workspace-name)
+        (+workspace/delete +calendar-workspace-name))
     (when (window-configuration-p +calendar--wconf)
       (set-window-configuration +calendar--wconf))
     (setq +calendar--wconf nil))

--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -2,7 +2,7 @@
 
 (defvar +calendar--wconf nil)
 (defvar +calendar-workspace-name "*calendar*"
-  "Name of the workspace created by `=calendar', dedicated to the calendar.")
+  "Name of the workspace created by `=calendar', dedicated to calfw.")
 
 (defun +calendar--init ()
   (if-let (win (cl-find-if (lambda (b) (string-match-p "^\\*cfw:" (buffer-name b)))

--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -18,8 +18,12 @@
   (if (modulep! :ui workspaces)
       (progn
         (+workspace-switch +calendar-workspace-name t)
-        (doom/switch-to-scratch-buffer)
-        (+calendar--init)
+        (unless (memq (buffer-local-value 'major-mode
+                                          (window-buffer (selected-window)))
+                      '(cfw:details-mode
+                        cfw:calendar-mode))
+          (doom/switch-to-scratch-buffer)
+          (+calendar--init))
         (+workspace/display))
     (setq +calendar--wconf (current-window-configuration))
     (delete-other-windows)

--- a/modules/app/irc/autoload/irc.el
+++ b/modules/app/irc/autoload/irc.el
@@ -13,8 +13,7 @@
           (require 'circe)
           (delete-other-windows)
           (switch-to-buffer (doom-fallback-buffer))
-          t)
-      (user-error "IRC buffer is already active and selected"))))
+          t))))
 
 ;;;###autoload
 (defun =irc (&optional inhibit-workspace)

--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -9,8 +9,13 @@
   (if (modulep! :ui workspaces)
       (progn
         (+workspace-switch +rss-workspace-name t)
-        (doom/switch-to-scratch-buffer)
-        (elfeed)
+        (unless (memq (buffer-local-value 'major-mode
+                                          (window-buffer
+                                           (selected-window)))
+                      '(elfeed-show-mode
+                        elfeed-search-mode))
+          (doom/switch-to-scratch-buffer)
+          (elfeed))
         (+workspace/display))
     (setq +rss--wconf (current-window-configuration))
     (delete-other-windows)

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -67,7 +67,14 @@ default/fallback account."
     (setq +mu4e--old-wconf (current-window-configuration))
     (delete-other-windows)
     (switch-to-buffer (doom-fallback-buffer)))
-  (mu4e)
+  (unless (memq (buffer-local-value 'major-mode
+                                    (window-buffer (selected-window)))
+                '(mu4e-main-mode
+                  mu4e-headers-mode
+                  mu4e-view-mode
+                  mu4e-compose-mode
+                  org-msg-edit-mode))
+    (mu4e))
   ;; (save-selected-window
   ;;   (prolusion-mail-show))
   )

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -32,7 +32,7 @@
   ;; (+popup/close (get-buffer-window "*notmuch-hello*"))
   (doom-kill-matching-buffers "^\\*notmuch")
   (when (modulep! :ui workspaces)
-    (+workspace/delete "*MAIL*")))
+    (+workspace/delete +notmuch-workspace-name)))
 
 (defun +notmuch-get-sync-command ()
   "Return a shell command string to synchronize your notmuch mail with."

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -1,5 +1,8 @@
 ;;; email/notmuch/autoload.el -*- lexical-binding: t; -*-
 
+(defvar +notmuch-workspace-name "*notmuch*"
+  "Name of the workspace created by `=notmuch', dedicated to notmuch.")
+
 ;;;###autoload
 (defun =notmuch ()
   "Activate (or switch to) `notmuch' in its workspace."
@@ -7,7 +10,7 @@
   (condition-case-unless-debug e
       (progn
         (when (modulep! :ui workspaces)
-          (+workspace-switch "*MAIL*" t))
+          (+workspace-switch +notmuch-workspace-name t))
         (if-let* ((win (cl-find-if (lambda (it) (string-match-p "^\\*notmuch" (buffer-name (window-buffer it))))
                                    (doom-visible-windows))))
             (select-window win)


### PR DESCRIPTION
In the #emacs-lisp channel of the Doom Emacs Discord, we were discussing how the current behavior of `=mu4e` can be annoying because if a user is already reading an email, leaves the `*mu4e*` workspace, and switches back with `=mu4e`, the Mu4e main buffer is opened again in the active window, forcing the user to manually `switch-to-previous-buffer`. I have implemented an improvement upon this behavior for various modules so that if we call `=mu4e`, `=rss`, etc., and that workspace is already in Mu4e/Elfeed, etc., we do not call `(mu4e)`, `(elfeed)`, etc. again (respectively).

While reviewing these various app modules, I have found some behaviors that seemed odd to me such as `=irc` emitting an error if the workspace is already in an IRC node or `=notmuch` using the workspace name `*notmuch*` and have patched these too.