### PR TITLE
docs: add native compilation as doom doctor suggest

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -293,7 +293,7 @@ to least recommended for Doom (based on compatibility).
   with macOS, native emojis and better childframe support.
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
-  brew install emacs-mac --with-modules
+  brew install emacs-mac --with-modules --with-native-comp
   ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I've added the option to enable native compilation on macOS.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.