### PR TITLE
fix(magit): remap magit-browse-thing to forge-browse-*

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -156,6 +156,10 @@ Only has an effect in GUI Emacs.")
   :config
   ;; All forge list modes are derived from `forge-topic-list-mode'
   (map! :map forge-topic-list-mode-map :n "q" #'kill-current-buffer)
+  (when (not forge-add-default-bindings)
+    (map! :map magit-mode-map [remap magit-browse-thing] #'forge-browse-dwim
+          :map magit-remote-section-map [remap magit-browse-thing] #'forge-browse-remote
+          :map magit-branch-section-map [remap magit-browse-thing] #'forge-browse-branch))
   (set-popup-rule! "^\\*?[0-9]+:\\(?:new-\\|[0-9]+$\\)" :size 0.45 :modeline t :ttl 0 :quit nil)
   (set-popup-rule! "^\\*\\(?:[^/]+/[^ ]+ #[0-9]+\\*$\\|Issues\\|Pull-Requests\\|forge\\)" :ignore t)
 


### PR DESCRIPTION
When using `evil +everywhere`, we disable the default forge bindings.
We must then explicitly remap `magit-browse-thing`, as it's just a placeholder command (bound in multiple places).

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.