### PR TITLE
feat(workspaces): add mru cache for alt-tab like functionality

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -408,6 +408,9 @@
         :desc "Delete workspace"             "k" #'+workspace/delete
         :desc "Save workspace"               "S" #'+workspace/save
         :desc "Switch to other workspace"    "o" #'+workspace/other
+        (:when (modulep! :ui workspaces +mru)
+         :desc "Switch to other non-app workspace"
+         "O" #'+workspace/other-non-app)
         :desc "Switch to left workspace"     "p" #'+workspace/switch-left
         :desc "Switch to right workspace"    "n" #'+workspace/switch-right
         :desc "Switch to"                    "w" #'+workspace/switch-to

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -4,8 +4,6 @@
 ;; file-based session persistence. I used workgroups2 before this, but abandoned
 ;; it because it was unstable and slow; `persp-mode' is neither (and still
 ;; maintained).
-;;
-;; NOTE persp-mode requires `workgroups' for file persistence in Emacs 24.4.
 
 (defvar +workspaces-main "main"
   "The name of the primary and initial workspace, which cannot be deleted.")

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -282,4 +282,11 @@ stored in `persp-save-dir'.")
   (add-hook! 'tab-bar-mode-hook
     (defun +workspaces-set-up-tab-bar-integration-h ()
       (add-hook 'persp-before-deactivate-functions #'+workspaces-save-tab-bar-data-h)
-      (add-hook 'persp-activated-functions #'+workspaces-load-tab-bar-data-h))))
+      (add-hook 'persp-activated-functions #'+workspaces-load-tab-bar-data-h)))
+
+;;; mru
+  (when (modulep! :ui workspaces +mru)
+    (add-hook 'persp-renamed-functions       #'+workspace--mru-rename)
+    (add-hook 'persp-created-functions       #'+workspace--mru-create)
+    (add-hook 'persp-before-kill-functions   #'+workspace--mru-kill)
+    (add-hook 'persp-before-switch-functions #'+workspace--mru-switch)))


### PR DESCRIPTION
This enables keeping a list of workspaces in most recently used order so that we can enable "alt-tab"-like functionality for switching between workspaces that are not apps (or vice versa, only switching between apps).

This is currently behind an +mru flag to workspaces but it doesn't necessarily need to be since it doesn't change any behavior. Users would need to opt-in to using the new functions.

Need to decide other keybindings for evil, if any. Also, need to decide if this should be a flag or not.