### PR TITLE
tweak(mu4e): try harder to attach files in order

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -278,7 +278,7 @@ When otherwise called, open a dired buffer and enable `dired-mu4e-attach-ctrl-c-
                    (mapcar
                     ;; don't attach directories
                     (lambda (f) (if (file-directory-p f) nil f))
-                    (dired-map-over-marks (dired-get-filename) nil)))))
+                    (nreverse (dired-map-over-marks (dired-get-filename) nil))))))
      (if (not files-to-attach)
          (progn
            (message "No files marked, aborting.")

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -426,6 +426,15 @@ Usefull for affecting HTML export config.")
         :localleader
         :desc "attach" "a" #'+mu4e/attach-files)
 
+  ;; I feel like it's reasonable to expect files to be attached
+  ;; in the order you attach them, not the reverse.
+  (defadvice! +org-msg-attach-attach-in-order-a (file &rest _args)
+    "Link FILE into the list of attachment."
+    :override #'org-msg-attach-attach
+    (interactive (list (read-file-name "File to attach: ")))
+    (let ((files (org-msg-get-prop "attachment")))
+      (org-msg-set-prop "attachment" (nconc files (list file)))))
+
   (defvar +mu4e-compose-org-msg-toggle-next t ; t to initialise org-msg
     "Whether to toggle ")
   (defun +mu4e-compose-org-msg-handle-toggle (toggle-p)


### PR DESCRIPTION
In 4d9ea6853b88 I reacted to a either a change that I presume occurred in org-msg at some point, or behaviour originally unnoticed, that led to bulk-selected files being attached in reverse. Further investigation has indicated that this isn't actually making attachment order work as expected, just hiding the reverse behaviour from bulk-attachment. The better approach is to keep the dired mark reversal, and change org-msg-attach-attach to add new files to the end, not the start, of the list of attachments.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
