### PR TITLE
fix(mu4e): file attachment prompt arguments

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -256,7 +256,7 @@ When otherwise called, open a dired buffer and enable `dired-mu4e-attach-ctrl-c-
   (pcase major-mode
     ((or 'mu4e-compose-mode 'org-msg-edit-mode)
      (let ((mail-buffer (current-buffer))
-           (location (read-file-name "Attach: ")))
+           (location (read-file-name "Attach: " nil nil t "")))
        (if (not (file-directory-p location))
            (pcase major-mode
              ('mu4e-compose-mode


### PR DESCRIPTION
There are two changes to the default optional read-file-name arguments that should be made for the purpose of attaching files:
1. The optional MUSTMATCH argument should be set, as one can't exactly attach non-existent files.
2. The INITIAL argument should be set to the empty string so that if default-directory is customised for some reason or another that selecting it leads to the expected directory being selected. Without INITIAL or DEFAULT-FILENAME being specified, the current file path will be used, which is never desirable as this is simply a path to the message buffer.

-----

I'm not sure about the commit subject here, but I couldn't think of anything better within 50 chars.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

