### PR TITLE
fix(layout): Bépo rotation happening before magit

### DIFF
--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -210,13 +210,52 @@ In all cases, 'h' functions go to 'c' and 'l' ones go to 'r' so the navigation k
     (map! :map Info-mode-map
           "s" nil
           "t" nil))
-  (after! (evil magit)
+
+  
+  ;; Start of the Magit zone
+  ;;
+  ;; The magit zone needs to be special because evil-collection and magit and
+  ;; this module don't fully agree on the order with which features, keymaps,
+  ;; overriding keymaps, and evil-collection-setup-hook are run.
+  ;;
+  ;; This is _probably_ more complex than what it needs to be, but the
+  ;; interactions between all packages are so hard to track that a
+  ;; trial-and-error approach has been used to arrive at this result.
+  (after! (evil magit-section)
     (+layout-bepo-rotate-ts-bare-keymap
-     '(magit-mode-map
-       magit-diff-section-base-map
+     '(magit-section-mode-map)))
+  (after! (evil magit-log)
+    (+layout-bepo-rotate-keymaps
+     '(magit-log-read-revs-map
+       magit-log-mode-map
+       ;; NOTE: magit-cherry-mode could be moved of magit-log anyday, be
+       ;; careful
+       magit-cherry-mode-map)))
+  (after! (evil magit-reflog)
+    (+layout-bepo-rotate-keymaps
+     '(magit-reflog-mode-map)))
+  (after! (evil magit-status)
+    (+layout-bepo-rotate-keymaps
+     '(magit-status-mode-map
        magit-staged-section-map
        magit-unstaged-section-map
-       magit-untracked-section-map))
+       magit-untracked-section-map)))
+  (after! (evil magit-diff)
+    (+layout-bepo-rotate-keymaps
+     '(magit-diff-mode-map
+       magit-diff-section-base-map)))
+  (after! (evil magit-process)
+    (+layout-bepo-rotate-keymaps
+     '(magit-process-mode-map)))
+  (after! (evil magit-refs)
+    (+layout-bepo-rotate-keymaps
+     '(magit-refs-mode-map)))
+  (after! (evil magit-blob)
+    (+layout-bepo-rotate-keymaps
+     '(magit-blob-mode-map)))
+  (after! (evil magit)
+    (+layout-bepo-rotate-ts-bare-keymap
+     '(magit-mode-map))
     ;; Without this, "s" is mapped to `magit-delete-thing' (the old "k" for "kill") and
     ;; takes precedence over the evil command to go up one line
     ;; :nv doesn't work on this, needs to be the bare map.
@@ -234,24 +273,11 @@ In all cases, 'h' functions go to 'c' and 'l' ones go to 'r' so the navigation k
     (map! :map magit-mode-map
           "s" nil
           "t" nil)
-    ;; Even though magit bindings are part of evil-collection now, the hook only
-    ;; runs on `evil-collection-magit-maps', which is way to short to cover all
-    ;; usages. The hook is run manually on other maps
-    ;; NOTE `magit-mode-map' is last because other keymaps inherit from it.
-    ;;      Therefore to prevent a "double rotation" issue, `magit-mode-map' is
-    ;;      changed last.
     (+layout-bepo-rotate-keymaps
-     '(magit-cherry-mode-map
-       magit-blob-mode-map
-       magit-diff-mode-map
-       magit-log-mode-map
-       magit-log-select-mode-map
-       magit-reflog-mode-map
-       magit-status-mode-map
-       magit-log-read-revs-map
-       magit-process-mode-map
-       magit-refs-mode-map
-       magit-mode-map)))
+     '(magit-mode-map)))
+  ;; End of the Magit zone
+  
+
   (after! evil-easymotion
     ;; Use "gé" instead of default "gs" to avoid conflicts w/org-mode later
     (evilem-default-keybindings "gé")

--- a/modules/input/layout/autoload/bepo.el
+++ b/modules/input/layout/autoload/bepo.el
@@ -167,6 +167,8 @@ See `+layout-bepo-cr-rotation-style' for the meaning of CR-STYLE."
       "É" "W"
       "w" (kbd "C-w"))))
 
+;; TODO: Use a macro to DRY +layout-bepo-rotate-{keymaps,minor-modes}
+
 ;;;###autoload
 (defun +layout-bepo-rotate-keymaps (keymaps &optional cr-style)
   "Remap evil-collection keybinds in KEYMAPS for Bépo keyboard keyboard layouts.
@@ -210,7 +212,8 @@ Remappings are done according to CR-STYLE (see
       (kbd "M-j") (kbd "M-t")
       (kbd "M-J") (kbd "M-T")
       (kbd "M-k") (kbd "M-s")
-      (kbd "M-K") (kbd "M-S"))
+      (kbd "M-K") (kbd "M-S")
+      :destructive nil)
     (if (eq cr-style 'ergodis)
         (evil-collection-translate-key '(normal motion visual operator) keymaps
           "h" "r"
@@ -224,7 +227,8 @@ Remappings are done according to CR-STYLE (see
           (kbd "M-h") (kbd "M-r")
           (kbd "M-H") (kbd "M-R")
           (kbd "M-l") (kbd "M-c")
-          (kbd "M-L") (kbd "M-C"))
+          (kbd "M-L") (kbd "M-C")
+          :destructive nil)
       (evil-collection-translate-key '(normal motion visual operator) keymaps
         "h" "c"
         "H" "C"
@@ -237,7 +241,8 @@ Remappings are done according to CR-STYLE (see
         (kbd "M-h") (kbd "M-c")
         (kbd "M-H") (kbd "M-C")
         (kbd "M-l") (kbd "M-r")
-        (kbd "M-L") (kbd "M-R")))
+        (kbd "M-L") (kbd "M-R")
+        :destructive nil))
 
     (evil-collection-translate-key '(insert) keymaps
       (kbd "M-c") (kbd "M-h")
@@ -251,32 +256,161 @@ Remappings are done according to CR-STYLE (see
       (kbd "M-j") (kbd "M-t")
       (kbd "M-J") (kbd "M-T")
       (kbd "M-k") (kbd "M-s")
-      (kbd "M-K") (kbd "M-S"))
+      (kbd "M-K") (kbd "M-S")
+      :destructive nil)
     (if (eq cr-style 'ergodis)
         (evil-collection-translate-key '(insert) keymaps
           (kbd "M-h") (kbd "M-r")
           (kbd "M-H") (kbd "M-R")
           (kbd "M-l") (kbd "M-c")
-          (kbd "M-L") (kbd "M-C"))
+          (kbd "M-L") (kbd "M-C")
+          :destructive nil)
       (evil-collection-translate-key '(insert) keymaps
         (kbd "M-h") (kbd "M-c")
         (kbd "M-H") (kbd "M-C")
         (kbd "M-l") (kbd "M-r")
-        (kbd "M-L") (kbd "M-R")))
+        (kbd "M-L") (kbd "M-R")
+        :destructive nil))
 
     ;; <> en direct
     (evil-collection-translate-key '(normal motion visual operator) keymaps
       "«" "<"
-      "»" ">")
+      "»" ">"
+      :destructive nil)
 
     ;; è pour aller au début de ligne
     (evil-collection-translate-key '(normal motion visual operator) keymaps
       "è" "^"
-      "È" "0")
+      "È" "0"
+      :destructive nil)
 
     ;; [W] -> [É]
     ;; [C-W] -> [W]
     (evil-collection-translate-key '(normal motion operator visual) keymaps
       "é" "w"
       "É" "W"
-      "w" (kbd "C-w"))))
+      "w" (kbd "C-w")
+      :destructive nil)))
+
+;;;###autoload
+(defun +layout-bepo-rotate-minor-modes (modes &optional cr-style)
+  "Remap evil-collection keybinds in MODES for Bépo keyboard keyboard layouts.
+
+Remappings are done according to CR-STYLE (see
+`+layout-bepo-cr-rotation-style')."
+  (let ((cr-style (or cr-style +layout-bepo-cr-rotation-style)))
+    (evil-collection-translate-minor-mode-key '(normal motion visual operator) modes
+      "c" "h"
+      "C" "H"
+      "t" "j"
+      "T" "J"
+      "s" "k"
+      "S" "K"
+      "r" "l"
+      "R" "L"
+      "j" "t"
+      "J" "T"
+      "k" "s"
+      "K" "S"
+      (kbd "C-c") (kbd "C-h")
+      (kbd "C-C") (kbd "C-H")
+      (kbd "C-t") (kbd "C-j")
+      (kbd "C-T") (kbd "C-J")
+      (kbd "C-s") (kbd "C-k")
+      (kbd "C-S") (kbd "C-K")
+      (kbd "C-r") (kbd "C-l")
+      (kbd "C-R") (kbd "C-L")
+      (kbd "C-j") (kbd "C-t")
+      (kbd "C-J") (kbd "C-T")
+      (kbd "C-k") (kbd "C-s")
+      (kbd "C-K") (kbd "C-S")
+      (kbd "M-c") (kbd "M-h")
+      (kbd "M-C") (kbd "M-H")
+      (kbd "M-t") (kbd "M-j")
+      (kbd "M-T") (kbd "M-J")
+      (kbd "M-s") (kbd "M-k")
+      (kbd "M-S") (kbd "M-K")
+      (kbd "M-r") (kbd "M-l")
+      (kbd "M-R") (kbd "M-L")
+      (kbd "M-j") (kbd "M-t")
+      (kbd "M-J") (kbd "M-T")
+      (kbd "M-k") (kbd "M-s")
+      (kbd "M-K") (kbd "M-S")
+      :destructive nil)
+    (if (eq cr-style 'ergodis)
+        (evil-collection-translate-minor-mode-key '(normal motion visual operator) modes
+          "h" "r"
+          "H" "R"
+          "l" "c"
+          "L" "C"
+          (kbd "C-h") (kbd "C-r")
+          (kbd "C-H") (kbd "C-R")
+          (kbd "C-l") (kbd "C-c")
+          (kbd "C-L") (kbd "C-C")
+          (kbd "M-h") (kbd "M-r")
+          (kbd "M-H") (kbd "M-R")
+          (kbd "M-l") (kbd "M-c")
+          (kbd "M-L") (kbd "M-C")
+          :destructive nil)
+      (evil-collection-translate-minor-mode-key '(normal motion visual operator) modes
+        "h" "c"
+        "H" "C"
+        "l" "r"
+        "L" "R"
+        (kbd "C-h") (kbd "C-c")
+        (kbd "C-H") (kbd "C-C")
+        (kbd "C-l") (kbd "C-r")
+        (kbd "C-L") (kbd "C-R")
+        (kbd "M-h") (kbd "M-c")
+        (kbd "M-H") (kbd "M-C")
+        (kbd "M-l") (kbd "M-r")
+        (kbd "M-L") (kbd "M-R")
+        :destructive nil))
+
+    (evil-collection-translate-minor-mode-key '(insert) modes
+      (kbd "M-c") (kbd "M-h")
+      (kbd "M-C") (kbd "M-H")
+      (kbd "M-t") (kbd "M-j")
+      (kbd "M-T") (kbd "M-J")
+      (kbd "M-s") (kbd "M-k")
+      (kbd "M-S") (kbd "M-K")
+      (kbd "M-r") (kbd "M-l")
+      (kbd "M-R") (kbd "M-L")
+      (kbd "M-j") (kbd "M-t")
+      (kbd "M-J") (kbd "M-T")
+      (kbd "M-k") (kbd "M-s")
+      (kbd "M-K") (kbd "M-S")
+      :destructive nil)
+    (if (eq cr-style 'ergodis)
+        (evil-collection-translate-minor-mode-key '(insert) modes
+          (kbd "M-h") (kbd "M-r")
+          (kbd "M-H") (kbd "M-R")
+          (kbd "M-l") (kbd "M-c")
+          (kbd "M-L") (kbd "M-C")
+          :destructive nil)
+      (evil-collection-translate-minor-mode-key '(insert) modes
+        (kbd "M-h") (kbd "M-c")
+        (kbd "M-H") (kbd "M-C")
+        (kbd "M-l") (kbd "M-r")
+        (kbd "M-L") (kbd "M-R")
+        :destructive nil))
+
+    ;; <> en direct
+    (evil-collection-translate-minor-mode-key '(normal motion visual operator) modes
+      "«" "<"
+      "»" ">"
+      :destructive nil)
+
+    ;; è pour aller au début de ligne
+    (evil-collection-translate-minor-mode-key '(normal motion visual operator) modes
+      "è" "^"
+      "È" "0"
+      :destructive nil)
+
+    ;; [W] -> [É]
+    ;; [C-W] -> [W]
+    (evil-collection-translate-minor-mode-key '(normal motion operator visual) modes
+      "é" "w"
+      "É" "W"
+      "w" (kbd "C-w")
+      :destructive nil)))


### PR DESCRIPTION
Fixes an issue where binding rotations in Bépo were happening too soon,
resulting in some remaps not being visible to the user when interacting
with magit, :editor evil +everywhere, and :input layout +bepo

Ref: https://discourse.doomemacs.org/t/layout-bepo-does-not-properly-remap-k-in-magit/3063