### PR TITLE
fix(lib): doom-info symlink-path

### DIFF
--- a/lisp/lib/debug.el
+++ b/lisp/lib/debug.el
@@ -246,8 +246,9 @@ ready to be pasted in a bug report on github."
                (abbreviate-file-name path)))
             (defun symlink-path (file)
               (format "%s%s" (abbrev-path file)
-                      (if (file-symlink-p file) ""
-                        (concat " -> " (abbrev-path (file-truename file)))))))
+                      (if (file-symlink-p file)
+                          (concat " -> " (abbrev-path (file-truename file)))
+                        ""))))
       `((generated . ,(format-time-string "%b %d, %Y %H:%M:%S"))
         (system . ,(delq
                     nil (list (doom-system-distro-version)


### PR DESCRIPTION
Swap the **THEN** and **ELSE** in `symlink-path` so that symlinks are displayed correctly.

Currently, `bin/doom info` displays a non-symlinked path like,
```
~/.config/emacs/ -> ~/.config/emacs/
```
and a symlinked path like,
```
~/.config/emacs/
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
