### PR TITLE
module: add :tools collab

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -505,6 +505,30 @@
        :desc "Unicode"                       "u"   #'insert-char
        :desc "From clipboard"                "y"   #'+default/yank-pop)
 
+      ;;; <leader> l --- live share/collab
+      ;;; TODO Do you like this location for this map? This was the best idea we
+      ;;; could come up with, but we're happy to move it if there's a better
+      ;;; place! Also not sure if we're allowed to say "live share" since that's
+      ;;; a blatant ripoff of VS Code's name for this feature
+      (:when (modulep! :tools collab)
+       (:prefix-map ("l" . "live share/collab")
+        :desc "Switch to a shared buffer"      "b"   #'crdt-switch-to-buffer
+        :desc "Connect to a session"           "c"   #'crdt-connect
+        :desc "Disconnect from session"        "d"   #'crdt-disconnect
+        :desc "Toggle following user's cursor" "f"   #'crdt-follow-user
+        :desc "Stop following user if any"     "F"   #'crdt-stop-follow
+        :desc "Goto another user's cursor"     "g"   #'crdt-goto-user
+        :desc "List shared buffers"            "i"   #'crdt-list-buffers
+        :desc "Kick a user (host only)"        "k"   #'crdt-kill-user
+        :desc "List sessions"                  "l"   #'crdt-list-sessions
+        :desc "Share current buffer"           "s"   #'crdt-share-buffer
+        :desc "Stop sharing current buffer"    "S"   #'crdt-stop-share-buffer
+        :desc "List connected users"           "u"   #'crdt-list-users
+        :desc "Stop a session (host only)"     "x"   #'crdt-stop-session
+        :desc "Copy URL of current session"    "y"   #'crdt-copy-url
+        :desc "Goto next user's cursor"        "]"   #'crdt-goto-next-user
+        :desc "Goto previous user's cursor"    "["   #'crdt-goto-prev-user))
+
       ;;; <leader> n --- notes
       (:prefix-map ("n" . "notes")
        :desc "Search notes for symbol"      "*" #'+default/search-notes-for-symbol-at-point

--- a/modules/tools/collab/README.org
+++ b/modules/tools/collab/README.org
@@ -107,12 +107,12 @@ When this module is enabled, the `SPC l` leader keymap becomes available, making
 This list is not exhaustive; for the full list of config options, type =SPC h V
 crdt-= after loading the module.
 
-| Custom variable             | Default            | Function                                                                                  |
-|-----------------------------+--------------------+-------------------------------------------------------------------------------------------|
-| crdt-ask-for-name           | t                  | Set to nil to always use =crdt-default-name= as your name without asking                  |
-| crdt-default-name           | ~(user-full-name)~ | Your display name in collaboration sessions                                               |
-| crdt-tuntox-executable      | "tuntox"           | Path to the tuntox binary                                                                 |
-| crdt-tuntox-password-in-url | nil                | Set to t to put your session password (in plaintext) into the URL made by =crdt-copy-url= |
+| Custom variable             | Default                  | Function                                                                                  |
+|-----------------------------+--------------------------+-------------------------------------------------------------------------------------------|
+| crdt-ask-for-name           | t                        | Set to nil to always use =crdt-default-name= as your name without asking                  |
+| crdt-default-name           | ~(user-full-name)~       | Your display name in collaboration sessions                                               |
+| crdt-tuntox-executable      | "tuntox"                 | Path to the tuntox binary                                                                 |
+| crdt-tuntox-password-in-url | t if =+tunnel=, else nil | Set to t to put your session password (in plaintext) into the URL made by =crdt-copy-url= |
 
 
 * Troubleshooting

--- a/modules/tools/collab/README.org
+++ b/modules/tools/collab/README.org
@@ -1,0 +1,138 @@
+#+TITLE:   tools/collab
+#+DATE:    September 2, 2022
+#+SINCE:   v3.0.0
+#+STARTUP: inlineimage nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+  - [[#with-tunnel][With =+tunnel=]]
+    - [[#macos][macOS]]
+    - [[#linux][Linux]]
+    - [[#windows][Windows]]
+- [[#features][Features]]
+  - [[#keybindings][Keybindings]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#people-outside-my-lan-cant-connect-to-the-collab-session-im-hosting][People outside my LAN can't connect to the collab session I'm hosting]]
+  - [[#i-got-an-error-saying-something-including-crdtel-protocol][I got an error saying something including "crdt.el protocol"]]
+
+* Description
+This module adds collaborative editing via the [[https://code.librehq.com/qhong/crdt.el][crdt]] plugin.
+
+** Maintainers
++ [[https://github.com/artenator][@artenator]]
++ [[https://github.com/jming422][@jming422]]
+
+** Module Flags
++ =+tunnel= Enables TCP forwarding over the [[https://tox.chat/][Tox]] protocol so that a collaborative
+  editing session can be established between machines that are behind a NAT.
+
+** Plugins
++ [[https://code.librehq.com/qhong/crdt.el][crdt]]
+
+* Prerequisites
+With no flags, this module requires nothing else to work. The =+tunnel= flag has one dependency:
+
+** With =+tunnel=
+Tunneling requires the [[https://github.com/gjedeer/tuntox][tuntox]] program, which is used to establish TCP
+connections to your collaborators over the Tox peer-to-peer networking protocol.
+
+*** macOS
+tuntox can be installed from Homebrew:
+#+BEGIN_SRC bash
+brew install tuntox
+#+END_SRC
+
+*** Linux
+You can download the tuntox binary for most architectures from its [[https://github.com/gjedeer/tuntox/releases][Releases]] page
+on GitHub, and it can be found in some [[https://repology.org/project/tuntox/versions][package manager repositories]] as well.
+
+*** Windows
+Tuntox is currently not supported on Windows, so Windows users cannot use the
+=+tunnel= flag and must choose another networking solution, such as a VPN. For
+more options, see [[*People outside my LAN can't connect to the collab session I'm hosting][this Troubleshooting entry]].
+
+* Features
++ Start a collaborative editing session in one of your buffers with =M-x
+  crdt-share-buffer= and following the prompts.
++ If you're using =+tunnel=, get the sharable URL of your session using =M-x
+  crdt-copy-url=. If not using =+tunnel=, then instead of a URL, others can
+  connect using your public IP address and chosen TCP port number (default port
+  is 6530)
++ Others can connect to your session using =M-x crdt-connect= and following the
+  prompts to pass in your tunnel URL or IP address and port
++ Once connected, some commands you can use are:
+  + =crdt-list-buffers= to list shared buffers. Use this after =crdt-connect= to
+    open shared buffers for editing!
+  + =crdt-share-buffer= Start a new collaboration session, or add more buffers
+    to an existing session. Once a session has started, both the host and
+    clients can use this function to share buffers!
+  + =crdt-goto-user= to jump to another collaborator
+  + =crdt-follow-user= / =crdt-stop-follow= to toggle following another
+    collaborator
+  + =crdt-visualize-author-mode= to add colors to regions of the buffer,
+    visualizing who most recently edited each part of the buffer
+  + =crdt-stop-session= (host) / =crdt-disconnect= (client) to exit the collab
+    session
+
+** Keybindings
+When this module is enabled, the `SPC l` leader keymap becomes available, making most of the above functions and more available under that prefix:
+
+| Binding   | Description                                             |
+|-----------+---------------------------------------------------------|
+| =SPC l b= | Switch to a shared buffer                               |
+| =SPC l c= | Connect to a session                                    |
+| =SPC l d= | Disconnect from session                                 |
+| =SPC l f= | Toggle following another user's cursor                  |
+| =SPC l F= | Stop following user if any                              |
+| =SPC l g= | Goto another user's cursor                              |
+| =SPC l i= | List shared buffers                                     |
+| =SPC l k= | Kick a user (host only)                                 |
+| =SPC l l= | List sessions                                           |
+| =SPC l s= | Share current buffer, optionally starting a new session |
+| =SPC l S= | Stop sharing current buffer                             |
+| =SPC l u= | List connected users                                    |
+| =SPC l x= | Stop a session (host only)                              |
+| =SPC l y= | Copy URL of current session                             |
+| =SPC l ]= | Goto next user's cursor                                 |
+| =SPC l [= | Goto previous user's cursor                             |
+
+
+* Configuration
+
+This list is not exhaustive; for the full list of config options, type =SPC h V
+crdt-= after loading the module.
+
+| Custom variable             | Default            | Function                                                                                  |
+|-----------------------------+--------------------+-------------------------------------------------------------------------------------------|
+| crdt-ask-for-name           | t                  | Set to nil to always use =crdt-default-name= as your name without asking                  |
+| crdt-default-name           | ~(user-full-name)~ | Your display name in collaboration sessions                                               |
+| crdt-tuntox-executable      | "tuntox"           | Path to the tuntox binary                                                                 |
+| crdt-tuntox-password-in-url | nil                | Set to t to put your session password (in plaintext) into the URL made by =crdt-copy-url= |
+
+
+* Troubleshooting
+
+** People outside my LAN can't connect to the collab session I'm hosting
+Without =+tunnel= enabled, on most home/work networks you will be unable to have
+others join you from across the Internet unless you set something up to
+facilitate the connection between collaborators.
+You have a lot of options here, but some of the most common are:
++ Enable the =+tunnel= flag to tunnel your traffic using the [[https://tox.chat/][Tox]] peer-to-peer
+  networking protocol
++ Use a VPN
++ Use a non-peer-to-peer tunneling method, such as Teredo. One free software
+  implementation of this method is called [[https://www.remlab.net/miredo/][Miredo]]
++ Use a TCP reverse proxy server, such as [[https://ngrok.com/][ngrok]]
++ Use SSH port forwarding, if you have access to a server with a public network
+  address
+
+** I got an error saying something including "crdt.el protocol"
+All collaborators must be using the same version of the crdt package in order to
+guarantee stability & support for all features. These types of errors should not
+occur if everyone is up to date, so ensure that all collaborators have upgraded
+Doom Emacs to the latest version and have not pinned =crdt=.

--- a/modules/tools/collab/config.el
+++ b/modules/tools/collab/config.el
@@ -1,0 +1,8 @@
+;;; tools/collab/config.el -*- lexical-binding: t; -*-
+
+(use-package! crdt
+  :commands (crdt-share-buffer crdt-connect)
+  :init
+  (when (featurep! +tunnel)
+    (setq crdt-use-tuntox t)
+    (setq crdt-tuntox-password-in-url t)))

--- a/modules/tools/collab/doctor.el
+++ b/modules/tools/collab/doctor.el
@@ -1,0 +1,4 @@
+;;; tools/collab/doctor.el -*- lexical-binding: t; -*-
+
+(when (and (featurep! +tunnel) (not (executable-find "tuntox")))
+  (warn! "Couldn't find tuntox command. This needs to be on your path for the +tunnel flag to work properly."))

--- a/modules/tools/collab/packages.el
+++ b/modules/tools/collab/packages.el
@@ -1,0 +1,6 @@
+;; -*- no-byte-compile: t; -*-
+;;; tools/collab/packages.el
+
+(package! crdt
+  :recipe (:host nil :repo "https://code.librehq.com/qhong/crdt.el")
+  :pin "e6d42f42c5dedb73560048f4bf6263c63ffa21bb")

--- a/modules/tools/collab/packages.el
+++ b/modules/tools/collab/packages.el
@@ -3,4 +3,4 @@
 
 (package! crdt
   :recipe (:host nil :repo "https://code.librehq.com/qhong/crdt.el")
-  :pin "e6d42f42c5dedb73560048f4bf6263c63ffa21bb")
+  :pin "3ba890658d657db5d6aaedd5c2a78b6f93a5f139")

--- a/templates/init.example.el
+++ b/templates/init.example.el
@@ -87,6 +87,7 @@
        :tools
        ;;ansible
        ;;biblio            ; Writes a PhD for you (citation needed)
+       ;;collab            ; buffers with friends
        ;;debugger          ; FIXME stepping through code, to help you add bugs
        ;;direnv
        ;;docker


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Add a collaborative editing module, powered by crdt.el.

@artenator and I (@jming422) are the authors of this module (we used crdt.el to write it collaboratively!), and we're offering to maintain it as best we can also.

**Some things we'd love feedback on:**
 - Keybindings -- For now we put it at the leader `SPC l`, but are very willing to change this!
 - UI look & feel -- Some of the interfaces used by crdt.el feel "vanilla Emacs-y", and we're not totally sure what to do about it. The menus for creating a new session with `crdt-share-buffer` and connecting to someone else's session using `crdt-connect` especially fall into this category - they use the `forms-mode` builtin major mode for these menus.

**Some things we still have in progress, but that shouldn't block initial review:** (all done now, yay!)
 - [x] When the host of a collaborative session kills their session, clients are only partially disconnected automatically. If the client forgets to run `crdt-disconnect`, and then they attempt to establish a new connection using `crdt-connect` later, the existence of their previous (now broken) session causes a TON of problems, basically making it necessary for them to restart Emacs. We've gotta contribute a fix to this before we'll feel comfortable marking this PR as non-draft. **Update:** We have submitted a fix which has been merged upstream [here](https://code.librehq.com/qhong/crdt.el/-/merge_requests/5)
 - [x] When the `+tunnel` flag is provided, starting or connecting a new session pops up a confusing/not-pretty `*Tuntox Proxy*` buffer in a big window. We'd like to change this so the buffer (which is basically a log) remains in the background instead. **Update:** We have merged a resolution to this upstream [here](https://code.librehq.com/qhong/crdt.el/-/merge_requests/4).
 - [x] We made an evil-collection to fix some of the crdt.el default bindings when in normal mode, and it is merged: https://github.com/emacs-evil/evil-collection/pull/673
 - [x] crdt.el provides `crdt-visualize-author-mode`, but it's faces are not very nice or easy to read with default theme settings, plus they use underlines which evoke the sense that it's an error checker instead of a collab feature. **Update:** These issues are no longer problematic on Doom default themes
 - [x] A bug seems to have appeared in crdt.el that can cause shared buffers to fall out of sync, it is tracked upstream [here](https://code.librehq.com/qhong/crdt.el/-/issues/4). **Update:** It seems to be resolved now!

Ref: https://code.librehq.com/qhong/crdt.el

![Screen Shot 2022-09-02 at 5 09 25 PM](https://user-images.githubusercontent.com/8932155/188248012-e48eba0c-0f45-4a32-a706-02682ae76174.png)

![Screen Shot 2022-09-02 at 5 03 45 PM](https://user-images.githubusercontent.com/8932155/188248011-7eae062b-571d-476e-95b9-1b8c12a201bd.png)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included ~before and~ after screenshots.
  - _I almost posted a picture of my empty hand for the "before" screenshot 😉_
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
