### PR TITLE
fix(mu4e): cooperative lock file watching

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -55,10 +55,11 @@ Else, write to this process' PID to the lock file"
     (delete-file +mu4e-lock-request-file)
     (call-process "touch" nil nil nil +mu4e-lock-request-file)
     (funcall orig-fun callback)
-    (setq +mu4e-lock--request-watcher
-          (file-notify-add-watch +mu4e-lock-request-file
-                                 '(change)
-                                 #'+mu4e-lock-request))))
+    (when +mu4e-lock--request-watcher
+      (file-notify-rm-watch +mu4e-lock--request-watcher))
+    (file-notify-add-watch +mu4e-lock-request-file
+                           '(change)
+                           #'+mu4e-lock--request)))
 
 (defvar +mu4e-lock--file-watcher nil)
 (defvar +mu4e-lock--file-just-deleted nil)
@@ -70,23 +71,24 @@ Else, write to this process' PID to the lock file"
   (setq +mu4e-lock--file-watcher
         (file-notify-add-watch +mu4e-lock-file
                                '(change)
-                               #'+mu4e-lock-file-updated)))
+                               #'+mu4e-lock--file-updated)))
 
-(defun +mu4e-lock-request (event)
+(defun +mu4e-lock--request (event)
   "Handle another process requesting the Mu4e lock."
-  (when (equal (nth 1 event) 'created)
+  (when (eq (nth 1 event) 'created)
     (when +mu4e-lock-relaxed
       (mu4e--stop)
       (file-notify-rm-watch +mu4e-lock--file-watcher)
+      (file-notify-rm-watch +mu4e-lock--request-watcher)
       (message "Someone else wants to use Mu4e, releasing lock")
       (delete-file +mu4e-lock-file)
       (run-at-time 0.2 nil #'+mu4e-lock-add-watcher))
     (delete-file +mu4e-lock-request-file)))
 
-(defun +mu4e-lock-file-updated (event)
+(defun +mu4e-lock--file-updated (event)
   (if +mu4e-lock--file-just-deleted
       (+mu4e-lock-add-watcher)
-    (when (equal (nth 1 event) 'deleted)
+    (when (eq (nth 1 event) 'deleted)
       (setq +mu4e-lock--file-just-deleted t)
       (when (and +mu4e-lock-greedy (+mu4e-lock-available t))
         (message "Noticed Mu4e lock was available, grabbed it")


### PR DESCRIPTION
Some time ago I noticed the cooperative lock file management wasn't working as I remember. I forget what exactly I was thinking, but basically I've poked at the code until it seems to work better.

If some other people could test this and report back, that would be much appreciated.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.