### PR TITLE
fix(config): tangle with the same Org as Doom uses

### DIFF
--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -70,6 +70,7 @@
           (start-process "tangle-config"
                          (get-buffer-create " *tangle config*")
                          "emacs" "--batch"
+                         "-L" (file-name-directory (locate-library "org"))
                          "--load" (doom-path doom-core-dir "doom")
                          "--load" (doom-path doom-core-dir "lib/print")
                          "--eval"


### PR DESCRIPTION
I feel like this is pretty simple and self-explanatory.

Without this change the sync and async tangling functions can (will) use different Org versions.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to (none).
- [ ] This a draft PR; I need more time to finish it.

