### PR TITLE
fix(mu4e): only widen the mu4e headers frame

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -245,9 +245,12 @@ is non-nil."
   ;; so if the header view is entered from a narrow frame,
   ;; it's probably worth trying to expand it
   (defun +mu4e-widen-frame-maybe ()
-    "Expand the frame with if it's less than `+mu4e-min-header-frame-width'."
-    (when (< (frame-width) +mu4e-min-header-frame-width)
-      (set-frame-width (selected-frame) +mu4e-min-header-frame-width)))
+    "Expand the mu4e-headers containing frame's width to `+mu4e-min-header-frame-width'."
+    (dolist (frame (frame-list))
+      (when (and (string= (buffer-name (window-buffer (frame-selected-window frame)))
+                          mu4e-headers-buffer-name)
+                 (< (frame-width) +mu4e-min-header-frame-width))
+        (set-frame-width frame +mu4e-min-header-frame-width))))
   (add-hook 'mu4e-headers-mode-hook #'+mu4e-widen-frame-maybe)
 
   (when (fboundp 'imagemagick-register-types)


### PR DESCRIPTION
It's a bit silly to just unconditionally widen the current frame when you could have the mu4e headers view in another frame entirely. Instead we can look for the mu4e headers buffer, and only widen frames where it is the active buffer.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
