### PR TITLE
fix(debugger): fix dap-ui conditional loading

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -155,6 +155,6 @@
 
 
 (use-package! dap-ui
-  :when (modulep! +lsp)
+  :when (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
   :hook (dap-mode . dap-ui-mode)
   :hook (dap-ui-mode . dap-ui-controls-mode))


### PR DESCRIPTION
Probably missed when adding eglot support code in the module