### PR TITLE
feat(config): use isearch in Info-mode for evil

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -73,7 +73,9 @@
       (:after helpful :map helpful-mode-map
        :n "o"       #'link-hint-open-link)
       (:after info :map Info-mode-map
-       :n "o"       #'link-hint-open-link)
+       :n "o"       #'link-hint-open-link
+       :nv "/" #'isearch-forward
+       :nv "?" #'isearch-backward)
       (:after apropos :map apropos-mode-map
        :n "o"       #'link-hint-open-link
        :n "TAB"     #'forward-button

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -74,8 +74,8 @@
        :n "o"       #'link-hint-open-link)
       (:after info :map Info-mode-map
        :n "o"       #'link-hint-open-link
-       :nv "/" #'isearch-forward
-       :nv "?" #'isearch-backward)
+       :nv "/"      #'isearch-forward
+       :nv "?"      #'isearch-backward)
       (:after apropos :map apropos-mode-map
        :n "o"       #'link-hint-open-link
        :n "TAB"     #'forward-button


### PR DESCRIPTION
In Info-mode, Isearch is superior to Evil's search facilities because
Isearch searches across the entire manual rather than just the current buffer.