### PR TITLE
fix(ivy): ensure flx is loaded with (ivy +fuzzy)

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -372,7 +372,9 @@ results buffer.")
   :when (modulep! +fuzzy)
   :unless (modulep! +prescient)
   :defer t  ; is loaded by ivy
-  :preface (setq ivy--flx-featurep (modulep! +fuzzy))
+  :preface (when (or (not (modulep! +fuzzy))
+                     (modulep! +prescient))
+             (setq ivy--flx-featurep nil))
   :init (setq ivy-flx-limit 10000))
 
 (use-package! ivy-avy


### PR DESCRIPTION
Overriding `ivy--flx-featurep` here would always prevent flx from being loaded and enabled---even if it were `t`---because ivy `require`s it in `ivy--flx-featurep`'s initvalue. So instead, this sets the variable if and only if it should be disabled. Because flx isn't installed when +prescient is enabled, I've included that in the condition for disabling ivy--flx-featurep as well

Fix: https://github.com/doomemacs/doomemacs/issues/6034
Amend: https://github.com/doomemacs/doomemacs/commit/bae7ab0d8dbb2ace3fb54692f3525826b69ed60a

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
  ~~I tried to scope this as fix(ivy), but I was getting a lint error that ivy was not a valid scope. I may have misunderstood the scoping rules~~
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
