### PR TITLE
fix(csharp): fix +tree-sitter

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -1,6 +1,9 @@
 ;;; lang/csharp/config.el -*- lexical-binding: t; -*-
 
 (use-package! csharp-mode
+  :init
+  (when (modulep! +tree-sitter)
+    (add-to-list 'auto-mode-alist '("\\.cs\\'" . csharp-tree-sitter-mode)))
   :hook (csharp-mode . rainbow-delimiters-mode)
   :config
   (set-electric! 'csharp-mode :chars '(?\n ?\}))

--- a/modules/lang/csharp/packages.el
+++ b/modules/lang/csharp/packages.el
@@ -10,5 +10,7 @@
   (package! shader-mode :pin "d7dc8d0d6fe8914e8b6d5cf2081ad61e6952359c"))
 (when (modulep! +dotnet)
   (package! sharper :pin "96edd4a1dbc267afdff0cb97298d1b05b7c2080c"))
+;; In addition to the packages provided by the tools/tree-sitter module,
+;; csharp-tree-sitter-mode also requires tree-sitter-indent.
 (when (modulep! +tree-sitter)
   (package! tree-sitter-indent :pin "4ef246db3e4ff99f672fe5e4b416c890f885c09e"))

--- a/modules/lang/csharp/packages.el
+++ b/modules/lang/csharp/packages.el
@@ -10,3 +10,5 @@
   (package! shader-mode :pin "d7dc8d0d6fe8914e8b6d5cf2081ad61e6952359c"))
 (when (modulep! +dotnet)
   (package! sharper :pin "96edd4a1dbc267afdff0cb97298d1b05b7c2080c"))
+(when (modulep! +tree-sitter)
+  (package! tree-sitter-indent :pin "4ef246db3e4ff99f672fe5e4b416c890f885c09e"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The syntax highlighting for basic csharp-mode is busted, and I don't know how to fix it upstream. I'm not even sure if it can be fixed without abandoning the current cc-langs based approach (explaining this is probably more complicated than maintainers want to hear about).

Fortunately, csharp-mode also supports an "experimental" csharp-tree-sitter-mode which actually works correctly. However, doom's +tree-sitter flag does not correctly enable this mode. I think the existing use of the flag may have been based on instructions from before it was a separate major mode. Anyway, this change seems to fix it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
