### PR TITLE
fix: change warning-suppress-types to list of lists

### DIFF
--- a/lisp/doom.el
+++ b/lisp/doom.el
@@ -610,7 +610,7 @@ Otherwise, `en/disable-command' (in novice.el.gz) is hardcoded to write them to
 ;; defvaralias, which are done because ensuring aliases are created before
 ;; packages are loaded is an unneeded and unhelpful maintenance burden. Emacs
 ;; still aliases them fine regardless.
-(setq warning-suppress-types '(defvaralias))
+(setq warning-suppress-types '((defvaralias)))
 
 ;; Reduce debug output unless we've asked for it.
 (setq debug-on-error init-file-debug


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Change the value of `warning-suppress-types` back to a list of list of symbols.

I noticed this issue in my python repl setup, based on this backtrace:

```
Debugger entered--Lisp error: (wrong-type-argument listp defvaralias)
  warning-suppress-p((python python-shell-prompt-regexp) (defvaralias))
  display-warning((python python-shell-prompt-regexp) "Python shell prompts cannot be detected.\nIf your e..." :warning)
  lwarn((python python-shell-prompt-regexp) :warning "Python shell prompts cannot be detected.\nIf your e...")
  python-shell-prompt-detect()
  python-shell-prompt-set-calculated-regexps()
  inferior-python-mode()
```

This appears to be a regression introduced in [8c442d84b9c055200e61c4333e117c1ce914027d](https://github.com/doomemacs/doomemacs/commit/8c442d84b9c055200e61c4333e117c1ce914027d)

note: The upstream documentation suggests that a list of plain symbols should be allowed, but this recent commit suggests otherwise. See https://github.com/emacs-mirror/emacs/commit/d5ee49c25c8f59ab17c40eebdf38a769c2f5588b

~Fixes #0000~
References https://github.com/doomemacs/doomemacs/commit/8c442d84b9c055200e61c4333e117c1ce914027d
~Replaces #0000~

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
