### PR TITLE
fix(lib): doom/delete-this-file nil path handling

### DIFF
--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -406,8 +406,8 @@ If FORCE-P, delete without confirmation."
    (list (buffer-file-name (buffer-base-buffer))
          current-prefix-arg))
   (let* ((path (or path (buffer-file-name (buffer-base-buffer))))
-         (short-path (abbreviate-file-name path)))
-    (unless (and path (file-exists-p path))
+         (short-path (and path (abbreviate-file-name path))))
+    (unless path
       (user-error "Buffer is not visiting any file"))
     (unless (file-exists-p path)
       (error "File doesn't exist: %s" path))


### PR DESCRIPTION
Fix the handling of a nil `path` within `doom/delete-this-file`.

If `path` is nil (e.g. called interactively when buffer is not visiting a file), avoid calling `abbreviate-file-name` on nil, otherwise an error will be signaled:
```
(wrong-type-argument stringp nil)
```
Additionally, fix the subsequent path checks. These were treating two distinct scenarios as a "Buffer is not visiting any file" user-error:
- nil path
- non-existent path
Only the first should result in that error. The second should proceed to the next path check (which was previously unreachable), to signal the appropriate error, "File doesn't exist: %s".

_Note_: I noticed that this function calls `user-error` in some cases and `error` in others. I'm not sure whether that's intentional, so I didn't change it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).