### PR TITLE
fix(vertico): erroring when grep or rg not found

### DIFF
--- a/modules/completion/vertico/doctor.el
+++ b/modules/completion/vertico/doctor.el
@@ -2,10 +2,14 @@
 
 (require 'consult)
 
-(unless (consult--grep-lookahead-p "grep" "-P")
-  (warn! "The installed grep binary was not built with support for PCRE lookaheads.
-  Some advanced consult filtering features will not work as a result, see the module readme."))
+(if (executable-find "grep")
+  (unless (consult--grep-lookahead-p "grep" "-P")
+    (warn! "The installed grep binary was not built with support for PCRE lookaheads.
+    Some advanced consult filtering features will not work as a result, see the module readme."))
+  (warn! "Couldn't find grep."))
 
-(unless (consult--grep-lookahead-p "rg" "-P")
-  (warn! "The installed ripgrep binary was not built with support for PCRE lookaheads.
-  Some advanced consult filtering features will not work as a result, see the module readme."))
+(if (executable-find "rg")
+  (unless (consult--grep-lookahead-p "rg" "-P")
+    (warn! "The installed ripgrep binary was not built with support for PCRE lookaheads.
+    Some advanced consult filtering features will not work as a result, see the module readme."))
+  (warn! "Couldn't find ripgrep."))


### PR DESCRIPTION
When installing Doom Emacs on Windows, I ran into `doom doctor` erroring out and exiting when `grep` wasn't found. The presence of `grep` and `rg` should be verified before they're presumed to exist in the call to `consult--grep-lookahead-p`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.