### PR TITLE
fix(nix): remove :mode hook for `nix-drv-mode`

### DIFF
--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -45,10 +45,6 @@
         "o" #'+nix/lookup-option))
 
 
-(use-package! nix-drv-mode
-  :mode "\\.drv\\'")
-
-
 (use-package! nix-update
   :commands nix-update-fetch)
 


### PR DESCRIPTION
The `nix-mode` package already does this (see https://github.com/NixOS/nix-mode/blob/34d51e2731408b5b615f785a83faa3d6dc2a92a1/nix-drv-mode.el#L48) and it shadows other entries for the `.drv` files in `auto-mode-alist` (namely Guix derivations).

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).