### PR TITLE
bump: :ui treemacs

### DIFF
--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/treemacs/packages.el
 
-(package! treemacs :pin "b18a05b1f62074a40e6011d83cd4c92cbee040dd")
+(package! treemacs :pin "861418d9d11b205930bd4555a40b430b9dde9dd4")
 ;; These packages have no :pin because they're in the same repo
 (when (modulep! :editor evil +everywhere)
   (package! treemacs-evil))
@@ -11,4 +11,4 @@
 (when (modulep! :ui workspaces)
   (package! treemacs-persp))
 (when (modulep! +lsp)
-  (package! lsp-treemacs :pin "355e468b7fa9887c616a8bfe873d8e456303b67b"))
+  (package! lsp-treemacs :pin "f7ae97560cfbc88e781a2d5b9253dace7175b918"))


### PR DESCRIPTION
A [new major version of treemacs](https://github.com/Alexander-Miller/treemacs/releases/tag/3.0) was released some days ago. The currently pinned version is from February 2022, and it stops at least the Scala LSP server from starting with message "cannot load treemacs-lib", I guess via lsp-treemacs.

Updates also lsp-treemacs to a commit that uses the latest release of treemacs.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] ~My changes are visual; I've included before and after screenshots.~
- [ ] ~I am blindly checking these off.~
- [ ] ~Any relevant issues or PRs have been linked to.~
- [ ] ~This a draft PR; I need more time to finish it.~