### PR TITLE
fix(treemacs): treemacs-collapse-dirs not changing

### DIFF
--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -36,7 +36,7 @@ This must be set before `treemacs' has loaded.")
       (setq +treemacs-git-mode 'simple))
     (treemacs-git-mode +treemacs-git-mode)
     (setq treemacs-collapse-dirs
-          (if (memq treemacs-git-mode '(extended deferred))
+          (if (memq +treemacs-git-mode '(extended deferred))
               3
             0))))
 


### PR DESCRIPTION
`treemacs-collapse-dirs` cannot be changed by setting `+treemacs-git-mode` to `extended` or `deferred`

Fixes #6850

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
