### PR TITLE
tweak(mu4e): autoload +mu4e-lock-available

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -26,6 +26,7 @@
           (cons pid process)
         (delete-file +mu4e-lock-file) nil))))
 
+;;;###autoload
 (defun +mu4e-lock-available (&optional strict)
   "If the `+mu4e-lock-file' is available (unset or owned by this emacs) return t.
 If STRICT only accept an unset lock file."


### PR DESCRIPTION
`+mu4e-lock-availible` seems like a potential entry-point to the mu-lock functionality, e.g. on startup check if another Emacs process has mu4e active, and so it might as well be turned into an autoload.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.
