### PR TITLE
fix(lib): unquote dir! call in load! macro

### DIFF
--- a/lisp/doom-lib.el
+++ b/lisp/doom-lib.el
@@ -610,7 +610,7 @@ directory path). If omitted, the lookup is relative to either `load-file-name',
 
 If NOERROR is non-nil, don't throw an error if the file doesn't exist."
   `(doom-load
-    (file-name-concat ,(or path `(dir!)) ,filename)
+    (file-name-concat ,(or path (dir!)) ,filename)
     ,noerror))
 
 (defmacro defer-until! (condition &rest body)


### PR DESCRIPTION
This restores previous behavior where `dir!` was called at the time of `load!`'s expansion, which ensured that it resolved to the directory of the source file where load! was called

In my case, this manifested in not being able to use evil-ex because of a "Cannot get this file-path" error _unless_ evil-ex was called with modules/editor/evil/config.el in the active buffer first to load it

AFAICT, this is equivalent to how load worked before https://github.com/doomemacs/doomemacs/commit/a179b8d262a0630e543af24fa5ffd8d33da0ac89, but I'm not sure whether quoting `(dir!)` was significant there and if this will have a negative impact on anything else and constitutes a breaking change

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
