### PR TITLE
fix(word-wrap): remove erroneous symbol-value use

### DIFF
--- a/modules/editor/word-wrap/autoload.el
+++ b/modules/editor/word-wrap/autoload.el
@@ -18,9 +18,9 @@
                (sp-point-in-string-or-comment p)))
       (pcase +word-wrap-extra-indent
         ('double
-         (* 2 (symbol-value +word-wrap--major-mode-indent-var)))
+         (* 2 +word-wrap--major-mode-indent-var))
         ('single
-         (symbol-value +word-wrap--major-mode-indent-var))
+         +word-wrap--major-mode-indent-var)
         ((and (pred integerp) fixed)
          fixed)
         (_ 0))


### PR DESCRIPTION
This is *very* straightforward. Honestly, I'm not sure how it took so long to be noticed.

Raised by ljg on the Doom discord.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- x ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.

