### PR TITLE
tweak(literate): clear the tangle output buffer

### DIFF
--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -68,7 +68,10 @@
           +literate-tangle--async-proc
           ;; See `+literate-tangle--sync' for an explanation of the (progn ...) below.
           (start-process "tangle-config"
-                         (get-buffer-create " *tangle config*")
+                         (with-current-buffer
+                             (get-buffer-create " *tangle config*")
+                           (erase-buffer)
+                           (current-buffer))
                          "emacs" "--batch"
                          "-L" (file-name-directory (locate-library "org"))
                          "--load" (doom-path doom-core-dir "doom")


### PR DESCRIPTION
While this is a hidden buffer, it's raised when an error occurs. In such situations, it can be a little confusing to see the result of every tangle to date instead of just the last tangle. It's easy enough to simple clear the buffer at the start of the tangle process.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.

