### PR TITLE
docs(notmuch): fix custom sync backend snippet

### DIFF
--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -140,9 +140,8 @@ will be quicker than =offlineimap=.
 If you have a unique method for synchronizing your email, you can define your
 own backend:
 #+begin_src emacs-lisp
-(setq +notmuch-sync-backend 'custom
-      ;; Set this to an arbitrary shell command
-      +notmuch-sync-command "my-notmuch-sync-cmd")
+;; Set this to an arbitrary shell command
+(setq +notmuch-sync-backend "my-notmuch-sync-cmd")
 #+end_src
 
 ** Sending mail


### PR DESCRIPTION
The method for customizing +notmuch-sync-backend was changed in 19d4126 to accept a string; consequently the current example in the docs results in an error:

`user-error: Invalid notmuch backend specified: custom`

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
