### PR TITLE
tweak(mu4e): don't reverse dired marks to attach

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -271,7 +271,7 @@ When otherwise called, open a dired buffer and enable `dired-mu4e-attach-ctrl-c-
                    (mapcar
                     ;; don't attach directories
                     (lambda (f) (if (file-directory-p f) nil f))
-                    (nreverse (dired-map-over-marks (dired-get-filename) nil))))))
+                    (dired-map-over-marks (dired-get-filename) nil)))))
      (if (not files-to-attach)
          (progn
            (message "No files marked, aborting.")


### PR DESCRIPTION
Originally this was added to have the order of attached files match the order of mark selection. Recent usage indicates that this was either misguided or the behaviour has changed, as this now achieves the opposite effect --- with nreverse files are attached in reverse order. Removing nreverse provides the expected behaviour.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
