### PR TITLE
Use Isearch for Evil in Info-mode

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -73,7 +73,9 @@
       (:after helpful :map helpful-mode-map
        :n "o"       #'link-hint-open-link)
       (:after info :map Info-mode-map
-       :n "o"       #'link-hint-open-link)
+       :n "o"       #'link-hint-open-link
+       :nv "/" #'isearch-forward
+       :nv "?" #'isearch-backward)
       (:after apropos :map apropos-mode-map
        :n "o"       #'link-hint-open-link
        :n "TAB"     #'forward-button

--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -572,6 +572,20 @@ This be hooked to `projectile-after-switch-project-hook'."
         (run-hooks 'projectile-after-switch-project-hook)
         (setq +workspaces--project-dir nil)))))
 
+;;;###autoload
+(defun +workspaces-save-tab-bar-data-h (_)
+  "Save the current workspace's tab bar data."
+  (when (get-current-persp)
+    (set-persp-parameter
+     'tab-bar-tabs (tab-bar-tabs))
+    (set-persp-parameter 'tab-bar-closed-tabs tab-bar-closed-tabs)))
+
+;;;###autoload
+(defun +workspaces-load-tab-bar-data-h (_)
+  "Restores the tab bar data of the workspace we have just switched to."
+  (tab-bar-tabs-set (persp-parameter 'tab-bar-tabs))
+  (setq tab-bar-closed-tabs (persp-parameter 'tab-bar-closed-tabs))
+  (tab-bar--update-tab-bar-lines t))
 
 ;;
 ;;; Advice

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -276,4 +276,10 @@ stored in `persp-save-dir'.")
               (when (get-buffer buffer-name)
                 (setq buffer-name (generate-new-buffer-name buffer-name)))
               (make-indirect-buffer base-buffer buffer-name t)))))
-      (setq +workspaces--indirect-buffers-to-restore nil))))
+      (setq +workspaces--indirect-buffers-to-restore nil)))
+
+;;; tab-bar
+  (add-hook! 'tab-bar-mode-hook
+    (defun +workspaces-set-up-tab-bar-integration-h ()
+      (add-hook 'persp-before-deactivate-functions #'+workspaces-save-tab-bar-data-h)
+      (add-hook 'persp-activated-functions #'+workspaces-load-tab-bar-data-h))))


### PR DESCRIPTION
In Info-mode, Isearch is superior to Evil's search facilities because Isearch
searches across the entire manual rather than just the current buffer.