### PR TITLE
fix(literate): use same org install when using CLI

### DIFF
--- a/modules/config/literate/cli.el
+++ b/modules/config/literate/cli.el
@@ -2,5 +2,18 @@
 
 (load! "autoload")
 
+(defun +literate-add-installed-org-to-load-path-h ()
+  "Use the straight-installed, not bundled Org."
+  (let ((straight-org-build-dir
+         (doom-path straight-base-dir "straight" straight-build-dir "org"))
+        (straight-org-repo-dir
+         (doom-path straight-base-dir "straight" "repos" "org")))
+    (cond
+     ((file-exists-p straight-org-build-dir)
+      (add-to-list 'load-path straight-org-build-dir))
+     ((file-exists-p straight-org-repo-dir)
+      (add-to-list 'load-path straight-org-repo-dir)))))
+
 ;; Tangle the user's config.org before 'doom sync' runs
 (add-hook 'doom-before-sync-hook #'+literate-tangle-h)
+(add-hook 'doom-before-sync-hook #'+literate-add-installed-org-to-load-path-h)


### PR DESCRIPTION
It's good for config tangling behaviour to be consistent across:
1. interactive sessions
2. asynchronous calls
3. the doom CLI

(1) of course uses the Doom-installed org, (2) was taken care of in #6778, and this should make (3) behave the same.

Without this, one can run into bugs and behavioural differences between the emacs-bundled Org and the (more recent) doom-installed Org, for example, see https://git.savannah.gnu.org/cgit/emacs/org-mode.git/commit/?id=cb8bf4a0d which fixes an issue with `:noweb-ref` references not being expanded in some situations.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.