### PR TITLE
Docs link format change

### DIFF
--- a/docs/appendix.org
+++ b/docs/appendix.org
@@ -184,8 +184,8 @@
   [[kbd:][C-x]] and [[kbd:][C-x C-k]] can be considered prefixes.
 
   Prefix keys allow to store and move keybindings in groups. For example by
-  default all [[doom-package:][lsp-mode]] commands are under ~SPC c l ...~, but if you want to
-  change that prefix to ~SPC L ...~ for all [[doom-package:][lsp-mode]] commands, it is a one liner
+  default all [[doom-package:lsp-mode]] commands are under ~SPC c l ...~, but if you want to
+  change that prefix to ~SPC L ...~ for all [[doom-package:lsp-mode]] commands, it is a one liner
   in your configuration; you do _not_ have to rebind each command manually to
   its new ~SPC L ...~ variant.
 

--- a/docs/examples.org
+++ b/docs/examples.org
@@ -14,8 +14,8 @@ examples; where the former can also be useful to users who don't use Doom.
 Some of Doom's components will read this file to generate documentation for you,
 for example:
 
-- Doom's [[doom-module:][:lang emacs-lisp]] module installs the [[doom-package:][elisp-demos]] package. This displays
-  usage examples alongside documentation in [[doom-package:][help]] and [[doom-package:][helpful]] buffers (produced
+- Doom's [[doom-module:][:lang emacs-lisp]] module installs the [[doom-package:elisp-demos]] package. This displays
+  usage examples alongside documentation in [[doom-package:help]] and [[doom-package:helpful]] buffers (produced
   by =describe-*= and =helpful-*= commands; e.g. [[kbd:][<help> h f]]). Doom has extended
   this package to search this file as well.
 - [[id:1b8b8fa9-6233-4ed8-95c7-f46f8e4e2592][Some Doom's CLI commands]] will emit documentation informed by Doom's org files,

--- a/docs/faq.org
+++ b/docs/faq.org
@@ -199,10 +199,10 @@ Doom's LSP support and install a supported LSP client.
 This provides code completion, lookup {definition,references,documentation}
 functionality, and syntax checking, all in one:
 
-1. Enable Doom's [[doom-module:][:tools lsp]] module. ([[id:01cffea4-3329-45e2-a892-95a384ab2338][How do I enable modules?]])
+1. Enable Doom's [[doom-module::tools lsp]] module. ([[id:01cffea4-3329-45e2-a892-95a384ab2338][How do I enable modules?]])
 2. Enable the ~+lsp~ flag on the ~:lang~ module corresponding to the language
-   you want LSP support for. E.g. For python, enable [[doom-module:][:lang python +lsp]]. For
-   rust, enable [[doom-module:][:lang rust +lsp]]. ([[id:01cffea4-3329-45e2-a892-95a384ab2338][How do I enable module flags?]])
+   you want LSP support for. E.g. For python, enable [[doom-module::lang python +lsp]]. For
+   rust, enable [[doom-module::lang rust +lsp]]. ([[id:01cffea4-3329-45e2-a892-95a384ab2338][How do I enable module flags?]])
 3. Install [[https://emacs-lsp.github.io/lsp-mode/page/languages/][a supported LSP client]] on your system using your OS package manager
    OR from within Emacs using ~M-x lsp-install-server~ (warning: not all servers
    can be installed this way).
@@ -215,7 +215,7 @@ functionality, and syntax checking, all in one:
 *** Potential issues
 1. Some language modules lack LSP support (either because it doesn't exist or
    I'm not aware of it -- let me know!). If you're certain a language is
-   supported by [[doom-package:][lsp-mode]], simply adding [[fn:][lsp!]] to that major mode's hook will be
+   supported by [[doom-package:lsp-mode]], simply adding [[fn:lsp!]] to that major mode's hook will be
    enough to enable it:
 
    #+begin_src elisp
@@ -238,15 +238,15 @@ documentation with [[kbd:][<help> d m]] (or ~M-x doom/help-modules~).
 ** Change my fonts
 Doom exposes a couple variables for setting fonts. They are:
 
-- [[var:][doom-font]]: the primary font for Emacs to use.
-- [[var:][doom-variable-pitch-font]]: used for non-monospace fonts (e.g. when using
+- [[var:doom-font]]: the primary font for Emacs to use.
+- [[var:doom-variable-pitch-font]]: used for non-monospace fonts (e.g. when using
   variable-pitch-mode or mixed-pitch-mode). Popular for text modes, like Org or
   Markdown.
-- [[var:][doom-unicode-font]]: used for rendering unicode glyphs. This is ~Symbola~ by
-  default. It is ignored if the [[doom-module:][:ui unicode]] module is enabled.
-- [[var:][doom-serif-font]]: the sans-serif font to use wherever the [[face:][fixed-pitch-serif]]
+- [[var:doom-unicode-font]]: used for rendering unicode glyphs. This is ~Symbola~ by
+  default. It is ignored if the [[doom-module::ui unicode]] module is enabled.
+- [[var:doom-serif-font]]: the sans-serif font to use wherever the [[face:fixed-pitch-serif]]
   face is used.
-- [[var:][doom-big-font]]: the large font to use when [[fn:][doom-big-font-mode]] is active.
+- [[var:doom-big-font]]: the large font to use when [[fn:doom-big-font-mode]] is active.
 
 Each of these variables accept one of:
 
@@ -329,7 +329,7 @@ This is documented in more detail in our user manual:
 - [[id:8e0d2c05-6028-4e68-a50d-b81851f3f258][How to bind aliases for your leader / localleader prefix]]
 
 ** Change the style of (or disable) line-numbers?
-Doom uses the [[doom-package:][display-line-numbers]] package, which is included with Emacs 26+.
+Doom uses the [[doom-package:display-line-numbers]] package, which is included with Emacs 26+.
 
 *** To disable line numbers entirely
 #+begin_src emacs-lisp
@@ -357,7 +357,7 @@ For example:
 #+end_src
 
 You'll find more precise documentation on the variable through [[kbd:][<help> v
-display-line-numbers-type]] ([[kbd:][<help>]] is [[kbd:][SPC h]] for [[doom-package:][evil]] users, [[kbd:][C-h]] otherwise).
+display-line-numbers-type]] ([[kbd:][<help>]] is [[kbd:][SPC h]] for [[doom-package:evil]] users, [[kbd:][C-h]] otherwise).
 
 *** To cycle through different styles of line numbers
 Use ~M-x doom/toggle-line-numbers~ (bound to [[kbd:][<leader> t l]] by default) to cycle
@@ -366,7 +366,7 @@ through the available line number styles in the current buffer.
 E.g. ~normal -> relative -> visual -> disabled -> normal~
 
 ** Disable Evil (vim emulation)?
-By disabling the [[doom-module:][:editor evil]] module ([[id:01cffea4-3329-45e2-a892-95a384ab2338][how to toggle modules]]).
+By disabling the [[doom-module::editor evil]] module ([[id:01cffea4-3329-45e2-a892-95a384ab2338][how to toggle modules]]).
 
 Read the "[[id:f3925da6-5f0b-4d11-aa08-7bb58bea1982][Removing evil-mode]]" section in the module's documentation for precise
 instructions.
@@ -408,7 +408,7 @@ moved.
 Delete =$EMACSDIR/.local/straight= and run ~$ doom sync~.
 
 ** Restore the s and S keys to their default vim behavior ([[doom-ref:][#1307]])
-[[kbd:][s]] and [[kbd:][S]] have been intentionally replaced with the [[doom-package:][evil-snipe]] plugin, which
+[[kbd:][s]] and [[kbd:][S]] have been intentionally replaced with the [[doom-package:evil-snipe]] plugin, which
 provides 2-character versions of the f/F/t/T motion keys, ala [[https://github.com/goldfeld/vim-seek][vim-seek]] or
 [[https://github.com/justinmk/vim-sneak][vim-sneak]].
 
@@ -456,7 +456,7 @@ The common explanations for this are:
   the error can shed more light on it (and will be required if you ask the
   community for help debugging it).
 
-- You have disabled the [[doom-module:][:ui doom-dashboard]] module. Read about
+- You have disabled the [[doom-module::ui doom-dashboard]] module. Read about
   [[id:5e267107-81fa-45b4-8ff3-26d4b98e508e][what Doom modules are]] and [[id:01cffea4-3329-45e2-a892-95a384ab2338][how to
   toggle them]].
 
@@ -521,7 +521,7 @@ Here are a few common causes for random crashes:
   ~doom-unicode-font~.
 
 - Ligatures can cause Emacs to crash. Try a different [[doom-module::ui ligatures +fira][ligature font]] or disable
-  the [[doom-module:][:ui ligatures]] module altogether.
+  the [[doom-module::ui ligatures]] module altogether.
 
 - On some systems (particularly MacOS), manipulating the fringes or window
   margins can cause Emacs to crash. This is most prominent in Doom's Dashboard
@@ -540,7 +540,7 @@ Here are a few common causes for random crashes:
     (setq org-startup-indented nil))
   #+end_src
 
-  Or disable the [[doom-module:][:ui doom-dashboard]] and [[doom-module:][:tools magit]] modules (see [[doom-ref:][#1170]]).
+  Or disable the [[doom-module::ui doom-dashboard]] and [[doom-module::tools magit]] modules (see [[doom-ref:][#1170]]).
 
 If these don't help, check our troubleshooting guides for [[id:f88eaf35-97c4-48de-85ef-2d53f8615d4a][hard crashes]] or
 [[id:0b744192-c648-452d-ba62-1b4c76dc3aee][freezes/hangs]].
@@ -575,10 +575,10 @@ There are a couple ways to address this:
    #+end_src
 
 3. Use [[https://editorconfig.org/][editorconfig]] to configure code style on a per-project basis. If you
-   enable Doom's [[doom-module:][:tools editorconfig]] module, Doom will recognize
+   enable Doom's [[doom-module::tools editorconfig]] module, Doom will recognize
    =.editorconfigrc= files.
 
-4. Or trust in [[doom-package:][dtrt-indent]]; a plugin Doom uses to analyze and detect indentation
+4. Or trust in [[doom-package:dtrt-indent]]; a plugin Doom uses to analyze and detect indentation
    when you open a file (that isn't in a project with an editorconfig file).
    This isn't foolproof, and won't work for files that have no content in them,
    but it can help in one-off scenarios.
@@ -886,7 +886,7 @@ All that said, I take no steps to disable or cripple =Customize= in Doom
 to cause issues). If used sparingly, you may not even run into these issues.
 
 ** Why no =expand-region= for evil users (by default)?
-I believe [[doom-package:][expand-region]] is redundant with and less precise than evil's text
+I believe [[doom-package:expand-region]] is redundant with and less precise than evil's text
 objects and motions.
 
 - There's a text object for every "step" of expansion that expand-region
@@ -904,7 +904,7 @@ objects and motions.
   the surrounding brackets/parentheses, etc. There is no reverse of this
   however; you'd have to restart visual mode.
 
-The [[doom-package:][expand-region]] way dictates you start at some point and expand/contract until
+The [[doom-package:expand-region]] way dictates you start at some point and expand/contract until
 you have what you want selected. The vim/evil way would rather you select
 exactly what you want from the get go. In the rare event a text object fails
 you, a combination of [[kbd:][o]] (swaps your cursor between the two ends of the region)
@@ -921,7 +921,7 @@ editing paradigm. Vimmers will feel right at home. To everyone else: mastering
 them will have a far-reaching effect on your effectiveness in vim environments.
 I highly recommend putting in the time to learn them.
 
-That said, if you aren't convinced, it is trivial to install [[doom-package:][expand-region]] and
+That said, if you aren't convinced, it is trivial to install [[doom-package:expand-region]] and
 binds keys to it yourself:
 #+begin_src emacs-lisp
 ;;; in $DOOMDIR/packages.el
@@ -939,17 +939,17 @@ variables. This affects macOS users (all =Emacs.app= bundles launch Emacs in an
 isolated environment), Linux users who misconfigure their launchers to use the
 wrong shell, or Windows users who may have no shell environment at all.
 
-[[doom-package:][exec-path-from-shell]] was written to mitigate this, by polling the shell at
+[[doom-package:exec-path-from-shell]] was written to mitigate this, by polling the shell at
 startup for those environment variables. ~$ doom env~ was written as more
 reliable (and slightly faster) substitute. Here's why it's better:
 
-1. [[doom-package:][exec-path-from-shell]] must spawn (at least) one process at startup to scrape
+1. [[doom-package:exec-path-from-shell]] must spawn (at least) one process at startup to scrape
    your shell environment. This can be slow depending on the user's shell
    configuration and may fail on non-standard shells (like =fish=). A single
    program (like =pyenv= or =nvm=) or config framework (like =oh-my-zsh=) could
    all our startup optimizations in one fell swoop.
 
-2. [[doom-package:][exec-path-from-shell]] takes a whitelist approach and captures only =$PATH= and
+2. [[doom-package:exec-path-from-shell]] takes a whitelist approach and captures only =$PATH= and
    =$MANPATH= by default. You must be proactive in order to capture all the
    envvars relevant to your development environment and tools.
 
@@ -957,7 +957,7 @@ reliable (and slightly faster) substitute. Here's why it's better:
    environment. This front loads the debugging process, which is nicer than
    dealing with it later, while you're getting work done.
 
-That said, if you still want [[var:][exec-path-from-shell]], it is trivial to install
+That said, if you still want [[var:exec-path-from-shell]], it is trivial to install
 yourself:
 #+begin_src emacs-lisp
 ;;; in $DOOMDIR/packages.el
@@ -970,12 +970,12 @@ yourself:
 #+end_src
 
 ** Why =ws-butler= over =whitespace-cleanup= or =delete-trailing-whitespace=?
-I believe [[doom-package:][ws-butler]] is less imposing on teammates/project maintainers; it only
+I believe [[doom-package:ws-butler]] is less imposing on teammates/project maintainers; it only
 cleans up whitespace on the lines you've touched.
 
 You know the story: a PR with 99 whitespace adjustments around a one-line
-contribution. Why? Because they added [[fn:][delete-trailing-whitespace]] (or
-[[fn:][whitespace-cleanup]]) to [[var:][before-save-hook]], which mutates entire buffers.
+contribution. Why? Because they added [[fn:delete-trailing-whitespace]] (or
+[[fn:whitespace-cleanup]]) to [[var:before-save-hook]], which mutates entire buffers.
 
 Automated processes that mutate entire files (or worse, whole projects) should
 be deliberately invoked, and by someone privvy to the consequences, rather than

--- a/modules/README.org
+++ b/modules/README.org
@@ -38,7 +38,7 @@ setup instructions.
 ** [[doom-module::app][:app]] (6) :unfold:
 Application modules are complex and opinionated modules that transform Emacs
 toward a specific purpose. They may have additional dependencies and *should be
-loaded last* (but before [[doom-module:][:config]] modules).
+loaded last* (but before [[doom-module::config]] modules).
 
 *** [[doom-module::app calendar][calendar]]:                                                          -
 : Watch your missed deadlines in real time
@@ -87,7 +87,7 @@ For modules dedicated to linting plain text (primarily code and prose).
 : Tasing grammar mistake every you make
 
 This module adds grammar checking to Emacs to aid your writing by combining
-[[doom-package:][lang-tool]] and [[doom-package:][writegood-mode]].
+[[doom-package:lang-tool]] and [[doom-package:writegood-mode]].
 
 *** [[doom-module::checkers spell][spell]]:              [[doom-module::checkers spell +aspell][+aspell]] [[doom-module::checkers spell +enchant][+enchant]] [[doom-module::checkers spell +everywhere][+everywhere]] [[doom-module::checkers spell +flyspell][+flyspell]] [[doom-module::checkers spell +hunspell][+hunspell]]
 : Tasing you for misspelling mispelling
@@ -102,13 +102,13 @@ includes ~org-mode~, ~markdown-mode~, the Git Commit buffer (from magit),
 - Spell checking and correction using =aspell=, =hunspell= or =enchant=.
 - Ignores source code inside org or markdown files.
 - Lazily spellchecking recent changes only when idle.
-- Choosing suggestions using completion interfaces ([[doom-package:][ivy]] or [[doom-package:][helm]]).
+- Choosing suggestions using completion interfaces ([[doom-package:ivy]] or [[doom-package:helm]]).
 
 *** [[doom-module::checkers syntax][syntax]]:                                                  [[doom-module::checkers syntax +childframe][+childframe]]
 : Tasing you for every semicolon you forget
 
 This module provides syntax checking and error highlighting, powered by
-[[doom-package:][flycheck]].
+[[doom-package:flycheck]].
 
 
 ** [[doom-module::completion][:completion]] (5) :unfold:
@@ -119,7 +119,7 @@ completion.
 : The ultimate code completion backend
 
 This module provides code completion, powered by [[https://github.com/company-mode/company-mode][company-mode]]. Many of Doom's
-[[doom-module:][:lang]] modules require it for "intellisense" functionality.
+[[doom-module::lang]] modules require it for "intellisense" functionality.
 
 https://assets.doomemacs.org/completion/company/overlay.png
 
@@ -153,7 +153,7 @@ provides a united interface for project search and replace, powered by [[https:/
 
 It does this with several modular packages focused on enhancing the built-in
 ~completing-read~ interface, rather than replacing it with a parallel ecosystem
-like [[doom-package:][ivy]] and [[doom-package:][helm]] do. The primary packages are:
+like [[doom-package:ivy]] and [[doom-package:helm]] do. The primary packages are:
 
 - Vertico, which provides the vertical completion user interface
 - Consult, which provides a suite of useful commands using ~completing-read~
@@ -173,7 +173,7 @@ This module provides a set of reasonable defaults, including:
 
 - A Spacemacs-inspired keybinding scheme
 - A configuration for (almost) universally repeating searches with [[kbd:][;]] and [[kbd:][,]]
-- A [[doom-package:][smartparens]] configuration for smart completion of certain delimiters, like
+- A [[doom-package:smartparens]] configuration for smart completion of certain delimiters, like
   ~/* */~ command blocks in C-languages, ~<?php ?>~ tags in PHP, or ~def end~ in
   Ruby/Crystal/etc.
 
@@ -197,12 +197,12 @@ This holy module brings the Vim editing model to Emacs.
 *** [[doom-module::editor file-templates][file-templates]]:                                                    -
 : Fill the void in your empty files
 
-This module adds file templates for blank files, powered by [[doom-package:][yasnippet]].
+This module adds file templates for blank files, powered by [[doom-package:yasnippet]].
 
 *** [[doom-module::editor fold][fold]]:                                                              -
 : What you can't see won't hurt you
 
-This module marries [[doom-package:][hideshow]], [[doom-package:][vimish-fold]], and ~outline-minor-mode~ to bring you
+This module marries [[doom-package:hideshow]], [[doom-package:vimish-fold]], and ~outline-minor-mode~ to bring you
 marker, indent and syntax-based code folding for as many languages as possible.
 
 *** [[doom-module::editor format][format]]:                                                      [[doom-module::editor format +onsave][+onsave]]
@@ -222,7 +222,7 @@ rustfmt, scalafmt, script shfmt, snakefmt, sqlformat, styler, swiftformat, tidy
 *** [[doom-module::editor god][god]]:                                                               -
 : IDDQD
 
-Adds [[doom-package:][god-mode]] support to Doom Emacs, allowing for entering commands without
+Adds [[doom-package:god-mode]] support to Doom Emacs, allowing for entering commands without
 modifier keys, similar to Vim's modality, separating command mode and insert
 mode.
 
@@ -251,7 +251,7 @@ evil) that loosely take after multi-cursors in Atom or Sublime Text.
 *** [[doom-module::editor objed][objed]]:                                                       [[doom-module::editor objed +manual][+manual]]
 : Text object editing for the innocent
 
-This modules adds [[doom-package:][objed]], a global minor-mode for navigating and manipulating
+This modules adds [[doom-package:objed]], a global minor-mode for navigating and manipulating
 text objects. It combines the ideas of ~versor-mode~ and other editors like Vim
 or Kakoune and tries to align them with regular Emacs conventions.
 
@@ -274,12 +274,12 @@ keywords or text patterns at point, like ~true~ and ~false~, or ~public~,
 *** [[doom-module::editor snippets][snippets]]:                                                          -
 : My elves type so I don't have to
 
-This module adds snippet expansions to Emacs, powered by [[doom-package:][yasnippet]].
+This module adds snippet expansions to Emacs, powered by [[doom-package:yasnippet]].
 
 *** [[doom-module::editor word-wrap][word-wrap]]:                                                         -
 : Soft-wrapping with language-aware indent
 
-This module adds a minor-mode [[fn:][+word-wrap-mode]], which intelligently wraps long
+This module adds a minor-mode [[fn:+word-wrap-mode]], which intelligently wraps long
 lines in the buffer without modifying the buffer content.
 
 
@@ -294,13 +294,13 @@ This module provides reasonable defaults and augmentations for dired.
 *** [[doom-module::emacs electric][electric]]:                                                          -
 : Shocking keyword-based electric-indent
 
-This module augments the built-in [[doom-package:][electric]] package with keyword-based
+This module augments the built-in [[doom-package:electric]] package with keyword-based
 indentation (as opposed to character-based).
 
 *** [[doom-module::emacs ibuffer][ibuffer]]:                                                      [[doom-module::emacs ibuffer +icons][+icons]]
 : Edit me like one of your French buffers
 
-This module augments the built-in [[doom-package:][ibuffer]] package.
+This module augments the built-in [[doom-package:ibuffer]] package.
 
 - Adds project-based grouping of buffers
 - Support for file-type icons
@@ -330,15 +330,15 @@ Modules that turn Emacs in an email client.
 
 This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]].
 
-- Tidied mu4e headers view, with flags from [[doom-package:][all-the-icons]].
+- Tidied mu4e headers view, with flags from [[doom-package:all-the-icons]].
 - Consistent coloring of reply depths (across compose and gnus modes).
 - Prettified =mu4e:main= view.
 - Cooperative locking of the =mu= process. Another Emacs instance may request
   access, or grab the lock when it's available.
-- [[doom-package:][org-msg]] integration with [[doom-module:][+org]], which can be toggled per-message, with revamped
+- [[doom-package:org-msg]] integration with [[doom-module:+org]], which can be toggled per-message, with revamped
   style and an accent color.
-- Gmail integrations with the [[doom-module:][+gmail]] flag.
-- Email notifications with [[doom-package:][mu4e-alert]], and (on Linux) a customised notification
+- Gmail integrations with the [[doom-module:+gmail]] flag.
+- Email notifications with [[doom-package:mu4e-alert]], and (on Linux) a customised notification
   style.
 
 #+begin_quote
@@ -355,7 +355,7 @@ This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/cod
 *** [[doom-module::email notmuch][notmuch]]:                                                  [[doom-module::email notmuch +afew][+afew]] [[doom-module::email notmuch +org][+org]]
 : Closest Emacs will ever be to multi-threaded
 
-This module turns Emacs into an email client using [[doom-package:][notmuch]].
+This module turns Emacs into an email client using [[doom-package:notmuch]].
 
 *** [[doom-module::email wanderlust][wanderlust]]:                                                   [[doom-module::email wanderlust +gmail][+gmail]]
 : To boldly go where no mail has gone before
@@ -431,7 +431,7 @@ This module adds support for the Clojure(Script) language.
 *** [[doom-module::lang common-lisp][common-lisp]]:                                                       -
 : If you've seen one lisp, you've seen them all
 
-This module provides support for [[https://lisp-lang.org/][Common Lisp]] and the [[doom-package:][Sly]] development
+This module provides support for [[https://lisp-lang.org/][Common Lisp]] and the [[doom-package:Sly]] development
 environment. Common Lisp is not a single language but a specification, with many
 competing compiler implementations. By default, [[http://www.sbcl.org/][Steel Bank Common Lisp]] (SBCL) is
 assumed to be installed, but this can be configured.
@@ -489,7 +489,7 @@ functions + types + imports.
 *** [[doom-module::lang elixir][elixir]]:                                                         [[doom-module::lang elixir +lsp][+lsp]]
 : Erlang done right
 
-This module provides support for [[https://elixir-lang.org/][Elixir programming language]] via [[doom-package:][alchemist]] or
+This module provides support for [[https://elixir-lang.org/][Elixir programming language]] via [[doom-package:alchemist]] or
 [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]].
 
 *** [[doom-module::lang elm][elm]]:                                                            [[doom-module::lang elm +lsp][+lsp]]
@@ -505,7 +505,7 @@ This module extends support for Emacs Lisp in Doom Emacs.
 - Macro expansion
 - Go-to-definitions or references functionality
 - Syntax highlighting for defined and quoted symbols
-- Replaces the built-in help with the more powerful [[doom-package:][helpful]]
+- Replaces the built-in help with the more powerful [[doom-package:helpful]]
 - Adds function example uses to documentation
 
 *** [[doom-module::lang erlang][erlang]]:                                                         [[doom-module::lang erlang +lsp][+lsp]]
@@ -515,8 +515,8 @@ This module provides support [[https://www.erlang.org/][Erlang programming langu
 [[https://github.com/erlang/sourcer][sourcer]] language server is optional.
 
 Includes:
-- Code completion ([[doom-module:][+lsp]], [[doom-module:][:completion company]], & [[doom-module:][:completion ivy]])
-- Syntax checking ([[doom-module:][:checkers syntax]])
+- Code completion ([[doom-module:+lsp]], [[doom-module::completion company]], & [[doom-module::completion ivy]])
+- Syntax checking ([[doom-module::checkers syntax]])
 
 *** [[doom-module::lang ess][ess]]:                                                           [[doom-module::lang ess +stan][+stan]]
 : 73.6% of all statistics are made up
@@ -528,7 +528,7 @@ SAS, Julia and Stata.
 : ...
 
 This module adds support to the [[https://github.com/factor/factor][factor]] programming language and its associated
-[[doom-package:][fuel]] emacs plugin.
+[[doom-package:fuel]] emacs plugin.
 
 *** [[doom-module::lang faust][faust]]:                                                             -
 : DSP, but you can keep your soul
@@ -549,7 +549,7 @@ Add support to [[https://faust.grame.fr/][Faust language]] inside emacs.
   shortcuts, etc.)
 - Automatic keyword completion (if Auto-Complete is installed)
 - Automatic objets (functions, operators, etc.) template insertion with default
-  sensible values (if [[doom-module:][:editor snippets]] is enabled)
+  sensible values (if [[doom-module::editor snippets]] is enabled)
 - Modeline indicator of the state of the code
 
 *** [[doom-module::lang fsharp][fsharp]]:                                                         [[doom-module::lang fsharp +lsp][+lsp]]
@@ -584,7 +584,7 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
 - Eldoc support (~go-eldoc~)
 - REPL (~gore~)
 - Syntax-checking (~flycheck~)
-- Auto-formatting on save (~gofmt~) (requires [[doom-module:][:editor format +onsave]])
+- Auto-formatting on save (~gofmt~) (requires [[doom-module::editor format +onsave]])
 - Code navigation & refactoring (~go-guru~)
 - [[../../editor/file-templates/templates/go-mode][File templates]]
 - [[https://github.com/hlissner/doom-snippets/tree/master/go-mode][Snippets]]
@@ -617,13 +617,13 @@ This module adds [[https://www.java.com][Java]] support to Doom Emacs, including
 
 This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.typescriptlang.org/][TypeScript]] support to Doom Emacs.
 
-- Code completion ([[doom-package:][tide]])
-- REPL support ([[doom-package:][nodejs-repl]])
-- Refactoring commands ([[doom-package:][js2-refactor]])
-- Syntax checking ([[doom-package:][flycheck]])
-- Browser code injection with [[doom-package:][skewer-mode]]
+- Code completion ([[doom-package:tide]])
+- REPL support ([[doom-package:nodejs-repl]])
+- Refactoring commands ([[doom-package:js2-refactor]])
+- Syntax checking ([[doom-package:flycheck]])
+- Browser code injection with [[doom-package:skewer-mode]]
 - Coffeescript & JSX support
-- Jump-to-definitions and references support ([[doom-package:][xref]])
+- Jump-to-definitions and references support ([[doom-package:xref]])
 
 *** [[doom-module::lang json][json]]:                                                           [[doom-module::lang json +lsp][+lsp]]
 : At least it ain't XML
@@ -635,9 +635,9 @@ This module adds [[https://www.json.org/json-en.html][JSON]] support to Doom Ema
 
 This module adds support for [[https://julialang.org/][the Julia language]] to Doom Emacs.
 
-- Syntax highlighting and latex symbols from [[doom-package:][julia-mode]]
-- REPL integration from [[doom-package:][julia-repl]]
-- Code completion and syntax checking, requires [[doom-module:][:tools lsp]] and [[doom-module:][+lsp]]
+- Syntax highlighting and latex symbols from [[doom-package:julia-mode]]
+- REPL integration from [[doom-package:julia-repl]]
+- Code completion and syntax checking, requires [[doom-module::tools lsp]] and [[doom-module:+lsp]]
 
 *** [[doom-module::lang kotlin][kotlin]]:                                                         [[doom-module::lang kotlin +lsp][+lsp]]
 : A Java(Script) that won't depress you
@@ -651,11 +651,11 @@ Provide a helping hand when working with LaTeX documents.
 
 - Sane defaults
 - Fontification of many popular commands
-- Pretty indentation of wrapped lines using the [[doom-package:][adaptive-wrap]] package
-- Spell checking with [[doom-package:][flycheck]]
-- Change PDF viewer to Okular or [[doom-package:][latex-preview-pane]]
+- Pretty indentation of wrapped lines using the [[doom-package:adaptive-wrap]] package
+- Spell checking with [[doom-package:flycheck]]
+- Change PDF viewer to Okular or [[doom-package:latex-preview-pane]]
 - Bibtex editor
-- Autocompletion using [[doom-package:][company-mode]]
+- Autocompletion using [[doom-package:company-mode]]
 - Compile your =.tex= code only once using LatexMk
 
 *** [[doom-module::lang lean][lean]]:                                                              -
@@ -722,9 +722,9 @@ for Markdown's syntax is the format of plain text email. -- John Gruber
 
 This module adds [[https://nim-lang.org][Nim]] support to Doom Emacs.
 
-- Code completion ([[doom-package:][nimsuggest]] + [[doom-package:][company]])
-- Syntax checking ([[doom-package:][nimsuggest]] + [[doom-package:][flycheck]])
-- Org babel support ([[doom-package:][ob-nim]])
+- Code completion ([[doom-package:nimsuggest]] + [[doom-package:company]])
+- Syntax checking ([[doom-package:nimsuggest]] + [[doom-package:flycheck]])
+- Org babel support ([[doom-package:ob-nim]])
 
 *** [[doom-module::lang nix][nix]]:                                                               -
 : I hereby declare "nix geht mehr!"
@@ -734,23 +734,23 @@ for managing [[https://nixos.org/][Nix(OS)]].
 
 Includes:
 - Syntax highlighting
-- Completion through [[doom-package:][company]] and/or [[doom-package:][helm]]
+- Completion through [[doom-package:company]] and/or [[doom-package:helm]]
 - Nix option lookup
 - Formatting (~nixfmt~)
 
 *** [[doom-module::lang ocaml][ocaml]]:                                                          [[doom-module::lang ocaml +lsp][+lsp]]
 : An objective camel
 
-This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:][tuareg-mode]].
+This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:tuareg-mode]].
 
 - Code completion, documentation look-up, code navigation and refactoring
-  ([[doom-package:][merlin]])
-- Type, documentation and function argument display on idle ([[doom-package:][merlin-eldoc]])
-- REPL ([[doom-package:][utop]])
-- Syntax-checking ([[doom-package:][merlin]] with [[doom-package:][flycheck-ocaml]])
-- Auto-indentation ([[doom-package:][ocp-indent]])
-- Code formatting ([[doom-package:][ocamlformat]])
-- Dune file format ([[doom-package:][dune]])
+  ([[doom-package:merlin]])
+- Type, documentation and function argument display on idle ([[doom-package:merlin-eldoc]])
+- REPL ([[doom-package:utop]])
+- Syntax-checking ([[doom-package:merlin]] with [[doom-package:flycheck-ocaml]])
+- Auto-indentation ([[doom-package:ocp-indent]])
+- Code formatting ([[doom-package:ocamlformat]])
+- Dune file format ([[doom-package:dune]])
 
 *** [[doom-module::lang org][org]]: [[doom-module::lang org +brain][+brain]] [[doom-module::lang org +dragndrop][+dragndrop]] [[doom-module::lang org +gnuplot][+gnuplot]] [[doom-module::lang org +hugo][+hugo]] [[doom-module::lang org +ipython][+ipython]] [[doom-module::lang org +journal][+journal]] [[doom-module::lang org +jupyter][+jupyter]] [[doom-module::lang org +noter][+noter]] [[doom-module::lang org +pandoc][+pandoc]] [[doom-module::lang org +pomodoro][+pomodoro]] [[doom-module::lang org +present][+present]] [[doom-module::lang org +pretty][+pretty]] [[doom-module::lang org +roam][+roam]] [[doom-module::lang org +roam2][+roam2]]
 : Organize your plain life in plain text
@@ -769,7 +769,7 @@ intuitive out of the box:
 - A configuration for using org-mode for slide-show presentations or exporting
   org files to reveal.js slideshows.
 - Drag-and-drop support for images (with inline preview) and media files (drops
-  a file icon and a short link) (requires [[doom-module:][+dragndrop]] flag).
+  a file icon and a short link) (requires [[doom-module:+dragndrop]] flag).
 - Integration with pandoc, ipython, jupyter, reveal.js, beamer, and others
   (requires flags).
 - Export-to-clipboard functionality, for copying text into formatted html,
@@ -826,10 +826,10 @@ This module adds [[https://www.purescript.org/][Purescript]] support to Doom Ema
 
 This module adds [[https://www.python.org/][Python]] support to Doom Emacs.
 
-- Syntax checking ([[doom-package:][flycheck]])
+- Syntax checking ([[doom-package:flycheck]])
 - Snippets
-- Run tests ([[doom-package:][nose]], [[doom-package:][pytest]])
-- Auto-format (with ~black~, requires [[doom-module:][:editor format]])
+- Run tests ([[doom-package:nose]], [[doom-package:pytest]])
+- Auto-format (with ~black~, requires [[doom-module::editor format]])
 - LSP integration (=mspyls=, =pyls=, or =pyright=)
 
 *** [[doom-module::lang qt][qt]]:                                                                -
@@ -877,11 +877,11 @@ This module adds [[https://docutils.sourceforge.io/rst.html][ReStructured Text]]
 
 This module add Ruby and optional Ruby on Rails support to Emacs.
 
-- Code completion ([[doom-package:][robe]])
-- Syntax checking ([[doom-package:][flycheck]])
-- Jump-to-definitions ([[doom-package:][robe]])
+- Code completion ([[doom-package:robe]])
+- Syntax checking ([[doom-package:flycheck]])
+- Jump-to-definitions ([[doom-package:robe]])
 - Bundler
-- Rubocop integration ([[doom-package:][flycheck]])
+- Rubocop integration ([[doom-package:flycheck]])
 
 *** [[doom-module::lang rust][rust]]:                                                           [[doom-module::lang rust +lsp][+lsp]]
 : Fe2O3.unwrap().unwrap().unwrap().unwrap()
@@ -889,9 +889,9 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
 This module adds support for the Rust language and integration for its tools,
 e.g. ~cargo~.
 
-- Code completion ([[doom-package:][racer]] or an LSP server)
-- Syntax checking ([[doom-package:][flycheck]])
-- LSP support (for rust-analyzer and rls) ([[doom-package:][rustic]])
+- Code completion ([[doom-package:racer]] or an LSP server)
+- Syntax checking ([[doom-package:flycheck]])
+- LSP support (for rust-analyzer and rls) ([[doom-package:rustic]])
 - Snippets
 
 *** [[doom-module::lang scala][scala]]:                                                          [[doom-module::lang scala +lsp][+lsp]]
@@ -926,8 +926,8 @@ This module provides support for the Scheme family of Lisp languages, powered by
 This module adds support for shell scripting languages (including Powershell and
 Fish script) to Doom Emacs.
 
-- Code completion ([[doom-package:][company-shell]])
-- Syntax Checking ([[doom-package:][flycheck]])
+- Code completion ([[doom-package:company-shell]])
+- Syntax Checking ([[doom-package:flycheck]])
 
 *** [[doom-module::lang sml][sml]]:                                                               -
 : ...
@@ -939,8 +939,8 @@ THis module adds [[https://smlfamily.github.io/][SML (Standard ML) programming l
 
 This module adds [[https://github.com/ethereum/solidity][Solidity]] support to Doom Emacs.
 
-- Syntax-checking ([[doom-package:][flycheck]])
-- Code completion ([[doom-package:][company-solidity]])
+- Syntax-checking ([[doom-package:flycheck]])
+- Code completion ([[doom-package:company-solidity]])
 - Gas estimation (~C-c C-g~)
 
 *** [[doom-module::lang swift][swift]]:                                                          [[doom-module::lang swift +lsp][+lsp]]
@@ -972,7 +972,7 @@ This module adds [[https://ziglang.org/][Zig]] support, with optional (but recom
 [[https://github.com/zigtools/zls][zls]].
 
 - Syntax highlighting
-- Syntax-checking ([[doom-package:][flycheck]])
+- Syntax-checking ([[doom-package:flycheck]])
 - Code completion and LSP integration (~zls~)
 
 
@@ -1001,9 +1001,9 @@ This module configures Emacs for use in the terminal, by providing:
 What's an operating system without a terminal? The modules in this category
 bring varying degrees of terminal emulation into Emacs.
 
-If you can't decide which to choose, I recommend [[doom-package:][vterm]] or [[doom-package:][eshell]]. [[doom-module:][:term vterm]]
+If you can't decide which to choose, I recommend [[doom-package:vterm]] or [[doom-package:eshell]]. [[doom-module::term vterm]]
 offers that best terminal emulation available but requires a few extra steps to
-get going. [[doom-module:][:term eshell]] works everywhere that Emacs runs, even Windows, and
+get going. [[doom-module::term eshell]] works everywhere that Emacs runs, even Windows, and
 provides a shell entirely implemented in Emacs Lisp.
 
 *** [[doom-module::term eshell][eshell]]:                                                            -
@@ -1011,7 +1011,7 @@ provides a shell entirely implemented in Emacs Lisp.
 
 This module provides additional features for the built-in [[https://www.gnu.org/software/emacs/manual/html_mono/eshell.html][Emacs Shell]]
 
-The Emacs Shell or [[doom-package:][eshell]] is a shell-like command interpreter implemented in
+The Emacs Shell or [[doom-package:eshell]] is a shell-like command interpreter implemented in
 Emacs Lisp. It is an alternative to traditional shells such as =bash=, =zsh=,
 =fish=, etc. that is built into Emacs and entirely cross-platform.
 
@@ -1022,8 +1022,8 @@ Provides a REPL for your shell.
 
 #+begin_quote
  💡 =shell= is more REPL than terminal emulator. You can edit your command line
-    like you would any ordinary text in Emacs -- something you can't do in [[doom-package:][term]]
-    (without ~term-line-mode~, which can be unstable) or [[doom-package:][vterm]].
+    like you would any ordinary text in Emacs -- something you can't do in [[doom-package:term]]
+    (without ~term-line-mode~, which can be unstable) or [[doom-package:vterm]].
 
     Due to =shell='s simplicity, you're less likely to encounter edge cases
     (e.g. against your shell config), but it's also the least capable. TUI
@@ -1043,7 +1043,7 @@ This module provides a terminal emulator powered by libvterm. It is still in
 alpha and requires a component be compiled (=vterm-module.so=).
 
 #+begin_quote
- 💡 [[doom-package:][vterm]] is as good as terminal emulation gets in Emacs (at the time of
+ 💡 [[doom-package:vterm]] is as good as terminal emulation gets in Emacs (at the time of
     writing) and the most performant, as it is implemented in C. However, it
     requires extra steps to set up:
 
@@ -1051,9 +1051,9 @@ alpha and requires a component be compiled (=vterm-module.so=).
     - and =vterm-module.so= must be compiled, which depends on =libvterm=,
       =cmake=, and =libtool-bin=.
 
-    [[doom-package:][vterm]] will try to automatically build =vterm-module.so= when you first open
+    [[doom-package:vterm]] will try to automatically build =vterm-module.so= when you first open
     it, but this will fail on Windows, NixOS and Guix out of the box. Install
-    instructions for nix/guix can be found in the [[doom-module:][:term vterm]] module's
+    instructions for nix/guix can be found in the [[doom-module::term vterm]] module's
     documentation. There is no way to install vterm on Windows that I'm aware of
     (but perhaps with WSL?).
 #+end_quote
@@ -1073,9 +1073,9 @@ Modules that integrate external tools into Emacs.
 *** [[doom-module::tools debugger][debugger]]:                                                       [[doom-module::tools debugger +lsp][+lsp]]
 : Step through code to help you add bugs
 
-Introduces a code debugger to Emacs, powered by [[doom-package:][realgud]] or [[doom-package:][dap-mode]] (LSP).
+Introduces a code debugger to Emacs, powered by [[doom-package:realgud]] or [[doom-package:dap-mode]] (LSP).
 
-This document will help you to configure [[doom-package:][dap-mode]] [[https://emacs-lsp.github.io/dap-mode/page/configuration/#native-debug-gdblldb][Native Debug(GDB/LLDB)]] as
+This document will help you to configure [[doom-package:dap-mode]] [[https://emacs-lsp.github.io/dap-mode/page/configuration/#native-debug-gdblldb][Native Debug(GDB/LLDB)]] as
 there is still not *enough* documentation for it.
 
 *** [[doom-module::tools direnv][direnv]]:                                                            -
@@ -1104,7 +1104,7 @@ Emacs.
 Provides a major ~dockerfile-mode~ to edit =Dockerfiles=. Additional convenience
 functions allow images to be built easily.
 
-[[doom-package:][docker-tramp]] offers [[https://www.gnu.org/software/tramp/][TRAMP]] support for Docker containers.
+[[doom-package:docker-tramp]] offers [[https://www.gnu.org/software/tramp/][TRAMP]] support for Docker containers.
 
 *** [[doom-module::tools editorconfig][editorconfig]]:                                                      -
 : Let someone else argue tabs and spaces
@@ -1148,33 +1148,33 @@ or synonyms.
 
 This module integrates [[https://langserver.org/][language servers]] into Doom Emacs. They provide features
 you'd expect from IDEs, like code completion, realtime linting, language-aware
-[[doom-package:][imenu]]/[[doom-package:][xref]] integration, jump-to-definition/references support, and more.
+[[doom-package:imenu]]/[[doom-package:xref]] integration, jump-to-definition/references support, and more.
 
 As of this writing, this is the state of LSP support in Doom Emacs:
 
 | Module           | Major modes                                             | Default language server                                       |
 |------------------+---------------------------------------------------------+---------------------------------------------------------------|
-| [[doom-module:][:lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls, clangd                                                  |
-| [[doom-module:][:lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
-| [[doom-module:][:lang csharp]]     | csharp-mode                                             | omnisharp                                                     |
-| [[doom-module:][:lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
-| [[doom-module:][:lang fsharp]]     | fsharp-mode                                             | Mono, .NET core                                               |
-| [[doom-module:][:lang go]]         | go-mode                                                 | go-langserver                                                 |
-| [[doom-module:][:lang haskell]]    | haskell-mode                                            | haskell-language-server                                       |
-| [[doom-module:][:lang java]]       | java-mode                                               | lsp-java                                                      |
-| [[doom-module:][:lang javascript]] | js2-mode, rjsx-mode, typescript-mode                    | ts-ls, deno-ls                                                |
-| [[doom-module:][:lang julia]]      | julia-mode                                              | LanguageServer.jl                                             |
-| [[doom-module:][:lang ocaml]]      | tuareg-mode                                             | ocaml-language-server                                         |
-| [[doom-module:][:lang php]]        | php-mode                                                | php-language-server                                           |
-| [[doom-module:][:lang purescript]] | purescript-mode                                         | purescript-language-server                                    |
-| [[doom-module:][:lang python]]     | python-mode                                             | lsp-python-ms                                                 |
-| [[doom-module:][:lang ruby]]       | ruby-mode                                               | solargraph                                                    |
-| [[doom-module:][:lang rust]]       | rust-mode                                               | rls                                                           |
-| [[doom-module:][:lang scala]]      | scala-mode                                              | metals                                                        |
-| [[doom-module:][:lang sh]]         | sh-mode                                                 | bash-language-server                                          |
-| [[doom-module:][:lang swift]]      | swift-mode                                              | sourcekit                                                     |
-| [[doom-module:][:lang web]]        | web-mode, css-mode, scss-mode, sass-mode, less-css-mode | vscode-css-languageserver-bin, vscode-html-languageserver-bin |
-| [[doom-module:][:lang zig]]        | zig-mode                                                | zls                                                           |
+| [[doom-module::lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls, clangd                                                  |
+| [[doom-module::lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
+| [[doom-module::lang csharp]]     | csharp-mode                                             | omnisharp                                                     |
+| [[doom-module::lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
+| [[doom-module::lang fsharp]]     | fsharp-mode                                             | Mono, .NET core                                               |
+| [[doom-module::lang go]]         | go-mode                                                 | go-langserver                                                 |
+| [[doom-module::lang haskell]]    | haskell-mode                                            | haskell-language-server                                       |
+| [[doom-module::lang java]]       | java-mode                                               | lsp-java                                                      |
+| [[doom-module::lang javascript]] | js2-mode, rjsx-mode, typescript-mode                    | ts-ls, deno-ls                                                |
+| [[doom-module::lang julia]]      | julia-mode                                              | LanguageServer.jl                                             |
+| [[doom-module::lang ocaml]]      | tuareg-mode                                             | ocaml-language-server                                         |
+| [[doom-module::lang php]]        | php-mode                                                | php-language-server                                           |
+| [[doom-module::lang purescript]] | purescript-mode                                         | purescript-language-server                                    |
+| [[doom-module::lang python]]     | python-mode                                             | lsp-python-ms                                                 |
+| [[doom-module::lang ruby]]       | ruby-mode                                               | solargraph                                                    |
+| [[doom-module::lang rust]]       | rust-mode                                               | rls                                                           |
+| [[doom-module::lang scala]]      | scala-mode                                              | metals                                                        |
+| [[doom-module::lang sh]]         | sh-mode                                                 | bash-language-server                                          |
+| [[doom-module::lang swift]]      | swift-mode                                              | sourcekit                                                     |
+| [[doom-module::lang web]]        | web-mode, css-mode, scss-mode, sass-mode, less-css-mode | vscode-css-languageserver-bin, vscode-html-languageserver-bin |
+| [[doom-module::lang zig]]        | zig-mode                                                | zls                                                           |
 
 *** [[doom-module::tools magit][magit]]:                                                        [[doom-module::tools magit +forge][+forge]]
 : Wield git like a wizard
@@ -1197,12 +1197,12 @@ This module provides an Emacs interface to [[https://www.passwordstore.org/][Pas
 This module improves support for reading and interacting with PDF files in
 Emacs.
 
-It uses [[doom-package:][pdf-tools]], which is a replacement for the built-in ~doc-view-mode~ for
+It uses [[doom-package:pdf-tools]], which is a replacement for the built-in ~doc-view-mode~ for
 PDF files. The key difference being pages are not pre-rendered, but instead
 rendered on-demand and stored in memory; a much faster approach, especially for
 larger PDFs.
 
-Displaying PDF files is just one function of [[doom-package:][pdf-tools]]. See [[https://github.com/politza/pdf-tools][its project website]]
+Displaying PDF files is just one function of [[doom-package:pdf-tools]]. See [[https://github.com/politza/pdf-tools][its project website]]
 for details and videos.
 
 *** [[doom-module::tools prodigy][prodigy]]:                                                           -
@@ -1220,7 +1220,7 @@ to easily modify color values or formats.
 *** [[doom-module::tools taskrunner][taskrunner]]:                                                        -
 : Taskrunner for all your projects
 
-This module integrates [[doom-package:][taskrunner]] into Doom Emacs, which scraps runnable tasks
+This module integrates [[doom-package:taskrunner]] into Doom Emacs, which scraps runnable tasks
 from build systems like make, gradle, npm and the like.
 
 *** [[doom-module::tools terraform][terraform]]:                                                         -
@@ -1263,11 +1263,11 @@ quickly jot down thoughts and easily retrieve them later.
 : Make Doom fabulous again
 
 This module gives Doom its signature look: powered by the [[doom-package:doom-themes][doom-one]] theme
-(loosely inspired by [[https://github.com/atom/one-dark-syntax][Atom's One Dark theme]]) and [[doom-package:][solaire-mode]]. Includes:
+(loosely inspired by [[https://github.com/atom/one-dark-syntax][Atom's One Dark theme]]) and [[doom-package:solaire-mode]]. Includes:
 
-- A custom folded-region indicator for [[doom-package:][hideshow]].
-- "Thin bar" fringe bitmaps for [[doom-package:][git-gutter-fringe]].
-- File-visiting buffers are slightly brighter (thanks to [[doom-package:][solaire-mode]]).
+- A custom folded-region indicator for [[doom-package:hideshow]].
+- "Thin bar" fringe bitmaps for [[doom-package:git-gutter-fringe]].
+- File-visiting buffers are slightly brighter (thanks to [[doom-package:solaire-mode]]).
 
 *** [[doom-module::ui doom-dashboard][doom-dashboard]]:                                                    -
 : Welcome to your doom
@@ -1341,7 +1341,7 @@ feature found in many other editors.
 : Snazzy, Atom-inspired modeline, plus API
 
 This module provides an Atom-inspired, minimalistic modeline for Doom Emacs,
-powered by the [[doom-package:][doom-modeline]] package (where you can find screenshots).
+powered by the [[doom-package:doom-modeline]] package (where you can find screenshots).
 
 *** [[doom-module::ui nav-flash][nav-flash]]:                                                         -
 : Blink after big motions
@@ -1360,7 +1360,7 @@ This module brings a side panel for browsing project files, inspired by vim's
 NERDTree.
 
 #+begin_quote
- 💡 Sure, there's [[doom-package:][dired]] and [[doom-package:][projectile]], but sometimes I'd like a bird's eye view
+ 💡 Sure, there's [[doom-package:dired]] and [[doom-package:projectile]], but sometimes I'd like a bird's eye view
     of a project.
 #+end_quote
 
@@ -1371,7 +1371,7 @@ This module provides op-hints (operation hinting), i.e. visual feedback for
 certain operations. It highlights regions of text that the last operation (like
 yank) acted on.
 
-Uses [[doom-package:][evil-goggles]] for evil users and [[doom-package:][volatile-highlights]] otherwise.
+Uses [[doom-package:evil-goggles]] for evil users and [[doom-package:volatile-highlights]] otherwise.
 
 *** [[doom-module::ui popup][popup]]:                                                [[doom-module::ui popup +all][+all]] [[doom-module::ui popup +defaults][+defaults]]
 : Tame sudden yet inevitable temporary windows
@@ -1401,9 +1401,9 @@ system outlines of your projects in a simple tree layout allowing quick
 navigation and exploration, while also possessing basic file management
 utilities. It includes:
 
-- Integration with Git (if [[doom-module:][:tools magit]] is enabled)
-- Integration with Evil (if [[doom-module:][:editor evil +everywhere]] is enabled)
-- Workspace awareness (if [[doom-module:][:ui workspaces]] is enabled)
+- Integration with Git (if [[doom-module::tools magit]] is enabled)
+- Integration with Evil (if [[doom-module::editor evil +everywhere]] is enabled)
+- Workspace awareness (if [[doom-module::ui workspaces]] is enabled)
 
 *** [[doom-module::ui unicode][unicode]]:                                                           -
 : Extended unicode support for various languages
@@ -1443,18 +1443,18 @@ Displays a tilde(~) in the left fringe to indicate an empty line, similar to Vi.
 This module provides several methods for selecting windows without the use of
 the mouse or spatial navigation (e.g. [[kbd:][C-w {h,j,k,l}]]).
 
-The command ~other-window~ is remapped to either [[doom-package:][switch-window]] or [[doom-package:][ace-window]],
+The command ~other-window~ is remapped to either [[doom-package:switch-window]] or [[doom-package:ace-window]],
 depending on which backend you've enabled. It is bound to [[kbd:][C-x o]] (and [[kbd:][C-w C-w]] for
 evil users).
 
-It also provides numbered windows and selection with the [[doom-package:][winum]] package, if
+It also provides numbered windows and selection with the [[doom-package:winum]] package, if
 desired. Evil users can jump to window N in [[kbd:][C-w <N>]] (where N is a number between
 0 and 9). Non evil users have [[kbd:][C-x w <N>]] instead.
 
 *** [[doom-module::ui workspaces][workspaces]]:                                                        -
 : Tab emulation, persistence, & separate workspaces
 
-This module adds support for workspaces, powered by [[doom-package:][persp-mode]], as well as a API
+This module adds support for workspaces, powered by [[doom-package:persp-mode]], as well as a API
 for manipulating them.
 
 #+begin_quote
@@ -1471,7 +1471,7 @@ for manipulating them.
 
 This module provides two minor modes that make Emacs into a more comfortable
 writing or coding environment. Folks familiar with "distraction-free" or "zen"
-modes from other editors -- or [[doom-package:][olivetti]], [[doom-package:][sublimity]], and [[doom-package:][tabula-rasa]] (Emacs
+modes from other editors -- or [[doom-package:olivetti]], [[doom-package:sublimity]], and [[doom-package:tabula-rasa]] (Emacs
 plugins) -- will feel right at home.
 
 These modes are:

--- a/modules/app/README.org
+++ b/modules/app/README.org
@@ -5,7 +5,7 @@
 * Description
 Application modules are complex and opinionated modules that transform Emacs
 toward a specific purpose. They may have additional dependencies and *should be
-loaded last* (but before [[doom-module:][:config]] modules).
+loaded last* (but before [[doom-module::config]] modules).
 
 * Frequently asked questions
 /This category has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]

--- a/modules/app/calendar/README.org
+++ b/modules/app/calendar/README.org
@@ -14,9 +14,9 @@ support.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][calfw]]
-- [[doom-package:][calfw-org]]
-- [[doom-package:][org-gcal]]
+- [[doom-package:calfw]]
+- [[doom-package:calfw-org]]
+- [[doom-package:org-gcal]]
   
 ** Hacks
 /No hacks documented for this module./
@@ -30,7 +30,7 @@ support.
 
 This module requires:
 - A Google Calendar account.
-- [[https://github.com/kidd/org-gcal.el#installation][An OAuth client ID]], for syncing said account with [[doom-package:][org-gcal]].
+- [[https://github.com/kidd/org-gcal.el#installation][An OAuth client ID]], for syncing said account with [[doom-package:org-gcal]].
 
 * TODO Usage
 #+begin_quote

--- a/modules/app/emms/README.org
+++ b/modules/app/emms/README.org
@@ -14,7 +14,7 @@ server and [[https://musicpd.org/clients/mpc/][mpc]] to update your music databa
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][emms]]
+- [[doom-package:emms]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/app/everywhere/README.org
+++ b/modules/app/everywhere/README.org
@@ -15,7 +15,7 @@ This module adds system-wide popup Emacs windows for quick edits.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][emacs-everywhere]]
+- [[doom-package:emacs-everywhere]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -49,7 +49,7 @@ return to the original window and paste the content with [[kbd:][C-c C-c]] or [[
 exit without pasting, use [[kbd:][C-c C-k]].
 
 * Configuration
-[[doom-package:][emacs-everywhere]] likes to guess if you triggered it from an application which
+[[doom-package:emacs-everywhere]] likes to guess if you triggered it from an application which
 supports markdown. Configure ~emacs-everywhere-markdown-windows~ and
 ~emacs-everywhere-markdown-apps~ to improve how accurate this is on your system.
 

--- a/modules/app/irc/README.org
+++ b/modules/app/irc/README.org
@@ -13,8 +13,8 @@ This module turns Emacs into an IRC client, capable of OS notifications.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][circe]]
-- [[doom-package:][circe-notifications]]
+- [[doom-package:circe]]
+- [[doom-package:circe-notifications]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -96,7 +96,7 @@ here are ways to avoid that:
 #+end_quote
 
 [[https://www.passwordstore.org/][Pass]] is my tool of choice. I use it to manage my passwords. If you activate the
-[[doom-module:][:tools pass]] module you get an elisp API through which to access your password
+[[doom-module::tools pass]] module you get an elisp API through which to access your password
 store.
 
 ~set-irc-server!~ accepts a plist can use functions instead of strings.

--- a/modules/app/rss/README.org
+++ b/modules/app/rss/README.org
@@ -11,13 +11,13 @@ Read RSS feeds in the comfort of Emacs.
 
 ** Module flags
 - +org ::
-  Enable [[doom-package:][elfeed-org]], so you can configure your feeds with an org file
+  Enable [[doom-package:elfeed-org]], so you can configure your feeds with an org file
   (={org-directory}/elfeed.org=) rather than Elisp.
 
 ** Packages
-- [[doom-package:][elfeed]]
-- [[doom-package:][elfeed-goodies]]
-- [[doom-package:][elfeed-org]] if [[doom-module:][+org]]
+- [[doom-package:elfeed]]
+- [[doom-package:elfeed-goodies]]
+- [[doom-package:elfeed-org]] if [[doom-module:+org]]
 
 ** Hacks
 - By default ~elfeed-search-filter~ is set to ~@2-weeks-ago~ and makes the last

--- a/modules/app/twitter/README.org
+++ b/modules/app/twitter/README.org
@@ -20,8 +20,8 @@ Enjoy twitter from emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][avy]]
-- [[doom-package:][twittering-mode]]
+- [[doom-package:avy]]
+- [[doom-package:twittering-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -64,7 +64,7 @@ Here is a list of available commands and their default keybindings (defined in
 | ~+twitter/quit~     | [[kbd:][q]]                | Close current window                                        |
 | ~+twitter/quit-all~ | [[kbd:][Q]]                | Close all twitter windows and buffers, and delete workspace |
 
-And when [[doom-module:][:editor evil +everywhere]] is active:
+And when [[doom-module::editor evil +everywhere]] is active:
 | command                                          | key / ex command | description                                                      |
 |--------------------------------------------------+------------------+------------------------------------------------------------------|
 | ~twittering-favorite~                            | [[kbd:][f]]                | Favorite/Like a tweet                                            |

--- a/modules/checkers/grammar/README.org
+++ b/modules/checkers/grammar/README.org
@@ -5,7 +5,7 @@
 
 * Description :unfold:
 This module adds grammar checking to Emacs to aid your writing by combining
-[[doom-package:][lang-tool]] and [[doom-package:][writegood-mode]].
+[[doom-package:lang-tool]] and [[doom-package:writegood-mode]].
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -14,8 +14,8 @@ This module adds grammar checking to Emacs to aid your writing by combining
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][langtool]]
-- [[doom-package:][writegood-mode]]
+- [[doom-package:langtool]]
+- [[doom-package:writegood-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/checkers/spell/README.org
+++ b/modules/checkers/spell/README.org
@@ -14,7 +14,7 @@ includes ~org-mode~, ~markdown-mode~, the Git Commit buffer (from magit),
 - Spell checking and correction using =aspell=, =hunspell= or =enchant=.
 - Ignores source code inside org or markdown files.
 - Lazily spellchecking recent changes only when idle.
-- Choosing suggestions using completion interfaces ([[doom-package:][ivy]] or [[doom-package:][helm]]).
+- Choosing suggestions using completion interfaces ([[doom-package:ivy]] or [[doom-package:helm]]).
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -27,21 +27,21 @@ includes ~org-mode~, ~markdown-mode~, the Git Commit buffer (from magit),
 - +everywhere ::
   Spell check in programming modes as well (in comments only).
 - +flyspell ::
-  Use [[doom-package:][flyspell]] instead of [[doom-package:][spell-fu]]. It's significantly slower, but supports
+  Use [[doom-package:flyspell]] instead of [[doom-package:spell-fu]]. It's significantly slower, but supports
   multiple languages and dictionaries.
 - +hunspell ::
   Use =hunspell= as a backend for correcting words.
 
 ** Packages
-- if [[doom-module:][+flyspell]]
-  - [[doom-package:][flyspell-correct]]
-  - [[doom-package:][flyspell-correct-ivy]] if [[doom-module:][:completion ivy]]
-  - [[doom-package:][flyspell-correct-helm]] if [[doom-module:][:completion helm]]
-  - [[doom-package:][flyspell-correct-popup]] unless [[doom-module:][:completion ivy]], [[doom-module:][:completion helm]], or
-    [[doom-module:][:completion vertico]]
-  - [[doom-package:][flyspell-lazy]]
+- if [[doom-module:+flyspell]]
+  - [[doom-package:flyspell-correct]]
+  - [[doom-package:flyspell-correct-ivy]] if [[doom-module::completion ivy]]
+  - [[doom-package:flyspell-correct-helm]] if [[doom-module::completion helm]]
+  - [[doom-package:flyspell-correct-popup]] unless [[doom-module::completion ivy]], [[doom-module::completion helm]], or
+    [[doom-module::completion vertico]]
+  - [[doom-package:flyspell-lazy]]
 - else
-  - [[doom-package:][spell-fu]]
+  - [[doom-package:spell-fu]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -58,9 +58,9 @@ your system and in your =$PATH=. They also need dictionaries for your
 language(s).
 
 #+begin_quote
- 🚧 If you *are not* using [[doom-module:][+flyspell]], you will need =aspell= (and a dictionary)
-    installed whether or not you have [[doom-module:][+hunspell]] or [[doom-module:][+enchant]] enabled. This is
-    because [[doom-package:][spell-fu]] does not support generating the word list with anything
+ 🚧 If you *are not* using [[doom-module:+flyspell]], you will need =aspell= (and a dictionary)
+    installed whether or not you have [[doom-module:+hunspell]] or [[doom-module:+enchant]] enabled. This is
+    because [[doom-package:spell-fu]] does not support generating the word list with anything
     other than =aspell= yet.
 #+end_quote
 
@@ -111,7 +111,7 @@ language(s).
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-When using [[doom-module:][+everywhere]], spell checking is performed for as many major modes as
+When using [[doom-module:+everywhere]], spell checking is performed for as many major modes as
 possible, and not only ~text-mode~ derivatives. e.g. in comments for programming
 major modes.
 
@@ -133,7 +133,7 @@ recent changes:
 #+end_src
 
 *** Flyspell users
-Lazy spellcheck is provided by [[doom-package:][flyspell-lazy]] package.
+Lazy spellcheck is provided by [[doom-package:flyspell-lazy]] package.
 
 ~flyspell-lazy-idle-seconds~ sets how many idle seconds until spellchecking
 recent changes (default as 1), while ~flyspell-lazy-window-idle-seconds~ sets
@@ -193,15 +193,15 @@ Return nil if on a link url, markup, html, or references."
 ** Adding or removing words to your personal dictionary
 Use ~M-x +spell/add-word~ and ~M-x +spell/remove-word~ to whitelist words that
 you know are not misspellings. For evil users these are bound to [[kbd:][zg]] and [[kbd:][zw]],
-respectively. [[doom-module:][+flyspell]] users can also add/remove words from the
-[[doom-package:][flyspell-correct]] popup interface (there will be extra options on the list of
+respectively. [[doom-module:+flyspell]] users can also add/remove words from the
+[[doom-package:flyspell-correct]] popup interface (there will be extra options on the list of
 corrections for "save word to dictionary").
 
 * Troubleshooting
 [[doom-report:][Report an issue?]]
 
 ** spell-fu highlights every single word
-[[doom-package:][spell-fu]] caches its word list. If it was activated before your dictionaries were
+[[doom-package:spell-fu]] caches its word list. If it was activated before your dictionaries were
 installed, it will generate an empty word list, causing it to highlight all
 words as incorrect. Delete its cache files in =$EMACSDIR/.local/etc/spell-fu/=
 to fix this.

--- a/modules/checkers/syntax/README.org
+++ b/modules/checkers/syntax/README.org
@@ -5,7 +5,7 @@
 
 * Description :unfold:
 This module provides syntax checking and error highlighting, powered by
-[[doom-package:][flycheck]].
+[[doom-package:flycheck]].
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -16,9 +16,9 @@ This module provides syntax checking and error highlighting, powered by
   *Requires GUI Emacs.*
 
 ** Packages
-- [[doom-package:][flycheck]]
-- [[doom-package:][flycheck-popup-tip]]
-- [[doom-package:][flycheck-posframe]] if [[doom-module:][+childframe]]
+- [[doom-package:flycheck]]
+- [[doom-package:flycheck-popup-tip]]
+- [[doom-package:flycheck-posframe]] if [[doom-module:+childframe]]
 
 ** Hacks
 - If ~lsp-ui-mode~ is active, most of the aesthetic functionality of this module

--- a/modules/completion/company/README.org
+++ b/modules/completion/company/README.org
@@ -5,7 +5,7 @@
 
 * Description :unfold:
 This module provides code completion, powered by [[https://github.com/company-mode/company-mode][company-mode]]. Many of Doom's
-[[doom-module:][:lang]] modules require it for "intellisense" functionality.
+[[doom-module::lang]] modules require it for "intellisense" functionality.
 
 https://assets.doomemacs.org/completion/company/overlay.png
 
@@ -23,9 +23,9 @@ https://assets.doomemacs.org/completion/company/overlay.png
   [[kbd:][S-TAB]] will navigate the completion candidates.
 
 ** Packages
-- [[doom-package:][company-box]] if [[doom-module:][+childframe]]
-- [[doom-package:][company-dict]]
-- [[doom-package:][company-mode]]
+- [[doom-package:company-box]] if [[doom-module:+childframe]]
+- [[doom-package:company-dict]]
+- [[doom-package:company-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/completion/helm/README.org
+++ b/modules/completion/helm/README.org
@@ -18,21 +18,21 @@ as a unified interface for project search and replace, powered by [[https://gith
   Enable fuzzy completion for Helm searches.
 - +icons ::
   Display icons on completion results (where possible) using either
-  [[doom-package:][all-the-icons]] or [[doom-package:][treemacs]] iconsets.
+  [[doom-package:all-the-icons]] or [[doom-package:treemacs]] iconsets.
 
 ** Packages
-- [[doom-package:][helm]]
-- [[doom-package:][helm-company]]
-- [[doom-package:][helm-c-yasnippet]]
-- [[doom-package:][helm-descbinds]]
-- [[doom-package:][helm-describe-modes]]
-- [[doom-package:][helm-flx]]* if [[doom-module:][+fuzzy]]
-- [[doom-package:][helm-icons]]* if [[doom-module:][+icons]]
-- [[doom-package:][helm-org]]* if [[doom-module:][:lang org]]
-- [[doom-package:][helm-posframe]]* if [[doom-module:][+childframe]]
-- [[doom-package:][helm-projectile]]
-- [[doom-package:][helm-rg]]
-- [[doom-package:][helm-swiper]]
+- [[doom-package:helm]]
+- [[doom-package:helm-company]]
+- [[doom-package:helm-c-yasnippet]]
+- [[doom-package:helm-descbinds]]
+- [[doom-package:helm-describe-modes]]
+- [[doom-package:helm-flx]]* if [[doom-module:+fuzzy]]
+- [[doom-package:helm-icons]]* if [[doom-module:+icons]]
+- [[doom-package:helm-org]]* if [[doom-module::lang org]]
+- [[doom-package:helm-posframe]]* if [[doom-module:+childframe]]
+- [[doom-package:helm-projectile]]
+- [[doom-package:helm-rg]]
+- [[doom-package:helm-swiper]]
 
 ** TODO Hacks
 #+begin_quote
@@ -59,13 +59,13 @@ Helm command or plugin.
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-Much like [[doom-package:][ivy]] and [[doom-package:][vertico]], [[doom-package:][helm]] is a /large/ framework. Covering all its
+Much like [[doom-package:ivy]] and [[doom-package:vertico]], [[doom-package:helm]] is a /large/ framework. Covering all its
 features is not within the scope of this module's documentation, so only its
 highlights will be covered here.
 
 ** Jump-to navigation
 Similar to Ivy, this module provides an interface to navigate within a project
-using [[doom-package:][projectile]]:
+using [[doom-package:projectile]]:
 | Keybind          | Description                         |
 |------------------+-------------------------------------|
 | [[kbd:][SPC p f]], [[kbd:][SPC SPC]] | Jump to file in project             |
@@ -109,7 +109,7 @@ Changes to the resulting wgrep buffer (opened by [[kbd:][C-c C-e]]) can be commi
 [[kbd:][C-c C-c]] and aborted with [[kbd:][C-c C-k]] (alternatively [[kbd:][ZZ]] and [[kbd:][ZQ]], for evil users).
 
 ** In-buffer searching
-The [[doom-package:][swiper]] package provides an interactive buffer search powered by helm. It can
+The [[doom-package:swiper]] package provides an interactive buffer search powered by helm. It can
 be invoked with:
 - [[kbd:][SPC s s]] (~swiper-isearch~)
 - [[kbd:][SPC s S]] (~swiper-isearch-thing-at-point~)
@@ -156,8 +156,8 @@ Helm also has a number of overrides for built-in functionality:
 #+end_quote
 
 ** Icons
-Icon support is now included, through one of two providers: [[doom-package:][all-the-icons]] and
-[[doom-package:][treemacs]]. By default, to maintain consistency we use [[doom-package:][all-the-icons]]; however if
+Icon support is now included, through one of two providers: [[doom-package:all-the-icons]] and
+[[doom-package:treemacs]]. By default, to maintain consistency we use [[doom-package:all-the-icons]]; however if
 you wish to modify this you can do so using the below snippet:
 
 #+begin_src emacs-lisp

--- a/modules/completion/ido/README.org
+++ b/modules/completion/ido/README.org
@@ -13,11 +13,11 @@ Interactive DO things. The completion engine that is /mostly/ built-into Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][crm-custom]]
-- [[doom-package:][flx-ido]]
-- [[doom-package:][ido-completing-read+]]
-- [[doom-package:][ido-sort-mtime]]
-- [[doom-package:][ido-vertical-mode]]
+- [[doom-package:crm-custom]]
+- [[doom-package:flx-ido]]
+- [[doom-package:ido-completing-read+]]
+- [[doom-package:ido-sort-mtime]]
+- [[doom-package:ido-vertical-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -27,18 +27,18 @@ lighter, simpler and faster in many cases.
   Enable prescient filtering and sorting for Ivy searches.
 
 ** Packages
-- [[doom-package:][all-the-icons-ivy]]* if [[doom-module:][+icons]]
-- [[doom-package:][amx]]
-- [[doom-package:][counsel]]
-- [[doom-package:][counsel-projectile]]
-- [[doom-package:][flx]]* if [[doom-module:][+fuzzy]]
-- [[doom-package:][ivy]]
-- [[doom-package:][ivy-hydra]]
-- [[doom-package:][ivy-posframe]]* if [[doom-module:][+childframe]]
-- [[doom-package:][ivy-rich]]
-- [[doom-package:][prescient]]* if [[doom-module:][+prescient]]
-- [[doom-package:][swiper]]
-- [[doom-package:][wgrep]]
+- [[doom-package:all-the-icons-ivy]]* if [[doom-module:+icons]]
+- [[doom-package:amx]]
+- [[doom-package:counsel]]
+- [[doom-package:counsel-projectile]]
+- [[doom-package:flx]]* if [[doom-module:+fuzzy]]
+- [[doom-package:ivy]]
+- [[doom-package:ivy-hydra]]
+- [[doom-package:ivy-posframe]]* if [[doom-module:+childframe]]
+- [[doom-package:ivy-rich]]
+- [[doom-package:prescient]]* if [[doom-module:+prescient]]
+- [[doom-package:swiper]]
+- [[doom-package:wgrep]]
 
 ** Hacks
 - Functions with ivy/counsel equivalents have been globally remapped (like
@@ -67,14 +67,14 @@ use their associated Helm command or plugin.
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-[[doom-package:][ivy]] is a /large/ framework for completing things. Covering all its features is
+[[doom-package:ivy]] is a /large/ framework for completing things. Covering all its features is
 not within the scope of this module's documentation, so only its highlights will
 be covered here.
 
 ** Jump-to navigation
 Inspired by Sublime Text's jump-to-anywhere, CtrlP/Unite in Vim, and Textmate's
-Command-T, this module provides similar functionality by bringing [[doom-package:][projectile]] and
-[[doom-package:][ivy]] together.
+Command-T, this module provides similar functionality by bringing [[doom-package:projectile]] and
+[[doom-package:ivy]] together.
 
 https://assets.doomemacs.org/completion/ivy/projectile.png
 
@@ -125,7 +125,7 @@ Changes to the resulting wgrep buffer (opened by [[kbd:][C-c C-e]]) can be commi
 https://assets.doomemacs.org/completion/ivy/search-replace.png
 
 ** In-buffer searching
-The [[doom-package:][swiper]] package provides an interactive buffer search powered by ivy. It
+The [[doom-package:swiper]] package provides an interactive buffer search powered by ivy. It
 can be invoked with:
 
 - [[kbd:][SPC s s]] (~swiper-isearch~)

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -9,7 +9,7 @@ provides a united interface for project search and replace, powered by [[https:/
 
 It does this with several modular packages focused on enhancing the built-in
 ~completing-read~ interface, rather than replacing it with a parallel ecosystem
-like [[doom-package:][ivy]] and [[doom-package:][helm]] do. The primary packages are:
+like [[doom-package:ivy]] and [[doom-package:helm]] do. The primary packages are:
 
 - Vertico, which provides the vertical completion user interface
 - Consult, which provides a suite of useful commands using ~completing-read~
@@ -31,16 +31,16 @@ like [[doom-package:][ivy]] and [[doom-package:][helm]] do. The primary packages
   Add icons to =file= and =buffer= category completion selections.
 
 ** Packages
-- [[doom-package:][all-the-icons-completion]] if [[doom-module:][+icons]]
-- [[doom-package:][consult]]
-- [[doom-package:][consult-flycheck]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][embark]]
-- [[doom-package:][embark-consult]]
-- [[doom-package:][marginalia]]
-- [[doom-package:][orderless]]
-- [[doom-package:][vertico]]
-- [[doom-package:][vertico-posframe]] if [[doom-module:][+childframe]]
-- [[doom-package:][wgrep]]
+- [[doom-package:all-the-icons-completion]] if [[doom-module:+icons]]
+- [[doom-package:consult]]
+- [[doom-package:consult-flycheck]] if [[doom-module::checkers syntax]]
+- [[doom-package:embark]]
+- [[doom-package:embark-consult]]
+- [[doom-package:marginalia]]
+- [[doom-package:orderless]]
+- [[doom-package:vertico]]
+- [[doom-package:vertico-posframe]] if [[doom-module:+childframe]]
+- [[doom-package:wgrep]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -95,7 +95,7 @@ due to Marginalia annotations.
 
 ** Jump-to navigation
 This module provides an interface to navigate within a project using
-[[doom-package:][projectile]]:
+[[doom-package:projectile]]:
 
 https://assets.doomemacs.org/completion/vertico/projectile.png
 
@@ -135,8 +135,8 @@ commands.
 On top of the usual Vertico keybindings, search commands also offer support for
 exporting the current candidate list to an editable buffer [[kbd:][C-c C-e]]. After
 editing the changes can be committed with [[kbd:][C-c C-c]] and aborted with [[kbd:][C-c C-k]]
-(alternatively [[kbd:][ZZ]] and [[kbd:][ZQ]], for evil users). It uses [[doom-package:][wgrep]] for grep searches,
-[[doom-package:][wdired]] for file searches, and =occur= for buffer searches.
+(alternatively [[kbd:][ZZ]] and [[kbd:][ZQ]], for evil users). It uses [[doom-package:wgrep]] for grep searches,
+[[doom-package:wdired]] for file searches, and =occur= for buffer searches.
 
 https://assets.doomemacs.org/completion/vertico/search-replace.png
 
@@ -213,7 +213,7 @@ Consult async commands (e.g. ~consult-ripgrep~) will have a preceding separator
 character (usually ~#~) before the search input. This is known as the =perl=
 splitting style. Input typed after the separator will be fed to the async
 command until you type a second seperator, afterwhich the candidate list will be
-filtered with Emacs instead (and can be filtered using [[doom-package:][orderless]], for example).
+filtered with Emacs instead (and can be filtered using [[doom-package:orderless]], for example).
 The specific seperator character can be changed by editing it, and might be
 different if the initial input already contains =#=.
 

--- a/modules/config/default/README.org
+++ b/modules/config/default/README.org
@@ -8,7 +8,7 @@ This module provides a set of reasonable defaults, including:
 
 - A Spacemacs-inspired keybinding scheme
 - A configuration for (almost) universally repeating searches with [[kbd:][;]] and [[kbd:][,]]
-- A [[doom-package:][smartparens]] configuration for smart completion of certain delimiters, like
+- A [[doom-package:smartparens]] configuration for smart completion of certain delimiters, like
   ~/* */~ command blocks in C-languages, ~<?php ?>~ tags in PHP, or ~def end~ in
   Ruby/Crystal/etc.
 
@@ -23,10 +23,10 @@ This module provides a set of reasonable defaults, including:
 - +smartparens :: ...
 
 ** Packages
-- [[doom-package:][avy]]
-- [[doom-package:][drag-stuff]]
-- [[doom-package:][link-hint]]
-- [[doom-package:][expand-region]] unless [[doom-module:][:editor evil]]
+- [[doom-package:avy]]
+- [[doom-package:drag-stuff]]
+- [[doom-package:link-hint]]
+- [[doom-package:expand-region]] unless [[doom-module::editor evil]]
 
 ** Hacks
 - ~epa-pinentry-mode~ is set to ~'loopback~, forcing gpg-agent to use the Emacs

--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -24,6 +24,9 @@
                 (org-startup-indented nil)
                 (org-startup-folded nil)
                 (vc-handled-backends nil)
+                ;; Emit more information about the tangle process:
+                (org-babel-pre-tangle-hook org-babel-pre-tangle-hook)   ; before file tangle
+                (org-babel-tangle-body-hook org-babel-tangle-body-hook) ; after src block
                 ;; Prevent unwanted entries in recentf, or formatters, or
                 ;; anything that could be on these hooks, really. Nothing else
                 ;; should be touching these files (particularly in interactive
@@ -38,9 +41,17 @@
                 ;; Allow evaluation of src blocks at tangle-time (would abort
                 ;; them otherwise). This is a security hazard, but Doom will
                 ;; trust that you know what you're doing!
-                (org-confirm-babel-evaluate nil)
-                ;; Say a little more
-                (doom-print-message-level 'info))
+                (org-confirm-babel-evaluate nil))
+            (push (lambda () (print! (start "Tangling file: %s...") buffer-file-name))
+                  org-babel-pre-tangle-hook)
+            (print-group!
+             (push (lambda ()
+                     (let ((element (org-element-at-point)))
+                       (when (eq 'src-block (org-element-type element))
+                         (org-element-property :language element)
+                         (print! (start "Tangling %s block...")
+                                 (org-element-property :language element)))))
+                   org-babel-tangle-body-hook))
             (if-let (files (org-babel-tangle-file target dest))
                 (always (print! (success "Done tangling %d file(s)!" (length files))))
               (print! (error "Failed to tangle any blocks from your config."))

--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -17,24 +17,24 @@ This holy module brings the Vim editing model to Emacs.
   as a foundation.
 
 ** Packages
-- [[doom-package:][evil]]
-- [[doom-package:][evil-args]]
-- [[doom-package:][evil-collection]] if [[doom-module:][+everywhere]]
-- [[doom-package:][evil-easymotion]]
-- [[doom-package:][evil-embrace]]
-- [[doom-package:][evil-escape]]
-- [[doom-package:][evil-exchange]]
-- [[doom-package:][evil-indent-plus]]
-- [[doom-package:][evil-lion]]
-- [[doom-package:][evil-nerd-commentary]]
-- [[doom-package:][evil-numbers]]
-- [[doom-package:][evil-quick-diff]]
-- [[doom-package:][evil-snipe]]
-- [[doom-package:][evil-surround]]
-- [[doom-package:][evil-textobj-anyblock]]
-- [[doom-package:][evil-vimish-fold]]
-- [[doom-package:][evil-visualstar]]
-- [[doom-package:][exato]]
+- [[doom-package:evil]]
+- [[doom-package:evil-args]]
+- [[doom-package:evil-collection]] if [[doom-module:+everywhere]]
+- [[doom-package:evil-easymotion]]
+- [[doom-package:evil-embrace]]
+- [[doom-package:evil-escape]]
+- [[doom-package:evil-exchange]]
+- [[doom-package:evil-indent-plus]]
+- [[doom-package:evil-lion]]
+- [[doom-package:evil-nerd-commentary]]
+- [[doom-package:evil-numbers]]
+- [[doom-package:evil-quick-diff]]
+- [[doom-package:evil-snipe]]
+- [[doom-package:evil-surround]]
+- [[doom-package:evil-textobj-anyblock]]
+- [[doom-package:evil-vimish-fold]]
+- [[doom-package:evil-visualstar]]
+- [[doom-package:exato]]
 
 ** Hacks
 - The o/O keys will respect and continue commented lines (can be disabled by
@@ -76,11 +76,11 @@ The following vim plugins have been ported to evil:
 This module has also ported vim-unimpaired keybinds to Emacs.
 
 In other modules:
-- The [[doom-module:][:ui neotree]] & [[doom-module:][:ui treemacs]] modules provide a =NERDTree= equivalent.
-- The [[doom-module:][:editor multiple-cursors]] module contains functionality equal to the
+- The [[doom-module::ui neotree]] & [[doom-module::ui treemacs]] modules provide a =NERDTree= equivalent.
+- The [[doom-module::editor multiple-cursors]] module contains functionality equal to the
   following vim plugins:
-  - [[doom-package:][evil-multiedit]] => [[github:hlissner/vim-multiedit][vim-multiedit]]
-  - [[doom-package:][evil-mc]] => [[https://github.com/terryma/vim-multiple-cursors][vim-multiple-cursors]]
+  - [[doom-package:evil-multiedit]] => [[github:hlissner/vim-multiedit][vim-multiedit]]
+  - [[doom-package:evil-mc]] => [[https://github.com/terryma/vim-multiple-cursors][vim-multiple-cursors]]
 
 ** Custom Text Objects
 This module provides a couple extra text objects, along with the built-in ones.
@@ -157,13 +157,13 @@ To undo this, use:
 #+end_src
 
 ** The [[kbd:][s]]/[[kbd:][S]] keys behave differently from Vim
-Doom replaces the [[kbd:][s]] and [[kbd:][S]] keys with the [[doom-package:][evil-snipe]] package (a port of
+Doom replaces the [[kbd:][s]] and [[kbd:][S]] keys with the [[doom-package:evil-snipe]] package (a port of
 vim-seek/vim-sneak for 2-character versions of f/F/t/T).
 
 To disable evil-snipe on s/S, you can either:
 1. Disable ~evil-snipe-mode~ by adding ~(remove-hook 'doom-first-input-hook
    #'evil-snipe-mode)~ to =$DOOMDIR/config.el=,
-2. Or disable [[doom-package:][evil-snipe]] completely with ~(package! evil-snipe :disable t)~
+2. Or disable [[doom-package:evil-snipe]] completely with ~(package! evil-snipe :disable t)~
    added to =$DOOMDIR/packages.el=, but this will also disable incremental
    highlighting for the f/F/t/T motions keys.
 3. Or use [[kbd:][cl]] and [[kbd:][cc]], respectively; they do the same thing.
@@ -198,7 +198,7 @@ If you prefer the old behavior, it can be reversed with:
 #+end_quote
 
 Evil-specific configuration and keybindings (defined with ~map!~) will be
-ignored without [[doom-module:][:editor evil]] present (and omitted when byte-compiling).
+ignored without [[doom-module::editor evil]] present (and omitted when byte-compiling).
 
 ** Include underscores in evil word motions?
 A more in-depth answer and explanation for this can be found [[https://evil.readthedocs.io/en/latest/faq.html#underscore-is-not-a-word-character][in Evil's

--- a/modules/editor/file-templates/README.org
+++ b/modules/editor/file-templates/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.0
 
 * Description :unfold:
-This module adds file templates for blank files, powered by [[doom-package:][yasnippet]].
+This module adds file templates for blank files, powered by [[doom-package:yasnippet]].
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -18,7 +18,7 @@ This module adds file templates for blank files, powered by [[doom-package:][yas
 /This module doesn't install any packages./
 
 ** Hacks
-- [[doom-package:][yasnippet]]
+- [[doom-package:yasnippet]]
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
@@ -60,13 +60,13 @@ A special command is available for inserting software licenses: ~M-x
 New file templates can be added to
 =$DOOMDIR/snippets/{major-mode}/{snippet-name}=. The yasnippet documentation
 covers [[https://joaotavora.github.io/yasnippet/snippet-development.html][how to write a snippet]]. You can map a snippet to a file path, major mode,
-or another arbitrary predicate using [[fn:][set-file-template!]].
+or another arbitrary predicate using [[fn:set-file-template!]].
 
 Look into its documentation with [[kbd:][<help> f set-file-template\!]].
 
 ** Adding new OSS licenses
 Add snippet files to =$DOOMDIR/snippets/text-mode/= with the =__licenses-=
-prefix and [[fn:][+file-templates/insert-license]] will recognize them. E.g.
+prefix and [[fn:+file-templates/insert-license]] will recognize them. E.g.
 =$DOOMDIR/snippets/text-mode/__license-mit=.
 
 * Troubleshooting

--- a/modules/editor/file-templates/templates/org-mode/__doom-readme
+++ b/modules/editor/file-templates/templates/org-mode/__doom-readme
@@ -39,7 +39,7 @@ the purpose of the module and the features/technology(ies) it provides.
   Display X in a [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Child-Frames.html][child frame]] rather than an overlay or tooltip. *Requires GUI
   Emacs.*
 - +lsp ::
-  Enable LSP support for ~X-mode~. Requires [[doom-module:][:tools lsp]] and a
+  Enable LSP support for ~X-mode~. Requires [[doom-module::tools lsp]] and a
   langserver (supports A, B, and C).
 
 # If this module has no flags, then...
@@ -52,13 +52,13 @@ the purpose of the module and the features/technology(ies) it provides.
 #+end_quote
 
 ** Packages
-- [[doom-package:][org]]
-- [[doom-package:][org-contrib]] if [[doom-module:][+contrib]]
-- [[doom-package:][org-bullets]] unless  [[doom-module:][+bullets]]
-- if [[doom-module:][+present]]
-  - [[doom-package:][centered-window]]
-  - [[doom-package:][org-tree-slide]]
-  - [[doom-package:][org-re-reveal]]
+- [[doom-package:org]]
+- [[doom-package:org-contrib]] if [[doom-module:+contrib]]
+- [[doom-package:org-bullets]] unless  [[doom-module:+bullets]]
+- if [[doom-module:+present]]
+  - [[doom-package:centered-window]]
+  - [[doom-package:org-tree-slide]]
+  - [[doom-package:org-re-reveal]]
 
 # If this module installs no packages, then...
 /This module doesn't install any packages./

--- a/modules/editor/fold/README.org
+++ b/modules/editor/fold/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0
 
 * Description :unfold:
-This module marries [[doom-package:][hideshow]], [[doom-package:][vimish-fold]], and ~outline-minor-mode~ to bring you
+This module marries [[doom-package:hideshow]], [[doom-package:vimish-fold]], and ~outline-minor-mode~ to bring you
 marker, indent and syntax-based code folding for as many languages as possible.
 
 ** Maintainers
@@ -16,10 +16,10 @@ marker, indent and syntax-based code folding for as many languages as possible.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][evil-vimish-fold]]
-- [[doom-package:][vimish-fold]]
-- if [[doom-module:][:tools tree-sitter]]
-  - [[doom-package:][ts-fold]]
+- [[doom-package:evil-vimish-fold]]
+- [[doom-package:vimish-fold]]
+- if [[doom-module::tools tree-sitter]]
+  - [[doom-package:ts-fold]]
 
 ** TODO Hacks
 #+begin_quote
@@ -40,7 +40,7 @@ marker, indent and syntax-based code folding for as many languages as possible.
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-Emacs keybinds when [[doom-module:][:editor evil +everywhere]] is disabled:
+Emacs keybinds when [[doom-module::editor evil +everywhere]] is disabled:
 | Keybind            | Description               |
 |--------------------+---------------------------|
 | [[kbd:][C-c C-f C-f]]        | Fold region               |

--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -27,11 +27,11 @@ rustfmt, scalafmt, script shfmt, snakefmt, sqlformat, styler, swiftformat, tidy
 ** Module flags
 - +onsave ::
   Enable reformatting of a buffer when it is saved. See
-  [[var:][+format-on-save-enabled-modes]] to control what major modes to (or not to)
+  [[var:+format-on-save-enabled-modes]] to control what major modes to (or not to)
   format on save.
 
 ** Packages
-- [[doom-package:][format-all]]
+- [[doom-package:format-all]]
 
 ** Hacks
 - format-all has been heavily modified to suit Doom's goals for this module:
@@ -39,7 +39,7 @@ rustfmt, scalafmt, script shfmt, snakefmt, sqlformat, styler, swiftformat, tidy
     affect on cursor position.
   - Adds partial formatting, i.e. you can now reformat a subset of the buffer.
   - Adds the ability to use any arbitrary formatter on the current buffer if you
-    pass the universal argument to [[fn:][+format/buffer]] or [[fn:][+format/region]] (i.e.
+    pass the universal argument to [[fn:+format/buffer]] or [[fn:+format/region]] (i.e.
     removes the major-mode lock on formatters).
 
 ** TODO Changelog
@@ -51,7 +51,7 @@ rustfmt, scalafmt, script shfmt, snakefmt, sqlformat, styler, swiftformat, tidy
 
 This module has no direct requirements, but each language will need one of their
 supported formatter programs in order for this to work. In their absence,
-[[doom-package:][format-all]] will fail silently.
+[[doom-package:format-all]] will fail silently.
 
 Supported formatters:
 - Angular/Vue (prettier)
@@ -137,7 +137,7 @@ default value:
 
 If you want to format code when you save a buffer, but want more granular
 control over which major modes this behavior is enabled in, there is an
-alternative. Make sure [[doom-module:][+onsave]] is disabled before you try this:
+alternative. Make sure [[doom-module:+onsave]] is disabled before you try this:
 #+begin_src emacs-lisp
 (add-hook 'python-mode-hook #'format-all-mode)
 (add-hook 'js2-mode-hook #'format-all-mode)
@@ -145,7 +145,7 @@ alternative. Make sure [[doom-module:][+onsave]] is disabled before you try this
 
 ** Disabling the LSP formatter
 If you are in a buffer with ~lsp-mode~ enabled and a server that supports
-=textDocument/formatting=, it will be used instead of [[doom-package:][format-all]]'s formatter.
+=textDocument/formatting=, it will be used instead of [[doom-package:format-all]]'s formatter.
 
 + To disable this behavior universally use: ~(setq +format-with-lsp nil)~
 + To disable this behavior in one mode: ~(setq-hook! 'python-mode-hook

--- a/modules/editor/god/README.org
+++ b/modules/editor/god/README.org
@@ -8,7 +8,7 @@
 #+end_quote
 
 * Description :unfold:
-Adds [[doom-package:][god-mode]] support to Doom Emacs, allowing for entering commands without
+Adds [[doom-package:god-mode]] support to Doom Emacs, allowing for entering commands without
 modifier keys, similar to Vim's modality, separating command mode and insert
 mode.
 
@@ -19,7 +19,7 @@ mode.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][god-mode]]
+- [[doom-package:god-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -24,8 +24,8 @@ languages:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][lispy]]
-- [[doom-package:][lispyville]] if [[doom-module:][:editor evil +everywhere]]
+- [[doom-package:lispy]]
+- [[doom-package:lispyville]] if [[doom-module::editor evil +everywhere]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -44,8 +44,8 @@ languages:
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-If [[doom-module:][:editor evil]] is enabled, [[doom-package:][lispyville]] would also be activated for every mode
-where [[doom-package:][lispy]] is active.
+If [[doom-module::editor evil]] is enabled, [[doom-package:lispyville]] would also be activated for every mode
+where [[doom-package:lispy]] is active.
 
 * TODO Configuration
 #+begin_quote

--- a/modules/editor/multiple-cursors/README.org
+++ b/modules/editor/multiple-cursors/README.org
@@ -16,17 +16,17 @@ evil) that loosely take after multi-cursors in Atom or Sublime Text.
 /This module has no flags./
 
 ** Packages
-- if [[doom-module:][:editor evil]]
-  - [[doom-package:][evil-multiedit]]
-  - [[doom-package:][evil-mc]]
+- if [[doom-module::editor evil]]
+  - [[doom-package:evil-multiedit]]
+  - [[doom-package:evil-mc]]
 - else
-  - [[doom-package:][multiple-cursors]]
+  - [[doom-package:multiple-cursors]]
 
 ** Hacks
-- Attempts to smooth over [[doom-package:][multiple-cursors]]' incompatibilities with [[doom-package:][evil]], which
+- Attempts to smooth over [[doom-package:multiple-cursors]]' incompatibilities with [[doom-package:evil]], which
   is used internally in some third party plugins.
-- Attempts to smooth over [[doom-package:][evil-mc]]'s incompatibilities with other packages, like
-  [[doom-package:][lispy]].
+- Attempts to smooth over [[doom-package:evil-mc]]'s incompatibilities with other packages, like
+  [[doom-package:lispy]].
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
@@ -43,7 +43,7 @@ evil) that loosely take after multi-cursors in Atom or Sublime Text.
 #+end_quote
 
 ** evil-mc
-- The [[doom-package:][evil-mc]] keys are under the [[kbd:][gz]] prefix, e.g.
+- The [[doom-package:evil-mc]] keys are under the [[kbd:][gz]] prefix, e.g.
   - [[kbd:][gzz]] to toggle new (frozen) cursors at point.
   - [[kbd:][gzt]] to toggle mirroring on and off (or switch to insert mode to activate
     them).

--- a/modules/editor/objed/README.org
+++ b/modules/editor/objed/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0
 
 * Description :unfold:
-This modules adds [[doom-package:][objed]], a global minor-mode for navigating and manipulating
+This modules adds [[doom-package:objed]], a global minor-mode for navigating and manipulating
 text objects. It combines the ideas of ~versor-mode~ and other editors like Vim
 or Kakoune and tries to align them with regular Emacs conventions.
 
@@ -15,11 +15,11 @@ or Kakoune and tries to align them with regular Emacs conventions.
 
 ** Module flags
 - +manual ::
-  Don't activate [[doom-package:][objed]] at startup, automatically, leaving it to the user to call
-  [[fn:][objed-activate]] (bound to [[kbd:][M-SPC]] if using [[doom-module:][:config default +bindings]]).
+  Don't activate [[doom-package:objed]] at startup, automatically, leaving it to the user to call
+  [[fn:objed-activate]] (bound to [[kbd:][M-SPC]] if using [[doom-module::config default +bindings]]).
   
 ** Packages
-- [[doom-package:][objed]]
+- [[doom-package:objed]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -34,7 +34,7 @@ or Kakoune and tries to align them with regular Emacs conventions.
 /This module has no external requirements./
 
 #+begin_quote
- 🚧 This module is incompatible with [[doom-module:][:editor evil]]. Do not enable them both at
+ 🚧 This module is incompatible with [[doom-module::editor evil]]. Do not enable them both at
     the same time or you will get errors.
 #+end_quote
 

--- a/modules/editor/parinfer/README.org
+++ b/modules/editor/parinfer/README.org
@@ -15,7 +15,7 @@ balanced and beautiful.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][parinfer-rust-mode]]
+- [[doom-package:parinfer-rust-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/editor/rotate-text/README.org
+++ b/modules/editor/rotate-text/README.org
@@ -17,7 +17,7 @@ keywords or text patterns at point, like ~true~ and ~false~, or ~public~,
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][rotate-text]]
+- [[doom-package:rotate-text]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/editor/snippets/README.org
+++ b/modules/editor/snippets/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.0
 
 * Description :unfold:
-This module adds snippet expansions to Emacs, powered by [[doom-package:][yasnippet]].
+This module adds snippet expansions to Emacs, powered by [[doom-package:yasnippet]].
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -15,9 +15,9 @@ This module adds snippet expansions to Emacs, powered by [[doom-package:][yasnip
 /This module exposes no flags./
 
 ** Packages
-- [[doom-package:][yasnippet]]
-- [[doom-package:][auto-yasnippet]]
-- [[doom-package:][doom-snippets]]
+- [[doom-package:yasnippet]]
+- [[doom-package:auto-yasnippet]]
+- [[doom-package:doom-snippets]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/editor/word-wrap/README.org
+++ b/modules/editor/word-wrap/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0 (#1709)
 
 * Description :unfold:
-This module adds a minor-mode [[fn:][+word-wrap-mode]], which intelligently wraps long
+This module adds a minor-mode [[fn:+word-wrap-mode]], which intelligently wraps long
 lines in the buffer without modifying the buffer content.
 
 ** Maintainers
@@ -16,7 +16,7 @@ lines in the buffer without modifying the buffer content.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][adaptive-wrap]]
+- [[doom-package:adaptive-wrap]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/emacs/dired/README.org
+++ b/modules/emacs/dired/README.org
@@ -16,12 +16,12 @@ This module provides reasonable defaults and augmentations for dired.
   Enables dired to be more like [[https://github.com/ranger/ranger][ranger]].
 
 ** Packages
-- [[doom-package:][all-the-icons-dired]] if [[doom-module:][+icons]]
-- [[doom-package:][diff-hl]]
-- [[doom-package:][diredfl]]
-- [[doom-package:][dired-rsync]]
-- [[doom-package:][fd-dired]]
-- [[doom-package:][ranger]] if [[doom-module:][+ranger]]
+- [[doom-package:all-the-icons-dired]] if [[doom-module:+icons]]
+- [[doom-package:diff-hl]]
+- [[doom-package:diredfl]]
+- [[doom-package:dired-rsync]]
+- [[doom-package:fd-dired]]
+- [[doom-package:ranger]] if [[doom-module:+ranger]]
 
 ** TODO Hacks
 #+begin_quote
@@ -47,13 +47,13 @@ This module has no requirements *except on BSDs* like MacOS or FreeBSD, where
 |---------+----------------------------|
 | [[kbd:][SPC f d]] | Find directory with dired  |
 | [[kbd:][q]]       | Exit dired buffer          |
-| [[kbd:][C-c C-r]] | Run [[doom-package:][dired-rsync]]            |
-| [[kbd:][C-c C-e]] | Rename entries with [[doom-package:][wdired]] |
+| [[kbd:][C-c C-r]] | Run [[doom-package:dired-rsync]]            |
+| [[kbd:][C-c C-e]] | Rename entries with [[doom-package:wdired]] |
 
 Other keybindings can be found on the official [[https://www.gnu.org/software/emacs/refcards/pdf/dired-ref.pdf][Dired reference card]].
 
 ** Ranger
-If [[doom-module:][+ranger]] is enabled often a buffer will be opened in minimal ranger mode
+If [[doom-module:+ranger]] is enabled often a buffer will be opened in minimal ranger mode
 (~deer-mode~). In this case [[kbd:][z P]] can be used to toggle between full ranger and
 ~deer-mode~.
 

--- a/modules/emacs/electric/README.org
+++ b/modules/emacs/electric/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.0
 
 * Description :unfold:
-This module augments the built-in [[doom-package:][electric]] package with keyword-based
+This module augments the built-in [[doom-package:electric]] package with keyword-based
 indentation (as opposed to character-based).
 
 ** Maintainers

--- a/modules/emacs/ibuffer/README.org
+++ b/modules/emacs/ibuffer/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0
 
 * Description :unfold:
-This module augments the built-in [[doom-package:][ibuffer]] package.
+This module augments the built-in [[doom-package:ibuffer]] package.
 
 - Adds project-based grouping of buffers
 - Support for file-type icons
@@ -15,11 +15,11 @@ This module augments the built-in [[doom-package:][ibuffer]] package.
 
 ** Module flags
 - +icons ::
-  Enable filetype icons for buffers using [[doom-package:][all-the-icons]].
+  Enable filetype icons for buffers using [[doom-package:all-the-icons]].
 
 ** Packages
-- [[doom-package:][ibuffer-projectile]]
-- [[doom-package:][ibuffer-vc]]
+- [[doom-package:ibuffer-projectile]]
+- [[doom-package:ibuffer-vc]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/emacs/undo/README.org
+++ b/modules/emacs/undo/README.org
@@ -14,13 +14,13 @@ persist across Emacs sessions.
 
 ** Module flags
 - +tree ::
-  Uses [[doom-package:][undo-tree]] instead of [[doom-package:][undo-fu]], which is a little less stable, but offers
+  Uses [[doom-package:undo-tree]] instead of [[doom-package:undo-fu]], which is a little less stable, but offers
   branching undo history and a visualizer for navigating it.
 
 ** Packages
-- [[doom-package:][undo-fu]]
-- [[doom-package:][undo-fu-session]]
-- [[doom-package:][undo-tree]] if [[doom-module:][+tree]]
+- [[doom-package:undo-fu]]
+- [[doom-package:undo-fu-session]]
+- [[doom-package:undo-tree]] if [[doom-module:+tree]]
 
 ** Hacks
 - Both undo-fu and undo-tree have been modified to use =zstd= to compress undo
@@ -54,7 +54,7 @@ persist across Emacs sessions.
 #+end_quote
 
 ** Disabling persistent undo history
-- If you are using [[doom-module:][+tree]]:
+- If you are using [[doom-module:+tree]]:
   #+begin_src emacs-lisp
   (after! undo-tree
     (setq undo-tree-auto-save-history nil))

--- a/modules/emacs/vc/README.org
+++ b/modules/emacs/vc/README.org
@@ -16,17 +16,17 @@ integration with =git=.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][browse-at-remote]]
-- [[doom-package:][git-timemachine]]
-- [[doom-package:][gitconfig-mode]]
-- [[doom-package:][gitignore-mode]]
+- [[doom-package:browse-at-remote]]
+- [[doom-package:git-timemachine]]
+- [[doom-package:gitconfig-mode]]
+- [[doom-package:gitignore-mode]]
 
 ** Hacks
-- Allow [[doom-package:][browse-at-remote]] commands in [[doom-package:][git-timemachine]] buffers to open that file
+- Allow [[doom-package:browse-at-remote]] commands in [[doom-package:git-timemachine]] buffers to open that file
   in your browser at the visited revision.
-- [[doom-package:][git-timemachine]] buffers will display revision details in the header-line,
+- [[doom-package:git-timemachine]] buffers will display revision details in the header-line,
   rather than the minibuffer (easier to see).
-- [[doom-package:][browse-at-remote]] will fall back to the =master= branch if target is in a
+- [[doom-package:browse-at-remote]] will fall back to the =master= branch if target is in a
   detached state.
 
 ** TODO Changelog

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -6,15 +6,15 @@
 * Description :unfold:
 This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]].
 
-- Tidied mu4e headers view, with flags from [[doom-package:][all-the-icons]].
+- Tidied mu4e headers view, with flags from [[doom-package:all-the-icons]].
 - Consistent coloring of reply depths (across compose and gnus modes).
 - Prettified =mu4e:main= view.
 - Cooperative locking of the =mu= process. Another Emacs instance may request
   access, or grab the lock when it's available.
-- [[doom-package:][org-msg]] integration with [[doom-module:][+org]], which can be toggled per-message, with revamped
+- [[doom-package:org-msg]] integration with [[doom-module:+org]], which can be toggled per-message, with revamped
   style and an accent color.
-- Gmail integrations with the [[doom-module:][+gmail]] flag.
-- Email notifications with [[doom-package:][mu4e-alert]], and (on Linux) a customised notification
+- Gmail integrations with the [[doom-module:+gmail]] flag.
+- Email notifications with [[doom-package:mu4e-alert]], and (on Linux) a customised notification
   style.
 
 #+begin_quote
@@ -38,12 +38,12 @@ This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/cod
   Enable gmail-specific configuration for mail ~To~ or ~From~ a gmail address,
   or a maildir with ~gmail~ in the name.
 - +org ::
-  Use [[doom-package:][org-msg]] for composing email in Org, then sending a multipart text (ASCII
+  Use [[doom-package:org-msg]] for composing email in Org, then sending a multipart text (ASCII
   export) and HTML message.
 
 ** Packages
-- [[doom-package:][mu4e-alert]]
-- [[doom-package:][org-msg]] if [[doom-module:][+org]]
+- [[doom-package:mu4e-alert]]
+- [[doom-package:org-msg]] if [[doom-module:+org]]
 
 ** TODO Hacks
 #+begin_quote
@@ -160,7 +160,7 @@ mail by disabling this module's backend selection and setting the value of the
 
 If your command prompts you for a passphrase, you might want to change the value
 of the ~mu4e~get-mail-password-regexp~ variable
-(~mu4e--get-mail-password-regexp~ if =mu= *>=1.8*) such that [[doom-package:][mu4e]] will recognize
+(~mu4e--get-mail-password-regexp~ if =mu= *>=1.8*) such that [[doom-package:mu4e]] will recognize
 the prompt and let you provide the passphrase from within Emacs.
 
 ** mu and mu4e
@@ -214,7 +214,7 @@ you are not replying to an email to or from one of the specified aliases, you
 will be prompted for an alias to send from.
 
 *** Gmail
-With the [[doom-module:][+gmail]] flag, integrations are applied which account for the different
+With the [[doom-module:+gmail]] flag, integrations are applied which account for the different
 behaviour of Gmail.
 
 The integrations are applied to addresses with /both/ "@gmail.com" in the
@@ -243,7 +243,7 @@ as deleted: Auto-Expunge off - Wait for the client to update the server." and
 folder: Move the message to the trash" for the integrations to work as expected.
 
 ** OrgMsg
-With the [[doom-module:][+org]] flag, [[doom-package:][org-msg]] is installed, and ~org-msg-mode~ is enabled before
+With the [[doom-module:+org]] flag, [[doom-package:org-msg]] is installed, and ~org-msg-mode~ is enabled before
 composing the first message. To disable ~org-msg-mode~ by default:
 #+begin_src emacs-lisp
 ;; add to $DOOMDIR/config.el
@@ -251,7 +251,7 @@ composing the first message. To disable ~org-msg-mode~ by default:
 #+end_src
 
 To toggle org-msg for a single message, just apply the universal argument to the
-compose or reply command ([[kbd:][SPC u]] with [[doom-package:][evil]], [[kbd:][C-u]] otherwise).
+compose or reply command ([[kbd:][SPC u]] with [[doom-package:evil]], [[kbd:][C-u]] otherwise).
 
 The accent color that Doom uses can be customised by setting
 ~+org-msg-accent-color~ to a CSS color string.

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -132,7 +132,7 @@ will also be the width of all other printable characters."
   (setq mu4e-use-fancy-chars t
         mu4e-headers-draft-mark      (cons "D" (+mu4e-normalised-icon "pencil"))
         mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "flag"))
-        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "sync" :set "material" :height 0.8 :v-adjust -0.10))
+        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "eye-slash" :v-adjust 0.05 :height 0.7))
         mu4e-headers-passed-mark     (cons "P" (+mu4e-normalised-icon "arrow-right"))
         mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "arrow-right"))
         mu4e-headers-seen-mark       (cons "S" "") ;(+mu4e-normalised-icon "eye" :height 0.6 :v-adjust 0.07 :color "dsilver"))

--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -34,7 +34,6 @@ If STRICT only accept an unset lock file."
                    (pid (car lock-info)))
          (when (or strict (/= (emacs-pid) pid)) t))))
 
-;;;###autoload
 (defun +mu4e-lock-file-delete-maybe ()
   "Check `+mu4e-lock-file', and delete it if this process is responsible for it."
   (when (+mu4e-lock-available)
@@ -54,7 +53,7 @@ Else, write to this process' PID to the lock file"
       (user-error "Unfortunately another Emacs is already doing stuff with Mu4e, and you can only have one at a time")
     (write-region (number-to-string (emacs-pid)) nil +mu4e-lock-file)
     (delete-file +mu4e-lock-request-file)
-    (call-process "touch" nil nil nil +mu4e-lock-request-file)
+    ;; (call-process "touch" nil nil nil +mu4e-lock-request-file)
     (funcall orig-fun callback)
     (when +mu4e-lock--request-watcher
       (file-notify-rm-watch +mu4e-lock--request-watcher))

--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0
 
 * Description :unfold:
-This module turns Emacs into an email client using [[doom-package:][notmuch]].
+This module turns Emacs into an email client using [[doom-package:notmuch]].
 
 ** Maintainers
 *This module needs a maintainer.* [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -13,13 +13,13 @@ This module turns Emacs into an email client using [[doom-package:][notmuch]].
 - +afew ::
   Enable integration with [[https://github.com/afewmail/afew][afew]].
 - +org ::
-  Enable [[doom-package:][org-mime]] for writing HTML emails using org-mode.
+  Enable [[doom-package:org-mime]] for writing HTML emails using org-mode.
 
 ** Packages
-- [[doom-package:][counsel-notmuch]] if [[doom-module:][:completion ivy]]
-- [[doom-package:][helm-notmuch]] if [[doom-module:][:completion helm]]
-- [[doom-package:][notmuch]]
-- [[doom-package:][org-mime]]* if [[doom-module:][+org]]
+- [[doom-package:counsel-notmuch]] if [[doom-module::completion ivy]]
+- [[doom-package:helm-notmuch]] if [[doom-module::completion helm]]
+- [[doom-package:notmuch]]
+- [[doom-package:org-mime]]* if [[doom-module:+org]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/email/wanderlust/README.org
+++ b/modules/email/wanderlust/README.org
@@ -16,7 +16,7 @@
   Enable gmail-specific configuration for mail ~To~ or ~From~ a gmail address.
 
 ** Packages
-- [[doom-package:][wanderlust]]
+- [[doom-package:wanderlust]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -89,8 +89,8 @@ default input method:
 
 ** Fonts
 Many good English fonts lack good coverage for RTL languages, especially for
-Hebrew and monospace fonts. To this end, we provide [[var:][+bidi-hebrew-font]] and
-[[var:][+bidi-arabic-font]] as an easy way to override the default fonts, but only for
+Hebrew and monospace fonts. To this end, we provide [[var:+bidi-hebrew-font]] and
+[[var:+bidi-arabic-font]] as an easy way to override the default fonts, but only for
 Hebrew and Arabic characters. They are set by default to =DejaVu Sans=, since it
 has decent looking Hebrew and Arabic character support.
 
@@ -109,7 +109,7 @@ If you use an RTL language the script of which isn't covered by the =hebrew= or
 #+end_src
 
 Make sure to use the correct unicode block name, see the documentation of
-[[fn:][set-fontset-font]] for more details.
+[[fn:set-fontset-font]] for more details.
 
 *** Smart Fontify
 Since good bidi fonts are often not monospace (as is the default =DejaVu Sans=),
@@ -138,7 +138,7 @@ insert mode after a hebrew character, in LaTeX buffers.
 
 ** Nastaliq font display bug
 If Emacs is having trouble properly displaying a Nastaliq font, try using one of
-[[https://urdufonts.net/fonts/jameel-noori-nastaleeq-regular][these]] [[https://urdufonts.net/fonts/alvi-nastaleeq-regular][two]] fonts for [[var:][+bidi-arabic-font]].
+[[https://urdufonts.net/fonts/jameel-noori-nastaleeq-regular][these]] [[https://urdufonts.net/fonts/alvi-nastaleeq-regular][two]] fonts for [[var:+bidi-arabic-font]].
 
 * Frequently asked questions
 /This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]

--- a/modules/input/chinese/README.org
+++ b/modules/input/chinese/README.org
@@ -14,11 +14,11 @@ methods: Pinyin and Wubi.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][ace-pinyin]]
-- [[doom-package:][chinese-wbim]] if [[doom-module:][+wubi]]
-- [[doom-package:][fcitx]]
-- [[doom-package:][pangu-spacing]]
-- [[doom-package:][pyim]] unless [[doom-module:][+wubi]]
+- [[doom-package:ace-pinyin]]
+- [[doom-package:chinese-wbim]] if [[doom-module:+wubi]]
+- [[doom-package:fcitx]]
+- [[doom-package:pangu-spacing]]
+- [[doom-package:pyim]] unless [[doom-module:+wubi]]
 
 ** Hacks
 - ~org-html-paragraph~ has been modified to join consecutive Chinese lines into

--- a/modules/input/japanese/README.org
+++ b/modules/input/japanese/README.org
@@ -13,10 +13,10 @@ This module adds support for Japanese script.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][avy-migemo]]
-- [[doom-package:][ddskk]]
-- [[doom-package:][migemo]]
-- [[doom-package:][pangu-spacing]]
+- [[doom-package:avy-migemo]]
+- [[doom-package:ddskk]]
+- [[doom-package:migemo]]
+- [[doom-package:pangu-spacing]]
 
 ** Hacks
 - ~org-html-paragraph~ has been modified to join consecutive Chinese lines into

--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -57,7 +57,7 @@ Support for the bépo layout includes:
 - Bind [[kbd:][`~]] functions to [[kbd:][$#]] keys when possible
 
 *** Easymotion
-If you use [[doom-package:][evil-easymotion]], then all the bindings that were on [[kbd:][gs]] have been
+If you use [[doom-package:evil-easymotion]], then all the bindings that were on [[kbd:][gs]] have been
 moved to [[kbd:][gé]].
 
 In short : [[kbd:][g s j]] -> [[kbd:][g é t]] (~evilem-motion-next-line~). And so on.
@@ -93,7 +93,7 @@ key in the bépo layout. Finding a way to use [[kbd:][é]] or even [[kbd:][è]] 
 a welcome change
 
 *** Org-mode
-[[doom-package:][evil-org]] allows to define ~evil-org-movement-bindings~ to automatically map
+[[doom-package:evil-org]] allows to define ~evil-org-movement-bindings~ to automatically map
 movement bindings on non-hjkl keys. It maps automatically keys to [[kbd:][C-c]] and [[kbd:][C-r]] in
 normal and insert states though, and it's not really user friendly in Emacs to
 remap those.
@@ -123,7 +123,7 @@ key that does not need a curl.
 
 ** Outstanding issues (contributions welcome)
 *** Bépo
-- In [[doom-package:][eshell]], the key [[kbd:][c]] is still bound to ~evil-collection-eshell-evil-change~ in
+- In [[doom-package:eshell]], the key [[kbd:][c]] is still bound to ~evil-collection-eshell-evil-change~ in
   normal mode.
   
 ** How to investigate an issue ?

--- a/modules/lang/agda/README.org
+++ b/modules/lang/agda/README.org
@@ -15,12 +15,12 @@ exists directly in the agda repository, but not in melpa.
   Use the =agda-mode= executable that comes with your local =agda= install.
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- unless [[doom-module:][+local]]
-  - [[doom-package:][agda-input]]
-  - [[doom-package:][agda2-mode]]
+- unless [[doom-module:+local]]
+  - [[doom-package:agda-input]]
+  - [[doom-package:agda2-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/beancount/README.org
+++ b/modules/lang/beancount/README.org
@@ -14,15 +14,15 @@ you [[https://plaintextaccounting.org/][manage your money in plain text]].
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~beancount-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~beancount-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/polarmutex/beancount-language-server][beancount-language-server]]).
 
 ** Packages
-- [[doom-package:][beancount]]
+- [[doom-package:beancount]]
 
 ** Hacks
 - Associates the material =attach_money= icon with =*.beancount= files in the
-  [[doom-package:][all-the-icons]] package.
+  [[doom-package:all-the-icons]] package.
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -21,33 +21,33 @@ This module adds support for the C-family of languages: C, C++, and Objective-C.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~c-mode~, ~c++-mode~, and ~objc-mode~. Requires [[doom-module:][:tools
+  Enable LSP support for ~c-mode~, ~c++-mode~, and ~objc-mode~. Requires [[doom-module::tools
   lsp]] and a langserver (supports ccls, clangd, and cquery). Replaces irony &
   rtags.
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][cmake-mode]]
-- [[doom-package:][company-glsl]]
-- [[doom-package:][cuda-mode]]
-- [[doom-package:][demangle-mode]]
-- [[doom-package:][disaster]]
-- [[doom-package:][glsl-mode]]
-- [[doom-package:][modern-cpp-font-lock]]
-- [[doom-package:][opencl-mode]]
-- if [[doom-module:][+lsp]]
-  - [[doom-package:][ccls]] if [[doom-module:][:tools lsp -eglot]]
+- [[doom-package:cmake-mode]]
+- [[doom-package:company-glsl]]
+- [[doom-package:cuda-mode]]
+- [[doom-package:demangle-mode]]
+- [[doom-package:disaster]]
+- [[doom-package:glsl-mode]]
+- [[doom-package:modern-cpp-font-lock]]
+- [[doom-package:opencl-mode]]
+- if [[doom-module:+lsp]]
+  - [[doom-package:ccls]] if [[doom-module::tools lsp -eglot]]
 - else
-  - [[doom-package:][company-irony]]
-  - [[doom-package:][company-irony-c-headers]]
-  - [[doom-package:][flycheck-irony]]
-  - [[doom-package:][helm-rtags]] if [[doom-module:][:completion helm]]
-  - [[doom-package:][irony]]
-  - [[doom-package:][irony-eldoc]]
-  - [[doom-package:][ivy-rtags]] if [[doom-module:][:completion ivy]]
-  - [[doom-package:][rtags]]
+  - [[doom-package:company-irony]]
+  - [[doom-package:company-irony-c-headers]]
+  - [[doom-package:flycheck-irony]]
+  - [[doom-package:helm-rtags]] if [[doom-module::completion helm]]
+  - [[doom-package:irony]]
+  - [[doom-package:irony-eldoc]]
+  - [[doom-package:ivy-rtags]] if [[doom-module::completion ivy]]
+  - [[doom-package:rtags]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -61,8 +61,8 @@ This module adds support for the C-family of languages: C, C++, and Objective-C.
 
 This module's requirements change depending on how you use it.
 
-- If [[doom-module:][+lsp]] is enabled, you need one of *clangd v9+* or *ccls*.
-- If [[doom-module:][+lsp]] is *not* enabled, you need *irony-server* and *rtags*.
+- If [[doom-module:+lsp]] is enabled, you need one of *clangd v9+* or *ccls*.
+- If [[doom-module:+lsp]] is *not* enabled, you need *irony-server* and *rtags*.
 - Other features in this module depend on:
   - (optional) glslangValidator, for GLSL completion in ~glsl-mode~
   - (optional) cmake, for code completion in ~cmake-mode~
@@ -146,7 +146,7 @@ rc -J $PROJECT_ROOT  # loads PROJECT_ROOT's compile_commands.json
 4. Run ~$ doom sync~ on the command line and restart Emacs.
 
 ** Eglot-specific bindings
-When using [[doom-module:][+lsp]] and [[doom-module:][:tools lsp +eglot]], [[doom-package:][lsp-mode]] is replaced with [[doom-package:][eglot]], and an
+When using [[doom-module:+lsp]] and [[doom-module::tools lsp +eglot]], [[doom-package:lsp-mode]] is replaced with [[doom-package:eglot]], and an
 additional function to get inheritance type hierarchy is added:
 | Binding                    | Description                                    |
 |----------------------------+------------------------------------------------|
@@ -219,7 +219,7 @@ Additional info:
 
 ** Configure LSP servers
 Search for your combination of =(LSP client package, LSP server)=. You are using
-[[doom-package:][lsp-mode]] by default, [[doom-package:][eglot]] if you have [[doom-module:][:tools lsp +eglot]] active in
+[[doom-package:lsp-mode]] by default, [[doom-package:eglot]] if you have [[doom-module::tools lsp +eglot]] active in
 =$DOOMDIR/init.el= file.
 
 *** LSP-mode with clangd

--- a/modules/lang/clojure/README.org
+++ b/modules/lang/clojure/README.org
@@ -18,13 +18,13 @@ This module adds support for the Clojure(Script) language.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~clojure-mode~ (alongside Cider). Requires [[doom-module:][:tools lsp]]
+  Enable LSP support for ~clojure-mode~ (alongside Cider). Requires [[doom-module::tools lsp]]
   and a langserver (supports [[https://clojure-lsp.io/][clojure-lsp]]).
 
 ** Packages
-- [[doom-package:][cider]]
-- [[doom-package:][clj-refactor]]
-- [[doom-package:][flycheck-clj-kondo]] if [[doom-module:][:checkers syntax]]
+- [[doom-package:cider]]
+- [[doom-package:clj-refactor]]
+- [[doom-package:flycheck-clj-kondo]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 - Error messages emitted from CIDER are piped into the REPL buffer when it is
@@ -42,7 +42,7 @@ This module requires:
 - [[https://clojure.org/][clojure]]
 - [[https://leiningen.org/][leiningen]], for the REPL
 - [[https://github.com/borkdude/clj-kondo][clj-kondo]], for linting code
-- [[https://clojure-lsp.github.io/clojure-lsp/][clojure-lsp]], for LSP support (if [[doom-module:][+lsp]])
+- [[https://clojure-lsp.github.io/clojure-lsp/][clojure-lsp]], for LSP support (if [[doom-module:+lsp]])
 
 * TODO Usage
 #+begin_quote

--- a/modules/lang/common-lisp/README.org
+++ b/modules/lang/common-lisp/README.org
@@ -4,7 +4,7 @@
 #+since:    21.12.0
 
 * Description :unfold:
-This module provides support for [[https://lisp-lang.org/][Common Lisp]] and the [[doom-package:][Sly]] development
+This module provides support for [[https://lisp-lang.org/][Common Lisp]] and the [[doom-package:Sly]] development
 environment. Common Lisp is not a single language but a specification, with many
 competing compiler implementations. By default, [[http://www.sbcl.org/][Steel Bank Common Lisp]] (SBCL) is
 assumed to be installed, but this can be configured.
@@ -21,9 +21,9 @@ to run unmodified for a long time.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][sly]]
-- [[doom-package:][sly-macrostep]]
-- [[doom-package:][sly-repl-ansi-color]]
+- [[doom-package:sly]]
+- [[doom-package:sly-macrostep]]
+- [[doom-package:sly-repl-ansi-color]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -42,7 +42,7 @@ This module requires [[http://www.sbcl.org/][SBCL]].
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-This module does not integrate with [[doom-module:][:tools lsp]]. Sly (and SLIME before it) is
+This module does not integrate with [[doom-module::tools lsp]]. Sly (and SLIME before it) is
 considered the defacto development environment for Common Lisp and provides much
 of what is normally expected of an LSP, plus tight integration with the REPL and
 Emacs.

--- a/modules/lang/coq/README.org
+++ b/modules/lang/coq/README.org
@@ -16,8 +16,8 @@ This module adds [[https://coq.inria.fr][coq]] support, powered by [[https://pro
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][proof-general]]
-- [[doom-package:][company-coq]]
+- [[doom-package:proof-general]]
+- [[doom-package:company-coq]]
 
 ** Hacks
 + Replaces coq-mode abbrevs with yasnippet snippets from doom's snippet library

--- a/modules/lang/crystal/README.org
+++ b/modules/lang/crystal/README.org
@@ -16,11 +16,11 @@ This module has no dedicated maintainers.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][crystal-mode]]
-- [[doom-package:][inf-crystal]]
-- if [[doom-module:][:checkers syntax]]
-  - [[doom-package:][flycheck-ameba]]
-  - [[doom-package:][flycheck-crystal]]
+- [[doom-package:crystal-mode]]
+- [[doom-package:inf-crystal]]
+- if [[doom-module::checkers syntax]]
+  - [[doom-package:flycheck-ameba]]
+  - [[doom-package:flycheck-crystal]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/csharp/README.org
+++ b/modules/lang/csharp/README.org
@@ -14,21 +14,21 @@ LSP).
 - +dotnet ::
   Enable Dotnet transient interface with Sharper
 - +lsp ::
-  Enable LSP support for ~csharp-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~csharp-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports =omnisharp-roslyn=).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 - +unity ::
   Enable special support for the [[https://unity.com/][Unity game engine]] (particularly, support for
   HLSL shaders).
 
 ** Packages
-- [[doom-package:][csharp-mode]]
-- [[doom-package:][csproj-mode]]
-- [[doom-package:][shader-mode]] if [[doom-module:][+unity]]
-- [[doom-package:][sharper]] if [[doom-module:][+dotnet]]
-- [[doom-package:][sln-mode]]
+- [[doom-package:csharp-mode]]
+- [[doom-package:csproj-mode]]
+- [[doom-package:shader-mode]] if [[doom-module:+unity]]
+- [[doom-package:sharper]] if [[doom-module:+dotnet]]
+- [[doom-package:sln-mode]]
   
 ** Hacks
 /No hacks documented for this module./
@@ -44,7 +44,7 @@ This module requires:
 - Mono (on UNIX platforms)
 - .NET SDKs (on Windows)
 - .NET Core 1.X - 3.X or .NET 5 for cross platform
-- omnisharp-rosyln (if [[doom-module:][+lsp]])
+- omnisharp-rosyln (if [[doom-module:+lsp]])
 
 ** TODO MacOS
 

--- a/modules/lang/dart/README.org
+++ b/modules/lang/dart/README.org
@@ -21,13 +21,13 @@ This module wraps ~dart-mode~, with [[https://microsoft.github.io/language-serve
   Enable ~flutter~ integration and some sane defaults for Flutter development
   along with ~hover~ for desktop development.
 - +lsp ::
-  Enable LSP support for ~dart-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~dart-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports flutter).
 
 ** Packages
-- [[doom-package:][dart-mode]]
-- [[doom-package:][flutter.el]]
-- [[doom-package:][hover.el]]
+- [[doom-package:dart-mode]]
+- [[doom-package:flutter.el]]
+- [[doom-package:hover.el]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -92,7 +92,7 @@ flutter doctor # for Dependency check and further instructions
 - Widget guide lines for Flutter.
 - Closing labels for constructors.
 - Run tests interactively.
-- Outline support via [[doom-package:][lsp-treemacs]].
+- Outline support via [[doom-package:lsp-treemacs]].
 - Emacs functions for running and debugging Flutter projects.
 
 * TODO Configuration

--- a/modules/lang/data/README.org
+++ b/modules/lang/data/README.org
@@ -13,7 +13,7 @@ This module adds Emacs support for CSV and XML files.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][csv-mode]]
+- [[doom-package:csv-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/dhall/README.org
+++ b/modules/lang/dhall/README.org
@@ -16,7 +16,7 @@ functions + types + imports.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][dhall-mode]]
+- [[doom-package:dhall-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/elixir/README.org
+++ b/modules/lang/elixir/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.3 (#83)
 
 * Description :unfold:
-This module provides support for [[https://elixir-lang.org/][Elixir programming language]] via [[doom-package:][alchemist]] or
+This module provides support for [[https://elixir-lang.org/][Elixir programming language]] via [[doom-package:alchemist]] or
 [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]].
 
 ** Maintainers
@@ -12,17 +12,17 @@ This module provides support for [[https://elixir-lang.org/][Elixir programming 
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~elixir-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~elixir-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][alchemist]]
-- [[doom-package:][elixir-mode]]
-- [[doom-package:][exunit]]
-- [[doom-package:][flycheck-credo]] if [[doom-module:][:checkers syntax]]
+- [[doom-package:alchemist]]
+- [[doom-package:elixir-mode]]
+- [[doom-package:exunit]]
+- [[doom-package:flycheck-credo]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -37,7 +37,7 @@ This module provides support for [[https://elixir-lang.org/][Elixir programming 
 This module requires Elixir. Install it via your distribution's package manager
 or a version management tool such as [[https://github.com/asdf-vm/asdf-elixir][asdf]].
 
-To add LSP support, install [[https://github.com/JakeBecker/elixir-ls/][elixir-ls]] and enable [[doom-module:][:tools lsp]].
+To add LSP support, install [[https://github.com/JakeBecker/elixir-ls/][elixir-ls]] and enable [[doom-module::tools lsp]].
 
 To support linting with [[https://github.com/rrrene/credo][credo]], add ~:checkers syntax~ to ~$DOOMDIR/init.el~.
 
@@ -70,12 +70,12 @@ zypper install elixir
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-- Code completion ([[doom-module:][:completion company]])
-- Documentation lookup ([[doom-module:][:tools lookup]])
+- Code completion ([[doom-module::completion company]])
+- Documentation lookup ([[doom-module::tools lookup]])
 - Mix integration
 - Phoenix support
-- ~iex~ integration ([[doom-module:][:tools eval]])
-- Syntax checking ([[doom-module:][:checkers syntax]], using [[doom-package:][flycheck-credo]])
+- ~iex~ integration ([[doom-module::tools eval]])
+- Syntax checking ([[doom-module::checkers syntax]], using [[doom-package:flycheck-credo]])
 
 ** exunit-mode
 The exunit-mode prefix is [[kbd:][<localleader> t]]. Here is some examples:

--- a/modules/lang/elm/README.org
+++ b/modules/lang/elm/README.org
@@ -11,15 +11,15 @@ This module adds [[https://elm-lang.org/][Elm]] support to Doom Emacs.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~elm-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~elm-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/elm-tooling/elm-language-server][elm-language-server]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][elm-mode]]
-- [[doom-package:][flycheck-elm]] if [[doom-module:][:checkers syntax]]
+- [[doom-package:elm-mode]]
+- [[doom-package:flycheck-elm]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -35,7 +35,7 @@ This module adds [[https://elm-lang.org/][Elm]] support to Doom Emacs.
  🔨 /This module's prerequisites are not all documented./ [[doom-contrib-module:][Document them?]]
 #+end_quote
 
-- If [[doom-module:][+lsp]] is enabled, [[https://github.com/elm-tooling/elm-language-server][elm-language-server]] is required to be installed and in
+- If [[doom-module:+lsp]] is enabled, [[https://github.com/elm-tooling/elm-language-server][elm-language-server]] is required to be installed and in
   your =$PATH=.
 
 * TODO Usage

--- a/modules/lang/emacs-lisp/README.org
+++ b/modules/lang/emacs-lisp/README.org
@@ -9,7 +9,7 @@ This module extends support for Emacs Lisp in Doom Emacs.
 - Macro expansion
 - Go-to-definitions or references functionality
 - Syntax highlighting for defined and quoted symbols
-- Replaces the built-in help with the more powerful [[doom-package:][helpful]]
+- Replaces the built-in help with the more powerful [[doom-package:helpful]]
 - Adds function example uses to documentation
 
 ** Maintainers
@@ -21,14 +21,14 @@ This module extends support for Emacs Lisp in Doom Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][buttercup]]
-- [[doom-package:][elisp-def]]
-- [[doom-package:][elisp-demos]]
-- [[doom-package:][flycheck-cask]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][flycheck-package]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][highlight-quoted]]
-- [[doom-package:][macrostep]]
-- [[doom-package:][overseer]]
+- [[doom-package:buttercup]]
+- [[doom-package:elisp-def]]
+- [[doom-package:elisp-demos]]
+- [[doom-package:flycheck-cask]] if [[doom-module::checkers syntax]]
+- [[doom-package:flycheck-package]] if [[doom-module::checkers syntax]]
+- [[doom-package:highlight-quoted]]
+- [[doom-package:macrostep]]
+- [[doom-package:overseer]]
 
 ** Hacks
 - Symbols that are defined in the current session are highlighted with

--- a/modules/lang/erlang/README.org
+++ b/modules/lang/erlang/README.org
@@ -8,20 +8,20 @@ This module provides support [[https://www.erlang.org/][Erlang programming langu
 [[https://github.com/erlang/sourcer][sourcer]] language server is optional.
 
 Includes:
-- Code completion ([[doom-module:][+lsp]], [[doom-module:][:completion company]], & [[doom-module:][:completion ivy]])
-- Syntax checking ([[doom-module:][:checkers syntax]])
+- Code completion ([[doom-module:+lsp]], [[doom-module::completion company]], & [[doom-module::completion ivy]])
+- Syntax checking ([[doom-module::checkers syntax]])
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~erlang-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~erlang-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/erlang/sourcer][sourcer]]).
 
 ** Packages
-- [[doom-package:][flycheck-rebar3]]
-- [[doom-package:][ivy-erlang-complete]]
+- [[doom-package:flycheck-rebar3]]
+- [[doom-package:ivy-erlang-complete]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/ess/README.org
+++ b/modules/lang/ess/README.org
@@ -15,15 +15,15 @@ SAS, Julia and Stata.
   Enable support for ~stan-mode~, including code completion and syntax checking.
 
 ** Packages
-- [[doom-package:][ess]]
-- [[doom-package:][ess-R-data-view]]
-- [[doom-package:][polymode]]
-- [[doom-package:][poly-R]]
-- if [[doom-module:][+stan]]
-  - [[doom-package:][company-stan]] if [[doom-module:][:completion company]]
-  - [[doom-package:][eldoc-stan]]
-  - [[doom-package:][flycheck-stan]] if [[doom-module:][:checkers syntax]]
-  - [[doom-package:][stan-mode]]
+- [[doom-package:ess]]
+- [[doom-package:ess-R-data-view]]
+- [[doom-package:polymode]]
+- [[doom-package:poly-R]]
+- if [[doom-module:+stan]]
+  - [[doom-package:company-stan]] if [[doom-module::completion company]]
+  - [[doom-package:eldoc-stan]]
+  - [[doom-package:flycheck-stan]] if [[doom-module::checkers syntax]]
+  - [[doom-package:stan-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -38,7 +38,7 @@ SAS, Julia and Stata.
 This module has several optional dependencies:
 
 - [[https://github.com/jimhester/lintr][lintr]]: for R linting.
-- [[https://github.com/REditorSupport/languageserver][languageserver]]: for LSP support in an R buffer (with [[doom-module:][+lsp]] flag).
+- [[https://github.com/REditorSupport/languageserver][languageserver]]: for LSP support in an R buffer (with [[doom-module:+lsp]] flag).
 
 * TODO Usage
 #+begin_quote

--- a/modules/lang/factor/README.org
+++ b/modules/lang/factor/README.org
@@ -5,7 +5,7 @@
 
 * Description :unfold:
 This module adds support to the [[https://github.com/factor/factor][factor]] programming language and its associated
-[[doom-package:][fuel]] emacs plugin.
+[[doom-package:fuel]] emacs plugin.
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]

--- a/modules/lang/faust/README.org
+++ b/modules/lang/faust/README.org
@@ -20,17 +20,17 @@ Add support to [[https://faust.grame.fr/][Faust language]] inside emacs.
   shortcuts, etc.)
 - Automatic keyword completion (if Auto-Complete is installed)
 - Automatic objets (functions, operators, etc.) template insertion with default
-  sensible values (if [[doom-module:][:editor snippets]] is enabled)
+  sensible values (if [[doom-module::editor snippets]] is enabled)
 - Modeline indicator of the state of the code
 
 ** Maintainers
 *This module needs a maintainer.* [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Packages
-- [[doom-package:][faustine]]
+- [[doom-package:faustine]]
 
 ** Hacks
-- Both ~faust-mode~ and ~faustine-mode~ are hardcoded to use [[doom-package:][auto-complete]],
+- Both ~faust-mode~ and ~faustine-mode~ are hardcoded to use [[doom-package:auto-complete]],
   which Doom does not use. Its obnoxious 'You really should install and use
   auto-complete' warnings have been silenced.
 

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -17,7 +17,7 @@ In particular, this module features:
 - Auto-formatting via =fprettier=.
 - Integration with the =fpm= package manager.
 - LSP support via [[https://github.com/gnikit/fortls][fortls]].
-- Optional Intel Fortran support via the [[doom-module:][+intel]] flag.
+- Optional Intel Fortran support via the [[doom-module:+intel]] flag.
 
 #+begin_quote
  💬 After a career of writing Fortran on Mainframes and Windows machines, my
@@ -33,7 +33,7 @@ In particular, this module features:
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~fortran-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~fortran-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (fortls).
 - +intel ::
   Use the =ifort= compiler by default.
@@ -68,7 +68,7 @@ $ sudo aura -A fortran-fpm fortls
 #+end_src bash
 
 ** Installing Intel Fortran
-Activating the [[doom-module:][+intel]] flag won't automatically install Intel Fortan for you.
+Activating the [[doom-module:+intel]] flag won't automatically install Intel Fortan for you.
 Here's how to do it on *nix systems.
 
 You can of course install the entire High-performance Computing kit from Intel,

--- a/modules/lang/fsharp/README.org
+++ b/modules/lang/fsharp/README.org
@@ -16,12 +16,12 @@ This module adds [[https://fsharp.org/][F#]] support to Doom Emacs.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~fsharp-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~fsharp-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-fsharp.el][lsp-fsharp]].).
 
 ** Packages
-- [[doom-package:][fsharp-mode]]
-- [[doom-package:][lsp-fsharp]] if [[doom-package:][+lsp]]
+- [[doom-package:fsharp-mode]]
+- [[doom-package:lsp-fsharp]] if [[doom-package:+lsp]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/fstar/README.org
+++ b/modules/lang/fstar/README.org
@@ -20,7 +20,7 @@ This module adds [[https://fstar-lang.org/][F*]] support, powered by [[https://g
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][fstar-mode]]
+- [[doom-package:fstar-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/gdscript/README.org
+++ b/modules/lang/gdscript/README.org
@@ -12,11 +12,11 @@ engine, to Doom Emacs, powered by [[https://github.com/GDQuest/emacs-gdscript-mo
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~gdscript-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~gdscript-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (Godot ~3.2.1~ or newer).
 
 ** Packages
-- [[doom-package:][gdscript-mode]]
+- [[doom-package:gdscript-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -47,7 +47,7 @@ pip3 install gdtoolkit
 
 ** LSP support
 The language server support for GDScript is built into by lsp-mode. As long as
-you have [[doom-module:][+lsp]] and [[doom-module:][:tools lsp]] enabled, and Godot 3.2.1+ installed, it should work
+you have [[doom-module:+lsp]] and [[doom-module::tools lsp]] enabled, and Godot 3.2.1+ installed, it should work
 out of the box.
 
 Godot's language server is built into the game engine, so you need to open your
@@ -67,7 +67,7 @@ available commands.
 [[doom-report:][Report an issue?]]
 
 - The GDScript language server has known issues causing some errors with
-  [[doom-package:][lsp-mode]]. They should be addressed in future releases.
+  [[doom-package:lsp-mode]]. They should be addressed in future releases.
 
 * Frequently asked questions
 /This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]

--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -12,7 +12,7 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
 - Eldoc support (~go-eldoc~)
 - REPL (~gore~)
 - Syntax-checking (~flycheck~)
-- Auto-formatting on save (~gofmt~) (requires [[doom-module:][:editor format +onsave]])
+- Auto-formatting on save (~gofmt~) (requires [[doom-module::editor format +onsave]])
 - Code navigation & refactoring (~go-guru~)
 - [[../../editor/file-templates/templates/go-mode][File templates]]
 - [[https://github.com/hlissner/doom-snippets/tree/master/go-mode][Snippets]]
@@ -24,22 +24,22 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~go-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~go-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports gopls). Highly recommended, as the non-LSP experience is deprecated
   (and poor).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][company-go]] if [[doom-module:][:completion company]] (DEPRECATED)
-- [[doom-package:][flycheck-golangci-lint]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][go-eldoc]]
-- [[doom-package:][go-gen-test]]
-- [[doom-package:][go-guru]]
-- [[doom-package:][go-mode]]
-- [[doom-package:][gorepl-mode]]
-- [[doom-package:][go-tag]]
+- [[doom-package:company-go]] if [[doom-module::completion company]] (DEPRECATED)
+- [[doom-package:flycheck-golangci-lint]] if [[doom-module::checkers syntax]]
+- [[doom-package:go-eldoc]]
+- [[doom-package:go-gen-test]]
+- [[doom-package:go-guru]]
+- [[doom-package:go-mode]]
+- [[doom-package:gorepl-mode]]
+- [[doom-package:go-tag]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/graphql/README.org
+++ b/modules/lang/graphql/README.org
@@ -8,14 +8,14 @@ This module adds [[https://www.graphql.org][GraphQL]] support to Doom Emacs.
 
 It includes:
 - Code completion
-- LSP support ([[doom-module:][+lsp]])
+- LSP support ([[doom-module:+lsp]])
   - Diagnostics (GraphQL syntax linting/validations) (spec-compliant)
   - Autocomplete suggestions (spec-compliant)
   - Hyperlink to fragment definitions and named types (type, input, enum) definitions (spec-compliant)
   - Outline view support for queries and SDL
   - Symbols support across the workspace
 - Local schema viewer
-- Org-babel exporter (requires [[doom-module:][:lang org]])
+- Org-babel exporter (requires [[doom-module::lang org]])
 
 ** Maintainers
 - [[doom-user:][@elken]]
@@ -24,16 +24,16 @@ It includes:
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~graphql-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~graphql-mode~. Requires [[doom-module::tools lsp]] and a langserver
   ([[https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli#readme][graphql-language-service-cli]]).
 
 ** Packages
-- [[doom-package:][company-graphql]] unless [[doom-module:][+lsp]]
-- [[doom-package:][graphql-mode]]
-- [[doom-package:][graphql-doc]]
+- [[doom-package:company-graphql]] unless [[doom-module:+lsp]]
+- [[doom-package:graphql-mode]]
+- [[doom-package:graphql-doc]]
 
 ** Hacks
-- Added a convenience function [[fn:][+graphql-doc-open-config]] to open schema docs from
+- Added a convenience function [[fn:+graphql-doc-open-config]] to open schema docs from
   a [[https://github.com/jimkyndemeyer/graphql-config-examples][.graphqlconfig]] file.
 
 ** TODO Changelog

--- a/modules/lang/haskell/README.org
+++ b/modules/lang/haskell/README.org
@@ -13,12 +13,12 @@ This module adds Haskell support to Doom Emacs.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~haskell-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~haskell-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/haskell/haskell-language-server][haskell-language-server]]).
 
 ** Packages
-- [[doom-package:][haskell-mode]]
-- [[doom-package:][lsp-haskell]] if [[doom-module:][+lsp]]
+- [[doom-package:haskell-mode]]
+- [[doom-package:lsp-haskell]] if [[doom-module:+lsp]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/hy/README.org
+++ b/modules/lang/hy/README.org
@@ -13,7 +13,7 @@
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][hy-mode]]
+- [[doom-package:hy-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/idris/README.org
+++ b/modules/lang/idris/README.org
@@ -13,7 +13,7 @@ This module adds rudimentary [[https://www.idris-lang.org/][Idris]] support to D
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][idris-mode]]
+- [[doom-package:idris-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -12,23 +12,23 @@ This module adds [[https://www.java.com][Java]] support to Doom Emacs, including
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~java-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
-  (supports eclipse.jdt.ls). *Incompatible with [[doom-module:][+meghanada]].*
+  Enable LSP support for ~java-mode~. Requires [[doom-module::tools lsp]] and a langserver
+  (supports eclipse.jdt.ls). *Incompatible with [[doom-module:+meghanada]].*
 - +meghanada ::
-  Enable [[doom-package:][meghanada-mode]]. *Incompatible with [[doom-module:][+lsp]].*
+  Enable [[doom-package:meghanada-mode]]. *Incompatible with [[doom-module:+lsp]].*
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][android-mode]]
-- [[doom-package:][groovy-mode]]
-- [[doom-package:][meghanada]] if [[doom-module:][+meghanada]]
-- if [[doom-module:][+eclim]]
-  - [[doom-package:][eclim]]
-  - [[doom-package:][company-emacs-eclim]] if [[doom-module:][:completion company]]
-- if [[doom-module:][+lsp]] and not [[doom-module:][:tools lsp +eglot]]
-  - [[doom-package:][lsp-java]]
+- [[doom-package:android-mode]]
+- [[doom-package:groovy-mode]]
+- [[doom-package:meghanada]] if [[doom-module:+meghanada]]
+- if [[doom-module:+eclim]]
+  - [[doom-package:eclim]]
+  - [[doom-package:company-emacs-eclim]] if [[doom-module::completion company]]
+- if [[doom-module:+lsp]] and not [[doom-module::tools lsp +eglot]]
+  - [[doom-package:lsp-java]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -42,7 +42,7 @@ This module adds [[https://www.java.com][Java]] support to Doom Emacs, including
 
 This module requires:
 - [[https://www.oracle.com/java/technologies/downloads/][Java SDK]]
-- The LSP test runner requires [[doom-module:][:tools debugger +lsp]] (requires [[doom-package:][dap-mode]])
+- The LSP test runner requires [[doom-module::tools debugger +lsp]] (requires [[doom-package:dap-mode]])
 
 ** OpenJDK 11
 *** Ubuntu
@@ -88,14 +88,14 @@ It is common to need support for multiple Java versions. You can use a generic
 tool like [[https://github.com/shyiko/jabba][jabba]] to install and manage multiple Java versions on any OS.
 
 To have a different version of Java per-project, it is recommended you use
-[[https://github.com/direnv/direnv][direnv]] and [[doom-module:][:tools direnv]]; create a =.envrc= in the root of the project pointing
+[[https://github.com/direnv/direnv][direnv]] and [[doom-module::tools direnv]]; create a =.envrc= in the root of the project pointing
 to the Java installation:
 #+begin_src sh
 PATH_add ~/.jabba/jdk/adopt@1.11.0-3
 JAVA_HOME=~/.jabba/jdk/adopt@1.11.0-3
 #+end_src
 
-And then run ~$ direnv allow .~ in the project directory. The [[doom-module:][:tools direnv]]
+And then run ~$ direnv allow .~ in the project directory. The [[doom-module::tools direnv]]
 module will automatically source this environment before activating LSP servers.
 
 * TODO Usage
@@ -103,23 +103,23 @@ module will automatically source this environment before activating LSP servers.
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-** [[doom-module:][+lsp]] features
+** [[doom-module:+lsp]] features
 According to [[https://github.com/emacs-lsp/lsp-java]], you get:
-- As you type reporting of parsing and compilation errors (via [[doom-package:][flycheck]] or
-  [[doom-package:][lsp-ui]])
-- Code completion ([[doom-package:][company-lsp]] or complete-at-point)
-- Javadoc hovers ([[doom-package:][lsp-ui]])
-- Code actions ([[doom-package:][lsp-ui]])
-- Code outline ([[doom-package:][imenu]])
-- Code navigation ([[doom-package:][xref]])
-- Code lens for references/implementations ([[doom-package:][xref]])
+- As you type reporting of parsing and compilation errors (via [[doom-package:flycheck]] or
+  [[doom-package:lsp-ui]])
+- Code completion ([[doom-package:company-lsp]] or complete-at-point)
+- Javadoc hovers ([[doom-package:lsp-ui]])
+- Code actions ([[doom-package:lsp-ui]])
+- Code outline ([[doom-package:imenu]])
+- Code navigation ([[doom-package:xref]])
+- Code lens for references/implementations ([[doom-package:xref]])
 - Highlights
 - Code formatting
 - Maven pom.xml project support
 - Limited Gradle support
-- Visual debugger ([[doom-package:][dap-mode]])
-- Test runner ([[doom-package:][dap-mode]])
-- Project explorer integration ([[doom-package:][treemacs]])
+- Visual debugger ([[doom-package:dap-mode]])
+- Test runner ([[doom-package:dap-mode]])
+- Project explorer integration ([[doom-package:treemacs]])
 - Integration with [[https://start.spring.io/][Spring Initializr]]
 
 ** =+meghanada= features
@@ -129,14 +129,14 @@ According to [[https://github.com/mopemope/meghanada-emacs/]], you get:
 - No need build tool's plugin
 - Run build tool task
 - Compile your project
-- Syntax check and analyze java source ([[doom-package:][flycheck-meghanada]])
+- Syntax check and analyze java source ([[doom-package:flycheck-meghanada]])
 - Support =Generic Types=
-- Code completion with [[doom-package:][company-mode]] ([[doom-package:][company-meghanada]])
+- Code completion with [[doom-package:company-mode]] ([[doom-package:company-meghanada]])
 - Optimize import and sort
 - Jump declaration
 - Run [[http://www.junit.org/][JUnit]] test (include test runner)
-- Diagnostic reporting with [[doom-package:][flycheck]] ([[doom-package:][flycheck-meghanada]])
-- Show symbol's type info with [[doom-package:][eldoc]]
+- Diagnostic reporting with [[doom-package:flycheck]] ([[doom-package:flycheck-meghanada]])
+- Show symbol's type info with [[doom-package:eldoc]]
 - Search references
 - Full-featured text search
 
@@ -145,7 +145,7 @@ According to [[https://github.com/mopemope/meghanada-emacs/]], you get:
  🔨 /This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-** [[doom-module:][+lsp]]
+** [[doom-module:+lsp]]
 Install the eclipse server by executing ~M-x lsp-install-server~ and selecting
 =jdtls=. After that any newly opened =java= files should start the LSP server
 automatically.
@@ -156,7 +156,7 @@ Note that if you change Java version you may need to remove the LSP server and
 install it again. You can do this with ~M-x +lsp/uninstall-server~ followed by
 ~M-x lsp-install-server~.
 
-Enable the [[doom-module:][:tools debugger +lsp]] module to get test runner support.
+Enable the [[doom-module::tools debugger +lsp]] module to get test runner support.
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]

--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -6,13 +6,13 @@
 * Description :unfold:
 This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.typescriptlang.org/][TypeScript]] support to Doom Emacs.
 
-- Code completion ([[doom-package:][tide]])
-- REPL support ([[doom-package:][nodejs-repl]])
-- Refactoring commands ([[doom-package:][js2-refactor]])
-- Syntax checking ([[doom-package:][flycheck]])
-- Browser code injection with [[doom-package:][skewer-mode]]
+- Code completion ([[doom-package:tide]])
+- REPL support ([[doom-package:nodejs-repl]])
+- Refactoring commands ([[doom-package:js2-refactor]])
+- Syntax checking ([[doom-package:flycheck]])
+- Browser code injection with [[doom-package:skewer-mode]]
 - Coffeescript & JSX support
-- Jump-to-definitions and references support ([[doom-package:][xref]])
+- Jump-to-definitions and references support ([[doom-package:xref]])
 
 ** Maintainers
 - [[doom-user:][@elken]]
@@ -24,21 +24,21 @@ This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.t
 ** Module flags
 - +lsp ::
   Enable LSP support for ~js2-mode~, ~rjsx-mode~, JS in ~web-mode~, and
-  ~typescript-mode~. Requires [[doom-module:][:tools lsp]] and a langserver (supports ts-ls and
+  ~typescript-mode~. Requires [[doom-module::tools lsp]] and a langserver (supports ts-ls and
   deno-ls).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][js2-refactor]]
-- [[doom-package:][nodejs-repl]]
-- [[doom-package:][npm-mode]]
-- [[doom-package:][rjsx-mode]]
-- [[doom-package:][skewer-mode]] (DEPRECATED)
-- [[doom-package:][tide]]
-- [[doom-package:][typescript-mode]]
-- [[doom-package:][xref-js2]] if [[doom-module:][:tools lookup]]
+- [[doom-package:js2-refactor]]
+- [[doom-package:nodejs-repl]]
+- [[doom-package:npm-mode]]
+- [[doom-package:rjsx-mode]]
+- [[doom-package:skewer-mode]] (DEPRECATED)
+- [[doom-package:tide]]
+- [[doom-package:typescript-mode]]
+- [[doom-package:xref-js2]] if [[doom-module::tools lookup]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/lang/json/README.org
+++ b/modules/lang/json/README.org
@@ -11,16 +11,16 @@ This module adds [[https://www.json.org/json-en.html][JSON]] support to Doom Ema
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~json-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~json-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/vscode-langservers/vscode-json-languageserver][vscode-json-languageserver]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][counsel-jq]] if [[doom-module:][:completion ivy]]
-- [[doom-package:][json-mode]]
-- [[doom-package:][json-snatcher]]
+- [[doom-package:counsel-jq]] if [[doom-module::completion ivy]]
+- [[doom-package:json-mode]]
+- [[doom-package:json-snatcher]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -6,31 +6,31 @@
 * Description :unfold:
 This module adds support for [[https://julialang.org/][the Julia language]] to Doom Emacs.
 
-- Syntax highlighting and latex symbols from [[doom-package:][julia-mode]]
-- REPL integration from [[doom-package:][julia-repl]]
-- Code completion and syntax checking, requires [[doom-module:][:tools lsp]] and [[doom-module:][+lsp]]
+- Syntax highlighting and latex symbols from [[doom-package:julia-mode]]
+- REPL integration from [[doom-package:julia-repl]]
+- Code completion and syntax checking, requires [[doom-module::tools lsp]] and [[doom-module:+lsp]]
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~julia-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~julia-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports LanguageServer.jl).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][julia-mode]]
-- [[doom-package:][julia-repl]]
-- if [[doom-package:][+lsp]]
-  - if [[doom-module:][:tools lsp]]
-    - [[doom-package:][lsp-julia]]
-    - [[doom-package:][lsp]]
-  - if [[doom-module:][:tools lsp +eglot]]
-    - [[doom-package:][eglot-jl]]
-    - [[doom-package:][eglot]]
+- [[doom-package:julia-mode]]
+- [[doom-package:julia-repl]]
+- if [[doom-package:+lsp]]
+  - if [[doom-module::tools lsp]]
+    - [[doom-package:lsp-julia]]
+    - [[doom-package:lsp]]
+  - if [[doom-module::tools lsp +eglot]]
+    - [[doom-package:eglot-jl]]
+    - [[doom-package:eglot]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -42,11 +42,11 @@ This module adds support for [[https://julialang.org/][the Julia language]] to D
 * Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-This module requires [[https://julialang.org/][Julia]] and an language server if [[doom-module:][+lsp]] is enabled.
+This module requires [[https://julialang.org/][Julia]] and an language server if [[doom-module:+lsp]] is enabled.
 
 ** Language Server
-[[doom-module:][+lsp]] requires ~LanguageServer.jl~ and ~SymbolServer.jl~. The [[doom-package:][lsp-julia]] and
-[[doom-package:][eglot-jl]] packages both come bundled with their own versions of these servers,
+[[doom-module:+lsp]] requires ~LanguageServer.jl~ and ~SymbolServer.jl~. The [[doom-package:lsp-julia]] and
+[[doom-package:eglot-jl]] packages both come bundled with their own versions of these servers,
 which is used by default. If you're happy with that, no further configuration is
 necessary.
 
@@ -58,17 +58,17 @@ Pkg.add("LanguageServer")
 Pkg.add("SymbolServer")
 #+end_src
 
-Then configure [[doom-package:][lsp-julia]] or [[doom-package:][eglot-jl]] depending on whether you have enabled
-[[doom-module:][:tools lsp]] or [[doom-module:][:tools lsp +eglot]], respectively:
+Then configure [[doom-package:lsp-julia]] or [[doom-package:eglot-jl]] depending on whether you have enabled
+[[doom-module::tools lsp]] or [[doom-module::tools lsp +eglot]], respectively:
 
 *** =lsp-julia=
-To instruct [[doom-package:][lsp-julia]] not to use the built-in package:
+To instruct [[doom-package:lsp-julia]] not to use the built-in package:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
 (setq lsp-julia-package-dir nil)
 #+end_src
 
-To find your installation of ~LanguageServer.jl~, [[doom-package:][lsp-julia]] needs to know the
+To find your installation of ~LanguageServer.jl~, [[doom-package:lsp-julia]] needs to know the
 environment in which it is installed. This is set to v1.6 by default as it is
 the current LTS:
 #+begin_src emacs-lisp
@@ -78,7 +78,7 @@ the current LTS:
 #+end_src
 
 *** =eglot-jl=
-To find your installation of ~LanguageServer.jl~, [[doom-package:][eglot-jl]] must know the
+To find your installation of ~LanguageServer.jl~, [[doom-package:eglot-jl]] must know the
 environment in which it is installed. This is set to v1.6 by default as it is
 the current LTS:
 #+begin_src emacs-lisp
@@ -86,7 +86,7 @@ the current LTS:
 (setq eglot-jl-language-server-project "~/.julia/environments/v1.6")
 #+end_src
 
-But to let [[doom-package:][eglot-jl]] use the environment bundled with it, set it to
+But to let [[doom-package:eglot-jl]] use the environment bundled with it, set it to
 ~eglot-jl-base~ instead:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
@@ -100,8 +100,8 @@ But to let [[doom-package:][eglot-jl]] use the environment bundled with it, set 
 #+end_quote
 
 ** Language Server
-[[doom-module:][+lsp]] adds code completion, syntax checking, formatting and other [[doom-package:][lsp-mode]] or
-[[doom-package:][eglot]] features. It requires ~LanguageServer.jl~, the installation of which is
+[[doom-module:+lsp]] adds code completion, syntax checking, formatting and other [[doom-package:lsp-mode]] or
+[[doom-package:eglot]] features. It requires ~LanguageServer.jl~, the installation of which is
 described above.
 
 * TODO Configuration
@@ -110,7 +110,7 @@ described above.
 #+end_quote
 
 ** Change the default environment for the Julia language server
-[[doom-package:][lsp-julia]] requires a variable be set for the Julia environment. This is set to
+[[doom-package:lsp-julia]] requires a variable be set for the Julia environment. This is set to
 v1.6 by default as it is the current LTS:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el

--- a/modules/lang/kotlin/README.org
+++ b/modules/lang/kotlin/README.org
@@ -11,12 +11,12 @@ This module adds [[https://kotlinlang.org/][Kotlin]] support to Doom Emacs.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~kotlin-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~kotlin-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/emacs-lsp/lsp-mode][kotlin-language-server]]).
 
 ** Packages
-- [[doom-package:][flycheck-kotlin]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][kotlin-mode]]
+- [[doom-package:flycheck-kotlin]] if [[doom-module::checkers syntax]]
+- [[doom-package:kotlin-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -8,11 +8,11 @@ Provide a helping hand when working with LaTeX documents.
 
 - Sane defaults
 - Fontification of many popular commands
-- Pretty indentation of wrapped lines using the [[doom-package:][adaptive-wrap]] package
-- Spell checking with [[doom-package:][flycheck]]
-- Change PDF viewer to Okular or [[doom-package:][latex-preview-pane]]
+- Pretty indentation of wrapped lines using the [[doom-package:adaptive-wrap]] package
+- Spell checking with [[doom-package:flycheck]]
+- Change PDF viewer to Okular or [[doom-package:latex-preview-pane]]
 - Bibtex editor
-- Autocompletion using [[doom-package:][company-mode]]
+- Autocompletion using [[doom-package:company-mode]]
 - Compile your =.tex= code only once using LatexMk
 
 ** Maintainers
@@ -23,27 +23,27 @@ Provide a helping hand when working with LaTeX documents.
 
 ** Module flags
 - +cdlatex ::
-  Enable [[doom-package:][cdlatex]] for fast math insertion.
+  Enable [[doom-package:cdlatex]] for fast math insertion.
 - +fold ::
-  Use TeX-fold (from [[doom-package:][auctex]]) to fold LaTeX macros to unicode, and make folding
+  Use TeX-fold (from [[doom-package:auctex]]) to fold LaTeX macros to unicode, and make folding
   hook-based and less manual.
 - +latexmk ::
   Use LatexMk instead of LaTeX to compile documents.
 - +lsp ::
-  Enable LSP support in latex buffers. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support in latex buffers. Requires [[doom-module::tools lsp]] and a langserver
   (supports digestif and TexLab).
 
 ** Packages
-- [[doom-package:][adaptive-wrap]]
-- [[doom-package:][auctex]]
-- [[doom-package:][auctex-latexmk]] if [[doom-module:][+latexmk]]
-- [[doom-package:][cdlatex]] if [[doom-module:][+cdlatex]]
-- [[doom-package:][evil-tex]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][latex-preview-pane]]
-- if [[doom-module:][:completion company]]
-  - [[doom-package:][company-auctex]]
-  - [[doom-package:][company-math]]
-  - [[doom-package:][company-reftex]]
+- [[doom-package:adaptive-wrap]]
+- [[doom-package:auctex]]
+- [[doom-package:auctex-latexmk]] if [[doom-module:+latexmk]]
+- [[doom-package:cdlatex]] if [[doom-module:+cdlatex]]
+- [[doom-package:evil-tex]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:latex-preview-pane]]
+- if [[doom-module::completion company]]
+  - [[doom-package:company-auctex]]
+  - [[doom-package:company-math]]
+  - [[doom-package:company-reftex]]
 
 ** TODO Hacks
 #+begin_quote
@@ -115,7 +115,7 @@ This module provides integration for four supported pdf viewers. They are
 + Sumatra PDF
 + Zathura
 + Okular
-+ pdf-tools (requires [[doom-module:][:tools pdf]] module)
++ pdf-tools (requires [[doom-module::tools pdf]] module)
 
 They are searched for in this order. See ~+latex-viewers~ to change the order,
 or remove tools from the search altogether. If you want to exclusively use one
@@ -130,8 +130,8 @@ is used as a fallback. You can use this exclusively by setting ~+latex-viewers~
 to ~nil~.
 
 ** Using cdlatex's snippets despite having yasnippet
-[[doom-package:][cdlatex]] has a snippet insertion capability which is disabled in favor of
-[[doom-package:][yasnippet]] when using [[doom-module:][:editor snippets]]. If you still wanna use it, simply rebind
+[[doom-package:cdlatex]] has a snippet insertion capability which is disabled in favor of
+[[doom-package:yasnippet]] when using [[doom-module::editor snippets]]. If you still wanna use it, simply rebind
 the [[kbd:][TAB]] key for cdlatex, which takes care of snippet-related stuff:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el

--- a/modules/lang/lean/README.org
+++ b/modules/lang/lean/README.org
@@ -13,8 +13,8 @@ This module adds support for the [[https://leanprover.github.io/about/][Lean pro
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][lean-mode]]
-- [[doom-package:][company-lean]] if [[doom-module:][:completion company]]
+- [[doom-package:lean-mode]]
+- [[doom-package:company-lean]] if [[doom-module::completion company]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/lang/ledger/README.org
+++ b/modules/lang/ledger/README.org
@@ -29,9 +29,9 @@ This modules enables the following features:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][evil-ledger]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][flycheck-ledger]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][ledger-mode]]
+- [[doom-package:evil-ledger]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:flycheck-ledger]] if [[doom-module::checkers syntax]]
+- [[doom-package:ledger-mode]]
 
 ** Hacks
 - This module sets ~ledger-clear-whole-transactions~ to ~t~ (default value is

--- a/modules/lang/lua/README.org
+++ b/modules/lang/lua/README.org
@@ -20,18 +20,18 @@ This module adds Lua support to Doom Emacs.
 - +fennel ::
   Enable support for the Fennel language.
 - +lsp ::
-  Enable LSP support for ~lua-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~lua-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports EmmyLua, lua-language-server, and lua-lsp).
 - +moonscript ::
   Enable support for the Moonscript language.
 
 ** Packages
-- [[doom-package:][company-lua]] if [[doom-module:][:completion company]]
-- [[doom-package:][fennel-mode]] if [[doom-module:][+fennel]]
-- [[doom-package:][lua-mode]]
-- if [[doom-module:][+moonscript]]
-  - [[doom-package:][flycheck-moonscript]] if [[doom-module:][:checkers syntax]]
-  - [[doom-package:][moonscript-mode]]
+- [[doom-package:company-lua]] if [[doom-module::completion company]]
+- [[doom-package:fennel-mode]] if [[doom-module:+fennel]]
+- [[doom-package:lua-mode]]
+- if [[doom-module:+moonscript]]
+  - [[doom-package:flycheck-moonscript]] if [[doom-module::checkers syntax]]
+  - [[doom-package:moonscript-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -48,8 +48,8 @@ fennel and moonscript transpilers. An LSP server is also required for LSP
 support.
 
 ** Language Server Protocol servers
-LSP server support depends on which flavor of the [[doom-module:][:tools lsp]] module you have
-installed ([[doom-package:][eglot]] or [[doom-package:][lsp-mode]]).
+LSP server support depends on which flavor of the [[doom-module::tools lsp]] module you have
+installed ([[doom-package:eglot]] or [[doom-package:lsp-mode]]).
 
 *** LSP-mode
 Three servers are supported, ordered from highest to lowest priority:
@@ -81,7 +81,7 @@ Eglot currently only supports one of the above servers out of the box:
  🔨 /This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-- lua-lsp-dir :: This must be set when using [[doom-module:][+lsp]] and using [[https://github.com/sumneko/lua-language-server][lua-language-server]].
+- lua-lsp-dir :: This must be set when using [[doom-module:+lsp]] and using [[https://github.com/sumneko/lua-language-server][lua-language-server]].
   This controls where the repository has been cloned and built to finish the
   configuration of the server.
 

--- a/modules/lang/markdown/README.org
+++ b/modules/lang/markdown/README.org
@@ -35,14 +35,14 @@ for Markdown's syntax is the format of plain text email. -- John Gruber
   previews of your markdown (or org) files.
 
 ** Packages
-- [[doom-package:][edit-indirect]]
-- [[doom-package:][evil-markdown]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][grip-mode]] if [[doom-module:][+grip]]
-- [[doom-package:][markdown-mode]]
-- [[doom-package:][markdown-toc]]
+- [[doom-package:edit-indirect]]
+- [[doom-package:evil-markdown]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:grip-mode]] if [[doom-module:+grip]]
+- [[doom-package:markdown-mode]]
+- [[doom-package:markdown-toc]]
 
 ** Hacks
-- [[doom-package:][flyspell]] has been configured not to spell check in code blocks, links, HTML
+- [[doom-package:flyspell]] has been configured not to spell check in code blocks, links, HTML
   tags or references.
 
 ** TODO Changelog
@@ -53,7 +53,7 @@ for Markdown's syntax is the format of plain text email. -- John Gruber
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
 This module requires:
-- A linter (requires [[doom-module:][:checkers syntax]])
+- A linter (requires [[doom-module::checkers syntax]])
 - A markdown compiler, for previewing Markdown
 
 ** Linters
@@ -124,7 +124,7 @@ installed through your OS's package manager:
 ~markdown-preview~ is bound to [[kbd:][<localleader> p]]. This will open a preview of your
 compiled markdown document in your browser.
 
-Alternatively, you can use ~grip-mode~ through [[doom-module:][+grip]].
+Alternatively, you can use ~grip-mode~ through [[doom-module:+grip]].
 
 * Configuration
 #+begin_quote

--- a/modules/lang/nim/README.org
+++ b/modules/lang/nim/README.org
@@ -6,9 +6,9 @@
 * Description :unfold:
 This module adds [[https://nim-lang.org][Nim]] support to Doom Emacs.
 
-- Code completion ([[doom-package:][nimsuggest]] + [[doom-package:][company]])
-- Syntax checking ([[doom-package:][nimsuggest]] + [[doom-package:][flycheck]])
-- Org babel support ([[doom-package:][ob-nim]])
+- Code completion ([[doom-package:nimsuggest]] + [[doom-package:company]])
+- Syntax checking ([[doom-package:nimsuggest]] + [[doom-package:flycheck]])
+- Org babel support ([[doom-package:ob-nim]])
 
 ** Maintainers
 *This module needs a maintainer.* [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -17,13 +17,13 @@ This module adds [[https://nim-lang.org][Nim]] support to Doom Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][flycheck-nim]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][nim-mode]]
+- [[doom-package:flycheck-nim]] if [[doom-module::checkers syntax]]
+- [[doom-package:nim-mode]]
 
 ** Hacks
-- [[doom-package:][nimsuggest]] was modified to strip invalid characters from its temp file paths
+- [[doom-package:nimsuggest]] was modified to strip invalid characters from its temp file paths
   (which would break nimsuggest on Windows systems).
-- [[doom-package:][nim-mode]] was modified to fail gracefully if =nimsuggest= (the executable)
+- [[doom-package:nim-mode]] was modified to fail gracefully if =nimsuggest= (the executable)
   isn't available.
 
 ** TODO Changelog

--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -9,7 +9,7 @@ for managing [[https://nixos.org/][Nix(OS)]].
 
 Includes:
 - Syntax highlighting
-- Completion through [[doom-package:][company]] and/or [[doom-package:][helm]]
+- Completion through [[doom-package:company]] and/or [[doom-package:helm]]
 - Nix option lookup
 - Formatting (~nixfmt~)
 
@@ -21,13 +21,13 @@ Includes:
 ** Module flags
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][company-nixos-options]] if [[doom-module:][:completion company]]
-- [[doom-package:][helm-nixos-options]] if [[doom-module:][:completion helm]]
-- [[doom-package:][nix-mode]]
-- [[doom-package:][nix-update]]
+- [[doom-package:company-nixos-options]] if [[doom-module::completion company]]
+- [[doom-package:helm-nixos-options]] if [[doom-module::completion helm]]
+- [[doom-package:nix-mode]]
+- [[doom-package:nix-update]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -42,7 +42,7 @@ Includes:
 This module requires:
 - [[https://nixos.org/guides/install-nix.html][The Nix package manager]], for a variety of its features (besides syntax
   highlighting).
-- =nixfmt=, for automatic formatting (requires [[doom-module:][:editor format]]).
+- =nixfmt=, for automatic formatting (requires [[doom-module::editor format]]).
 
 - *MacOS:* TODO
 - *Arch Linux:* TODO

--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -4,45 +4,45 @@
 #+since:    2.0.4 (#128)
 
 * Description :unfold:
-This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:][tuareg-mode]].
+This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:tuareg-mode]].
 
 - Code completion, documentation look-up, code navigation and refactoring
-  ([[doom-package:][merlin]])
-- Type, documentation and function argument display on idle ([[doom-package:][merlin-eldoc]])
-- REPL ([[doom-package:][utop]])
-- Syntax-checking ([[doom-package:][merlin]] with [[doom-package:][flycheck-ocaml]])
-- Auto-indentation ([[doom-package:][ocp-indent]])
-- Code formatting ([[doom-package:][ocamlformat]])
-- Dune file format ([[doom-package:][dune]])
+  ([[doom-package:merlin]])
+- Type, documentation and function argument display on idle ([[doom-package:merlin-eldoc]])
+- REPL ([[doom-package:utop]])
+- Syntax-checking ([[doom-package:merlin]] with [[doom-package:flycheck-ocaml]])
+- Auto-indentation ([[doom-package:ocp-indent]])
+- Code formatting ([[doom-package:ocamlformat]])
+- Dune file format ([[doom-package:dune]])
 
 ** Maintainers
 *This module needs a maintainer.* [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~tuareg-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~tuareg-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/freebroccolo/ocaml-language-server][ocaml-language-server]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][dune]]
-- [[doom-package:][ocamlformat]] if [[doom-module:][:editor format]]
-- [[doom-package:][ocp-indent]]
-- [[doom-package:][tuareg]]
-- [[doom-package:][utop]] if [[doom-module:][:tools eval]]
-- unless [[doom-module:][+lsp]]
-  - [[doom-package:][flycheck-ocaml]] if [[doom-module:][:checkers syntax]]
-  - [[doom-package:][merlin]]
-  - [[doom-package:][merlin-company]]
-  - [[doom-package:][merlin-eldoc]]
+- [[doom-package:dune]]
+- [[doom-package:ocamlformat]] if [[doom-module::editor format]]
+- [[doom-package:ocp-indent]]
+- [[doom-package:tuareg]]
+- [[doom-package:utop]] if [[doom-module::tools eval]]
+- unless [[doom-module:+lsp]]
+  - [[doom-package:flycheck-ocaml]] if [[doom-module::checkers syntax]]
+  - [[doom-package:merlin]]
+  - [[doom-package:merlin-company]]
+  - [[doom-package:merlin-eldoc]]
 
 ** Hacks
 - ~set-ligatures!~ is called with the full tuareg prettify symbol list, this can
   cause columns to change as certain keywords are shortened (e.g. =fun= becomes
   \lambda).
-- ~tuareg-opam-update-env~ is called the first time [[doom-package:][tuareg]] is loaded
+- ~tuareg-opam-update-env~ is called the first time [[doom-package:tuareg]] is loaded
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
@@ -86,16 +86,16 @@ This module requires the following packages available through [[http://opam.ocam
  🔨 /This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-- If [[doom-module:][:completion company]] is enabled then autocomplete is provided by [[doom-package:][merlin]]
-- When [[doom-module:][:checkers syntax]] is enabled then [[doom-package:][flycheck-ocaml]] is activated to do
-  on-the-fly syntax/type checking via [[doom-package:][merlin]], otherwise this is only done when
+- If [[doom-module::completion company]] is enabled then autocomplete is provided by [[doom-package:merlin]]
+- When [[doom-module::checkers syntax]] is enabled then [[doom-package:flycheck-ocaml]] is activated to do
+  on-the-fly syntax/type checking via [[doom-package:merlin]], otherwise this is only done when
   the file is saved.
-- Spell checking is activated in comments if [[doom-module:][:checkers spell]] is active
-- A REPL is provided if [[doom-package:][utop]] is installed and [[doom-module:][:tools eval]] is active
-- If [[doom-module:][:editor format]] is enabled, the =ocamlformat= executable is available and
+- Spell checking is activated in comments if [[doom-module::checkers spell]] is active
+- A REPL is provided if [[doom-package:utop]] is installed and [[doom-module::tools eval]] is active
+- If [[doom-module::editor format]] is enabled, the =ocamlformat= executable is available and
   there is an =.ocamlformat= file present then ~format-all-buffer~ is bound to
   =ocamlformat=, otherwise to =ocp-indent=
-- If [[doom-module:][:editor multiple-cursors]] is enabled then identifiers can be refactored with
+- If [[doom-module::editor multiple-cursors]] is enabled then identifiers can be refactored with
   [[kbd:][v R]] and multiple cursors (this correctly matches identifier occurrences
   according to scope, it is not purely a textual match)
 

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -18,7 +18,7 @@ intuitive out of the box:
 - A configuration for using org-mode for slide-show presentations or exporting
   org files to reveal.js slideshows.
 - Drag-and-drop support for images (with inline preview) and media files (drops
-  a file icon and a short link) (requires [[doom-module:][+dragndrop]] flag).
+  a file icon and a short link) (requires [[doom-module:+dragndrop]] flag).
 - Integration with pandoc, ipython, jupyter, reveal.js, beamer, and others
   (requires flags).
 - Export-to-clipboard functionality, for copying text into formatted html,
@@ -58,12 +58,12 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 - +ipython ::
   (**DEPRECATED**) Enable ipython integration for babel.
 - +journal ::
-  Enable [[doom-package:][org-journal]] integration.
+  Enable [[doom-package:org-journal]] integration.
 - +jupyter ::
   Enable Jupyter integration for babel.
 - +noter ::
-  Enable [[doom-package:][org-noter]] integration. Keeps notes in sync with a document. Requires
-  [[doom-module:][:tools pdf]], [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][DocView]], or [[https://github.com/wasamasa/nov.el][nov.el]] to be enabled.
+  Enable [[doom-package:org-noter]] integration. Keeps notes in sync with a document. Requires
+  [[doom-module::tools pdf]], [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][DocView]], or [[https://github.com/wasamasa/nov.el][nov.el]] to be enabled.
 - +pandoc ::
   Enable pandoc integration into the Org exporter.
 - +passwords ::
@@ -79,10 +79,10 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   too slow, it'd be wise to disable this flag.
 - +roam ::
   Enable integration with [[https://github.com/org-roam/org-roam-v1][org-roam v1]]. This requires ~sqlite3~ to be installed
-  on your system. /Incompatible with [[doom-module:][+roam2]]./
+  on your system. /Incompatible with [[doom-module:+roam2]]./
 - +roam2 ::
   Enable integration with [[https://github.com/org-roam/org-roam][org-roam v2]]. This requires ~sqlite3~ to be installed
-  on your system. /Incompatible with [[doom-module:][+roam]]./
+  on your system. /Incompatible with [[doom-module:+roam]]./
 
 ** Packages
 - [[doom-package:][evil-org]] if [[doom-package:][:editor evil]]
@@ -128,16 +128,16 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 ** Hacks
 - Adds support for a ~:sync~ parameter for org src blocks. This overrides
   ~:async~.
-- Gracefully degrades ~:async~ babel blocks to ~:sync~ when [[doom-package:][ob-async]] would cause
-  errors or issues (such as with a ~:session~ parameter, which [[doom-package:][ob-async]] does not
+- Gracefully degrades ~:async~ babel blocks to ~:sync~ when [[doom-package:ob-async]] would cause
+  errors or issues (such as with a ~:session~ parameter, which [[doom-package:ob-async]] does not
   support, or when exporting org documents).
 - The window is recentered when following links.
 - The breadcrumbs displayed in eldoc when hovering over an org headline has been
   reworked to strip out link syntax and normalize font-size disparities.
-- If [[doom-module:][:ui workspaces]] is enabled, persp-mode won't register org agenda buffers
+- If [[doom-module::ui workspaces]] is enabled, persp-mode won't register org agenda buffers
   that are temporarily opened in the background.
 - Temporary org agenda files aren't added to recentf.
-- =file:= links are highlighted with the ~error~ face if they are broken.
+- =file:= links are highlighted with the [[face:error]] face if they are broken.
 - TAB was changed to toggle only the visibility state of the current subtree,
   rather than cycle through it recursively. This can be reversed with:
 
@@ -146,19 +146,19 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
     (remove-hook 'org-tab-first-hook #'+org-cycle-only-current-subtree-h))
   #+end_src
 - (Evil users) Nearby tables are formatted when exiting insert or replace mode
-  (see ~+org-enable-auto-reformat-tables-h~).
+  (see [[fn:+org-enable-auto-reformat-tables-h]]).
 - Statistics cookies are updated when saving the buffer of exiting insert mode
-  (see ~+org-enable-auto-update-cookies-h~).
-- Org-protocol has been lazy loaded (see ~+org-init-protocol-lazy-loader-h~);
-  loaded when the server receives a request for an org-protocol:// url.
+  (see [[fn:+org-enable-auto-update-cookies-h]]).
+- Org-protocol has been lazy loaded (see [[fn:+org-init-protocol-lazy-loader-h]]);
+  loaded when the server receives a request for an =org-protocol://= url.
 - Babel and babel plugins are now lazy loaded (see
-  ~+org-init-babel-lazy-loader-h~); loaded when a src block is executed. No need
-  to use ~org-babel-do-load-languages~ in your config, just install your babel
+  [[fn:+org-init-babel-lazy-loader-h]]); loaded when a src block is executed. No need
+  to use [[fn:org-babel-do-load-languages]] in your config, just install your babel
   packages to extend language support (and ensure its ~org-babel-execute:*~
   function is autoloaded).
-- If a variable is used as a file path in ~org-capture-template~, it will be
-  resolved relative to ~org-directory~, instead of ~default-directory~ (see
-  ~+org-capture-expand-variable-file-a~).
+- If a variable is used as a file path in [[var:org-capture-template]], it will be
+  resolved relative to [[var:org-directory]], instead of [[var:default-directory]] (see
+  [[fn:+org--capture-expand-variable-file-a]]).
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
@@ -169,14 +169,14 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 
 This module has no hard requirements, but these soft requirements are needed to
 use Org's more esoteric features:
-- For inline LaTeX previews, ~latex~ and ~dvipng~ is needed.
-- To render GNUPlot images (with [[doom-module:][+gnuplot]] flag) the ~gnuplot~ program is needed.
+- For inline LaTeX previews, [[doom-executable:latex]] and [[doom-executable:dvipng]] is needed.
+- To render GNUPlot images (with [[doom-module:+gnuplot]] flag) the [[doom-executable:gnuplot]] program is needed.
 - To execute babel code blocks, you need whatever dependencies those languages
-  need. It is recommended you enable the associated [[doom-module:][:lang]] module and ensure its
-  dependencies are met, e.g. install the =ruby= executable for ruby support. To
-  use ~jupyter kernels~ you need the [[doom-module:][+jupyter]] flag, the associated kernel as
-  well as the ~jupyter~ program.
-- [[doom-package:][org-roam]] (with [[doom-module:][+roam]] or [[doom-module:][+roam2]] flag) requires =sqlite3= to be installed.
+  need. It is recommended you enable the associated [[doom-module::lang]] module and ensure its
+  dependencies are met, e.g. install the [[doom-executable:ruby]] executable for ruby support. To
+  use ~jupyter kernels~ you need the [[doom-module:+jupyter]] flag, the associated kernel as
+  well as the [[doom-executable:jupyter]] program.
+- [[doom-package:org-roam]] (with [[doom-module:+roam]] or [[doom-module:+roam2]] flag) requires [[doom-executable:sqlite3]] to be installed.
 
 ** MacOS
 #+begin_src sh
@@ -246,7 +246,7 @@ For =evil-mode= users, an overview of org-mode keybindings is provided [[https:/
 #+end_quote
 
 ** Changing ~org-directory~
-~org-directory~ must be set /before/ [[doom-package:][org]] has loaded:
+~org-directory~ must be set /before/ [[doom-package:org]] has loaded:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
 (setq org-directory "~/new/org/location/")
@@ -263,9 +263,9 @@ For =evil-mode= users, an overview of org-mode keybindings is provided [[https:/
 
 ** =org-roam=
 *** Should I go with =+roam= (v1) or =+roam2= (v2)?
-Long story short: if you're new to [[doom-package:][org-roam]] and haven't used it, then you should
-go with [[doom-module:][+roam2]]; if you already have an ~org-roam-directory~ with the v1 files in
-it, then you can keep use [[doom-module:][+roam]] for a time being.
+Long story short: if you're new to [[doom-package:org-roam]] and haven't used it, then you should
+go with [[doom-module:+roam2]]; if you already have an ~org-roam-directory~ with the v1 files in
+it, then you can keep use [[doom-module:+roam]] for a time being.
 
 V1 isn't actively maintained anymore and is now basically EOL. This means that
 the feature disparity between the both will continue to grow, while its existing
@@ -289,7 +289,7 @@ appear during the migration process. Because of that, *don't forget to backup*
 your ~org-roam-directory~ before attempting to migrate.
 
 In order to migrate from v1 to v2 using Doom follow the next steps:
-1. Enable [[doom-module:][+roam2]] flag (and disable [[doom-module:][+roam]] if it was previously enabled) in your
+1. Enable [[doom-module:+roam2]] flag (and disable [[doom-module:+roam]] if it was previously enabled) in your
    =init.el=.
 2. Ensure your ~org-roam-directory~ points to a directory with your v1 files.
 3. Run ~$ doom sync -u~ in your shell.

--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -77,36 +77,36 @@ exist, and `org-link' otherwise."
                                     keystr t t)))
   keystr)
 
-(defun +org-link--read-module-link (link)
+(defun +org-link--read-module-spec (module-spec-str)
   (cl-destructuring-bind (category &optional module flag)
-      (let ((desc (+org-link-read-desc-at-point link)))
-        (if (string-prefix-p "+" (string-trim-left desc))
-            (list nil nil (intern desc))
-          (mapcar #'intern (split-string desc " " nil))))
+      (if (string-prefix-p "+" (string-trim-left module-spec-str))
+          (list nil nil (intern module-spec-str))
+        (mapcar #'intern (split-string module-spec-str " " nil)))
     (list :category category
           :module module
           :flag flag)))
 
 ;;;###autoload
-(defun +org-link--doom-module-link-face-fn (link)
+(defun +org-link--doom-module-link-face-fn (module-path)
   (cl-destructuring-bind (&key category module flag)
-      (+org-link--read-module-link link)
+      (+org-link--read-module-spec module-path)
     (if (doom-module-locate-path category module)
         `(:inherit org-priority
           :weight bold)
       'error)))
+
 ;;;###autoload
-(defun +org-link-follow-doom-module-fn (link)
+(defun +org-link-follow-doom-module-fn (module-path _prefixarg)
   "TODO"
   (cl-destructuring-bind (&key category module flag)
-      (+org-link--read-module-link link)
+      (+org-link--read-module-spec module-path)
     (when category
       (let ((doom-modules-dirs (list doom-modules-dir)))
         (if-let* ((path (doom-module-locate-path category module))
                   (path (or (car (doom-glob path "README.org"))
                             path)))
             (find-file path)
-          (user-error "Can't find Doom module '%s'" link))))
+          (user-error "Can't find Doom module '%s'" module-path))))
     (when flag
       (goto-char (point-min))
       (when (and (re-search-forward "^\\*+ \\(?:TODO \\)?Module flags")
@@ -118,11 +118,9 @@ exist, and `org-link' otherwise."
         (recenter)))))
 
 ;;;###autoload
-(defun +org-link-follow-doom-package-fn (link)
+(defun +org-link-follow-doom-package-fn (pkg _prefixarg)
   "TODO"
-  (doom/describe-package
-   (intern-soft
-    (+org-link-read-desc-at-point link))))
+  (doom/describe-package (intern-soft pkg)))
 
 
 ;;

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -542,11 +542,10 @@ relative to `org-directory', unless it is an absolute path."
   ;; Add "lookup" links for packages and keystrings; useful for Emacs
   ;; documentation -- especially Doom's!
   (letf! ((defun -call-interactively (fn)
-            (lambda (link)
-              (let ((desc (+org-link-read-desc-at-point link)))
-                (funcall
-                 fn (or (intern-soft desc)
-                        (user-error "Can't find documentation for %S" desc))))))
+            (lambda (path _prefixarg)
+              (funcall
+               fn (or (intern-soft path)
+                      (user-error "Can't find documentation for %S" path)))))
           (defun -eldoc-fn (label face)
             (lambda (context)
               (format "%s %s"

--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -31,24 +31,24 @@ This module adds support for PHP 5.3+ (including PHP7) to Doom Emacs.
 - +hack ::
   Add support for the [[https://hacklang.org/][Hack dialect of PHP]] by Facebook.
 - +lsp ::
-  Enable LSP support for ~php-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~php-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://phpactor.readthedocs.io/en/develop/usage/standalone.html][phpactor]] and intelephense).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][async]]
-- [[doom-package:][hack-mode]] if [[doom-module:][+hack]]
-- [[doom-package:][php-boris]]
-- [[doom-package:][php-cs-fixer]] if [[doom-package:][:editor format]]
-- [[doom-package:][php-extras]]
-- [[doom-package:][php-mode]]
-- [[doom-package:][php-refactor-mode]]
-- [[doom-package:][phpunit]]
-- if [[doom-module:][+lsp]]
-  - [[doom-package:][phpactor]]
-  - [[doom-package:][company-phpactor]]
+- [[doom-package:async]]
+- [[doom-package:hack-mode]] if [[doom-module:+hack]]
+- [[doom-package:php-boris]]
+- [[doom-package:php-cs-fixer]] if [[doom-package::editor format]]
+- [[doom-package:php-extras]]
+- [[doom-package:php-mode]]
+- [[doom-package:php-refactor-mode]]
+- [[doom-package:phpunit]]
+- if [[doom-module:+lsp]]
+  - [[doom-package:phpactor]]
+  - [[doom-package:company-phpactor]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -62,7 +62,7 @@ This module adds support for PHP 5.3+ (including PHP7) to Doom Emacs.
 
 This module requires ~php~ (5.3+) and ~composer~.
 
-If [[doom-module:][+lsp]] is enabled, you'll also need one of these LSP servers:
+If [[doom-module:+lsp]] is enabled, you'll also need one of these LSP servers:
 - Phpactor requires ~php~ 7.3+.
 - Intelephense requires ~node~ and ~npm~.
 

--- a/modules/lang/plantuml/README.org
+++ b/modules/lang/plantuml/README.org
@@ -14,8 +14,8 @@ from plain text.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][plantuml-mode]]
-- [[doom-package:][flycheck-plantuml]] if [[doom-module:][:checkers syntax]]
+- [[doom-package:plantuml-mode]]
+- [[doom-package:flycheck-plantuml]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/purescript/README.org
+++ b/modules/lang/purescript/README.org
@@ -11,13 +11,13 @@ This module adds [[https://www.purescript.org/][Purescript]] support to Doom Ema
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~purescript-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~purescript-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/nwolverson/purescript-language-server][purescript-language-server]]).
 
 ** Packages
-- [[doom-package:][psci]]
-- [[doom-package:][psc-ide]]
-- [[doom-package:][purescript-mode]]
+- [[doom-package:psci]]
+- [[doom-package:psc-ide]]
+- [[doom-package:purescript-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -6,10 +6,10 @@
 * Description :unfold:
 This module adds [[https://www.python.org/][Python]] support to Doom Emacs.
 
-- Syntax checking ([[doom-package:][flycheck]])
+- Syntax checking ([[doom-package:flycheck]])
 - Snippets
-- Run tests ([[doom-package:][nose]], [[doom-package:][pytest]])
-- Auto-format (with ~black~, requires [[doom-module:][:editor format]])
+- Run tests ([[doom-package:nose]], [[doom-package:pytest]])
+- Auto-format (with ~black~, requires [[doom-module::editor format]])
 - LSP integration (=mspyls=, =pyls=, or =pyright=)
 
 ** Maintainers
@@ -23,7 +23,7 @@ This module adds [[https://www.python.org/][Python]] support to Doom Emacs.
 - +cython ::
   Enable support for Cython files support.
 - +lsp ::
-  Enable LSP support for ~python-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~python-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports mspyls, pyls, and pyright).
 - +poetry ::
   Enable Python packaging, dependency management, and virtual environment
@@ -31,33 +31,33 @@ This module adds [[https://www.python.org/][Python]] support to Doom Emacs.
 - +pyenv ::
   Enable Python virtual environment support via [[https://github.com/pyenv/pyenv][pyenv]]
 - +pyright ::
-  Use the pyright LSP server instead of mspyls or pyls (requires [[doom-module:][+lsp]]).
+  Use the pyright LSP server instead of mspyls or pyls (requires [[doom-module:+lsp]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][anaconda-mode]]
-- [[doom-package:][conda]]
-- [[doom-package:][nose]]
-- [[doom-package:][pipenv]]
-- [[doom-package:][pip-requirements]]
-- [[doom-package:][poetry]] if [[doom-module:][+poetry]]
-- [[doom-package:][pyenv]]
-- [[doom-package:][pyimport]]
-- [[doom-package:][py-isort]]
-- [[doom-package:][python-pytest]]
-- if [[doom-module:][+cython]]
-  - [[doom-package:][cython-mode]]
-  - [[doom-package:][flycheck-cython]] if [[doom-module:][:checkers syntax]]
-- if [[doom-module:][+lsp]]
-  - if [[doom-module:][+pyright]]
-    - [[doom-package:][lsp-pyright]]
+- [[doom-package:anaconda-mode]]
+- [[doom-package:conda]]
+- [[doom-package:nose]]
+- [[doom-package:pipenv]]
+- [[doom-package:pip-requirements]]
+- [[doom-package:poetry]] if [[doom-module:+poetry]]
+- [[doom-package:pyenv]]
+- [[doom-package:pyimport]]
+- [[doom-package:py-isort]]
+- [[doom-package:python-pytest]]
+- if [[doom-module:+cython]]
+  - [[doom-package:cython-mode]]
+  - [[doom-package:flycheck-cython]] if [[doom-module::checkers syntax]]
+- if [[doom-module:+lsp]]
+  - if [[doom-module:+pyright]]
+    - [[doom-package:lsp-pyright]]
   - else
-    - [[doom-package:][lsp-python-ms]]
+    - [[doom-package:lsp-python-ms]]
 
 ** Hacks
-- [[doom-package:][anaconda-mode]] is configured to activate when [[doom-package:][lsp-mode]] (or [[doom-package:][eglot]]) don't -- or
+- [[doom-package:anaconda-mode]] is configured to activate when [[doom-package:lsp-mode]] (or [[doom-package:eglot]]) don't -- or
   fail to.
 
 ** TODO Changelog
@@ -71,9 +71,9 @@ This module has no hard requirements, but softly depends on:
 - For this module's supported test runners:
   - ~$ pip install pytest~
   - ~$ pip install nose~
-- The [[doom-module:][:editor format]] module uses Black for python files: ~$ pip install black~
-- [[doom-package:][pyimport]] requires Python's module ~pyflakes~: ~$ pip install pyflakes~
-- [[doom-package:][py-isort]] requires [[https://github.com/timothycrosley/isort][isort]] to be installed: ~pip install isort~
+- The [[doom-module::editor format]] module uses Black for python files: ~$ pip install black~
+- [[doom-package:pyimport]] requires Python's module ~pyflakes~: ~$ pip install pyflakes~
+- [[doom-package:py-isort]] requires [[https://github.com/timothycrosley/isort][isort]] to be installed: ~pip install isort~
 - Python virtual environments install instructions at:
   - [[https://github.com/pyenv/pyenv][pyenv]]
   - [[https://conda.io/en/latest/][Conda]]
@@ -82,9 +82,9 @@ This module has no hard requirements, but softly depends on:
 - ~cython~ requires [[https://cython.org/][Cython]]
 
 ** Language Server Protocol Support
-For LSP support the [[doom-module:][:tools lsp]] module must be enabled, along with this module's
-[[doom-module:][+lsp]] flag. By default, it supports [[doom-package:][mspyls]] and [[doom-package:][pyls]], in that order. With the
-[[doom-module:][+pyright]] flag, it will try Pyright first.
+For LSP support the [[doom-module::tools lsp]] module must be enabled, along with this module's
+[[doom-module:+lsp]] flag. By default, it supports [[doom-package:mspyls]] and [[doom-package:pyls]], in that order. With the
+[[doom-module:+pyright]] flag, it will try Pyright first.
 
 Each of these servers must be installed on your system via your OS package
 manager or manually:
@@ -101,7 +101,7 @@ manager or manually:
 This module supports LSP. It requires installation of [[https://pypi.org/project/python-language-server/][Python Language Server]],
 [[https://github.com/Microsoft/python-language-server][Microsoft Language Server]], or [[https://github.com/microsoft/pyright][pyright]], see [[Language Server Protocol Support][LSP Support]].
 
-To enable support for auto-formatting with black enable [[doom-module:][:editor format]].
+To enable support for auto-formatting with black enable [[doom-module::editor format]].
 
 ** Keybindings
 | Binding           | Description                      |

--- a/modules/lang/qt/README.org
+++ b/modules/lang/qt/README.org
@@ -16,8 +16,8 @@ This module provides language functionality for [[https://qt.io][Qt]] specific f
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][qml-mode]]
-- [[doom-package:][qt-pro-mode]]
+- [[doom-package:qml-mode]]
+- [[doom-package:qt-pro-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -11,14 +11,14 @@ This module adds support for the [[https://www.racket-lang.org/][Racket programm
 
 ** Module flags
 - +lsp ::
-  Enable support for ~racket-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable support for ~racket-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/jeapostrophe/racket-langserver][racket-langserver]]).
 - +xp ::
   Enable the explore mode (~racket-xp-mode~), which "analyzes expanded code to
   explain and explore."
 
 ** Packages
-- [[doom-package:][racket-mode]]
+- [[doom-package:racket-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/raku/README.org
+++ b/modules/lang/raku/README.org
@@ -13,8 +13,8 @@ This module adds support for the [[https://www.raku.org/][Raku programming langu
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][raku-mode]]
-- [[doom-package:][flycheck-raku]] if [[doom-module:][:checkers syntax]]
+- [[doom-package:raku-mode]]
+- [[doom-package:flycheck-raku]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/rest/README.org
+++ b/modules/lang/rest/README.org
@@ -29,15 +29,15 @@ This module turns Emacs into a [[https://en.wikipedia.org/wiki/Representational_
   *Requires the =jq= command line utility.*
 
 ** Packages
-- [[doom-package:][company-restclient]] if [[doom-module:][:completion company]]
-- [[doom-package:][restclient]]
-- if [[doom-module:][+jq]]
-  - [[doom-package:][restclient-jq]]
-  - [[doom-package:][jq-mode]]
+- [[doom-package:company-restclient]] if [[doom-module::completion company]]
+- [[doom-package:restclient]]
+- if [[doom-module:+jq]]
+  - [[doom-package:restclient-jq]]
+  - [[doom-package:jq-mode]]
 
 ** Hacks
 - Adds imenu support to ~restclient-mode~.
-- [[doom-package:][restclient]] has been modified not to silently reject self-signed or invalid
+- [[doom-package:restclient]] has been modified not to silently reject self-signed or invalid
   certificates.
 
 ** TODO Changelog

--- a/modules/lang/rst/README.org
+++ b/modules/lang/rst/README.org
@@ -13,7 +13,7 @@ This module adds [[https://docutils.sourceforge.io/rst.html][ReStructured Text]]
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][sphinx-mode]]
+- [[doom-package:sphinx-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/ruby/README.org
+++ b/modules/lang/ruby/README.org
@@ -6,11 +6,11 @@
 * Description :unfold:
 This module add Ruby and optional Ruby on Rails support to Emacs.
 
-- Code completion ([[doom-package:][robe]])
-- Syntax checking ([[doom-package:][flycheck]])
-- Jump-to-definitions ([[doom-package:][robe]])
+- Code completion ([[doom-package:robe]])
+- Syntax checking ([[doom-package:flycheck]])
+- Jump-to-definitions ([[doom-package:robe]])
 - Bundler
-- Rubocop integration ([[doom-package:][flycheck]])
+- Rubocop integration ([[doom-package:flycheck]])
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -21,7 +21,7 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
 - +chruby ::
   Enable chruby integration.
 - +lsp ::
-  Enable LSP support for ~ruby-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~ruby-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports solargraph).
 - +rails ::
   Enable rails navigational commands, plus server+console integration.
@@ -31,23 +31,23 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
   Enable RVM (Ruby Version Manager) integration.
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][bundler]]
-- [[doom-package:][chruby]] if [[doom-module:][+chruby]]
-- [[doom-package:][company-inf-ruby]] if :completion company
-- [[doom-package:][inf-ruby]]
-- [[doom-package:][minitest]]
-- [[doom-package:][rake]]
-- [[doom-package:][rbenv]] if [[doom-module:][+rbenv]]
-- [[doom-package:][robe]]
-- [[doom-package:][rspec-mode]]
-- [[doom-package:][rubocop]]
-- [[doom-package:][rvm]] if [[doom-module:][+rvm]]
-- if [[doom-module:][+rails]]
-  - [[doom-package:][inflections]]
-  - [[doom-package:][projectile-rails]]
+- [[doom-package:bundler]]
+- [[doom-package:chruby]] if [[doom-module:+chruby]]
+- [[doom-package:company-inf-ruby]] if :completion company
+- [[doom-package:inf-ruby]]
+- [[doom-package:minitest]]
+- [[doom-package:rake]]
+- [[doom-package:rbenv]] if [[doom-module:+rbenv]]
+- [[doom-package:robe]]
+- [[doom-package:rspec-mode]]
+- [[doom-package:rubocop]]
+- [[doom-package:rvm]] if [[doom-module:+rvm]]
+- if [[doom-module:+rails]]
+  - [[doom-package:inflections]]
+  - [[doom-package:projectile-rails]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/rust/README.org
+++ b/modules/lang/rust/README.org
@@ -7,9 +7,9 @@
 This module adds support for the Rust language and integration for its tools,
 e.g. ~cargo~.
 
-- Code completion ([[doom-package:][racer]] or an LSP server)
-- Syntax checking ([[doom-package:][flycheck]])
-- LSP support (for rust-analyzer and rls) ([[doom-package:][rustic]])
+- Code completion ([[doom-package:racer]] or an LSP server)
+- Syntax checking ([[doom-package:flycheck]])
+- LSP support (for rust-analyzer and rls) ([[doom-package:rustic]])
 - Snippets
 
 ** Maintainers
@@ -19,15 +19,15 @@ e.g. ~cargo~.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~rustic-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~rustic-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://rust-analyzer.github.io/][rust-analyzer]] and rls).
 
 ** Packages
-- [[doom-package:][rustic]]
+- [[doom-package:rustic]]
 
 ** Hacks
 - rustic has been modified /not/ to automatically install lsp-mode or eglot if
-  they're missing. Doom expects you to have enabled the [[doom-module:][:tools lsp]] module
+  they're missing. Doom expects you to have enabled the [[doom-module::tools lsp]] module
   yourself.
 
 ** TODO Changelog
@@ -49,9 +49,9 @@ rustup update --no-self-update
 #+end_src
 
 ** Other Requirements
-- If [[doom-module:][:editor format]] is enabled, you'll need =rustfmt=: ~$ rustup component add
+- If [[doom-module::editor format]] is enabled, you'll need =rustfmt=: ~$ rustup component add
   rustfmt-preview~.
-- Users with [[doom-module:][+lsp]] enabled will need [[https://rust-analyzer.github.io/][rust-analyzer]] (rls is supported, but
+- Users with [[doom-module:+lsp]] enabled will need [[https://rust-analyzer.github.io/][rust-analyzer]] (rls is supported, but
   [[https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html][deprecated]]).
 - Using the following commands requires:
   - ~cargo-process-check~: ~$ cargo install cargo-check~
@@ -67,11 +67,11 @@ This module supports LSP integration. For it to work you'll need:
 
 1. To install [[https://github.com/rust-analyzer/rust-analyzer][rust-analyzer]] through your OS package manager ([[https://github.com/rust-lang/rls][RLS]] is supported
    too, but it is [[https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html][deprecated]]).
-2. To enable the [[doom-module:][:tools lsp]] module.
-3. To enable the [[doom-module:][+lsp]] flag on this module.
+2. To enable the [[doom-module::tools lsp]] module.
+3. To enable the [[doom-module:+lsp]] flag on this module.
 
 ** Format on save
-Enable [[doom-module:][:editor format +onsave]] to get formatting on save with =rustfmt=. No
+Enable [[doom-module::editor format +onsave]] to get formatting on save with =rustfmt=. No
 additional configuration is necessary.
 
 ** Keybinds
@@ -95,7 +95,7 @@ additional configuration is necessary.
 #+end_quote
 
 ** Enabling eglot support for Rust
-Doom's [[doom-module:][:tools lsp]] module has an [[doom-module:][+eglot]] flag. Enable it and this module will use
+Doom's [[doom-module::tools lsp]] module has an [[doom-module:+eglot]] flag. Enable it and this module will use
 eglot instead.
 
 * Troubleshooting
@@ -104,7 +104,7 @@ eglot instead.
 ** error[E0670]: `async fn` is not permitted in the 2015 edition
 You may be seeing this error, despite having ~edition = "2018"~ in your
 =Cargo.toml=. This error actually originates from ~rustfmt~, which the LSP
-server tries to invoke on save (if you have ~rustic-format-trigger~ or [[doom-module:][:editor
+server tries to invoke on save (if you have ~rustic-format-trigger~ or [[doom-module::editor
 format]] enabled).
 
 To fix this your project needs a =rustfmt.toml= with ~edition = "2018"~ in it.

--- a/modules/lang/scala/README.org
+++ b/modules/lang/scala/README.org
@@ -26,16 +26,16 @@ Through the power of [[https://scalameta.org/metals/docs/editors/overview.html][
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~scala-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~scala-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports metals).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][sbt-mode]]
-- [[doom-package:][scala-mode]]
-- [[doom-package:][lsp-metals]] if [[doom-module:][+lsp]]
+- [[doom-package:sbt-mode]]
+- [[doom-package:scala-mode]]
+- [[doom-package:lsp-metals]] if [[doom-module:+lsp]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/scheme/README.org
+++ b/modules/lang/scheme/README.org
@@ -22,18 +22,18 @@ This module provides support for the Scheme family of Lisp languages, powered by
 - +racket ::
 
 ** Packages
-- [[doom-package:][flycheck-guile]] if [[doom-module:][+guile]] and [[doom-module:][:checkers syntax]]
-- [[doom-package:][geiser]]
-- [[doom-package:][geiser-chez]] if [[doom-module:][+chez]]
-- [[doom-package:][geiser-chibi]] if [[doom-module:][+chibi]]
-- [[doom-package:][geiser-chicken]] if [[doom-module:][+chicken]]
-- [[doom-package:][geiser-gambit]] if [[doom-module:][+gambit]]
-- [[doom-package:][geiser-gauche]] if [[doom-module:][+gauche]]
-- [[doom-package:][geiser-guile]] if [[doom-module:][+guile]]
-- [[doom-package:][geiser-kawa]] if [[doom-module:][+kawa]]
-- [[doom-package:][geiser-mit]] if [[doom-module:][+mit]]
-- [[doom-package:][geiser-racket]] if [[doom-module:][+racket]]
-- [[doom-package:][macrostep-geiser]]
+- [[doom-package:flycheck-guile]] if [[doom-module:+guile]] and [[doom-module::checkers syntax]]
+- [[doom-package:geiser]]
+- [[doom-package:geiser-chez]] if [[doom-module:+chez]]
+- [[doom-package:geiser-chibi]] if [[doom-module:+chibi]]
+- [[doom-package:geiser-chicken]] if [[doom-module:+chicken]]
+- [[doom-package:geiser-gambit]] if [[doom-module:+gambit]]
+- [[doom-package:geiser-gauche]] if [[doom-module:+gauche]]
+- [[doom-package:geiser-guile]] if [[doom-module:+guile]]
+- [[doom-package:geiser-kawa]] if [[doom-module:+kawa]]
+- [[doom-package:geiser-mit]] if [[doom-module:+mit]]
+- [[doom-package:geiser-racket]] if [[doom-module:+racket]]
+- [[doom-package:macrostep-geiser]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -53,7 +53,7 @@ associated Schemes, namely:
 - [[https://synthcode.com/scheme/chibi][Chibi Scheme]] 0.7.3 or better
 - [[https://www.scheme.com][Chez Scheme]] 9.4 or better
 
-Their executables must be present in your =$PATH= for [[doom-package:][geiser]] to work properly.
+Their executables must be present in your =$PATH= for [[doom-package:geiser]] to work properly.
 
 * TODO Usage
 #+begin_quote

--- a/modules/lang/sh/README.org
+++ b/modules/lang/sh/README.org
@@ -7,8 +7,8 @@
 This module adds support for shell scripting languages (including Powershell and
 Fish script) to Doom Emacs.
 
-- Code completion ([[doom-package:][company-shell]])
-- Syntax Checking ([[doom-package:][flycheck]])
+- Code completion ([[doom-package:company-shell]])
+- Syntax Checking ([[doom-package:flycheck]])
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -19,18 +19,18 @@ Fish script) to Doom Emacs.
 - +fish ::
   Add syntax highlighting for fish script files.
 - +lsp ::
-  Enable LSP support for ~sh-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~sh-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports bash-language-server).
 - +powershell ::
   Add syntax highlighting for Powershell script files (=.ps1= and =.psm1=).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
  
 ** Packages
-- [[doom-package:][company-shell]] if [[doom-module:][:completion company]]
-- [[doom-package:][fish-mode]] if [[doom-module:][+fish]]
-- [[doom-package:][powershell-mode]] if [[doom-module:][+powershell]]
+- [[doom-package:company-shell]] if [[doom-module::completion company]]
+- [[doom-package:fish-mode]] if [[doom-module:+fish]]
+- [[doom-package:powershell-mode]] if [[doom-module:+powershell]]
 
 ** Hacks
 - Interpolated variables are fontified.
@@ -45,8 +45,8 @@ Fish script) to Doom Emacs.
 This module has several optional dependencies:
 
 - [[https://github.com/koalaman/shellcheck][shellcheck]]: Enables advanced shell script linting.
-- [[https://github.com/mads-hartmann/bash-language-server][bash-language-server]]: Enables LSP support (with [[doom-module:][+lsp]] flag).
-- With the [[doom-module:][:tools debugger]] module
+- [[https://github.com/mads-hartmann/bash-language-server][bash-language-server]]: Enables LSP support (with [[doom-module:+lsp]] flag).
+- With the [[doom-module::tools debugger]] module
   - [[http://bashdb.sourceforge.net/][bashdb]]: Enables debugging for bash scripts
   - [[https://github.com/rocky/zshdb][zshdb]]: Enables debugging for zsh scripts
 

--- a/modules/lang/sml/README.org
+++ b/modules/lang/sml/README.org
@@ -13,8 +13,8 @@ THis module adds [[https://smlfamily.github.io/][SML (Standard ML) programming l
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][company-mlton]] if [[doom-module:][:completion company]]
-- [[doom-package:][sml-mode]]
+- [[doom-package:company-mlton]] if [[doom-module::completion company]]
+- [[doom-package:sml-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/solidity/README.org
+++ b/modules/lang/solidity/README.org
@@ -6,8 +6,8 @@
 * Description :unfold:
 This module adds [[https://github.com/ethereum/solidity][Solidity]] support to Doom Emacs.
 
-- Syntax-checking ([[doom-package:][flycheck]])
-- Code completion ([[doom-package:][company-solidity]])
+- Syntax-checking ([[doom-package:flycheck]])
+- Code completion ([[doom-package:company-solidity]])
 - Gas estimation (~C-c C-g~)
 
 ** Maintainers
@@ -17,9 +17,9 @@ This module adds [[https://github.com/ethereum/solidity][Solidity]] support to D
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][company-solidity]] if [[doom-module:][:completion company]]
-- [[doom-package:][solidity-flycheck]] if [[doom-module:][:checkers syntax]]
-- [[doom-package:][solidity-mode]]
+- [[doom-package:company-solidity]] if [[doom-module::completion company]]
+- [[doom-package:solidity-flycheck]] if [[doom-module::checkers syntax]]
+- [[doom-package:solidity-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/swift/README.org
+++ b/modules/lang/swift/README.org
@@ -11,19 +11,19 @@ This module adds support for the [[https://developer.apple.com/swift/][Swift pro
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~swift-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~swift-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports sourcekit).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][swift-mode]]
-- if [[doom-module:][+lsp]]
-  - [[doom-package:][lsp-sourcekit]]
+- [[doom-package:swift-mode]]
+- if [[doom-module:+lsp]]
+  - [[doom-package:lsp-sourcekit]]
 - else
-  - [[doom-package:][company-sourcekit]] if [[doom-module:][:completion company]]
-  - [[doom-package:][flycheck-sourcekit]] if [[doom-module:][:checkers syntax]]
+  - [[doom-package:company-sourcekit]] if [[doom-module::completion company]]
+  - [[doom-package:flycheck-sourcekit]] if [[doom-module::checkers syntax]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/terra/README.org
+++ b/modules/lang/terra/README.org
@@ -13,8 +13,8 @@
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][company-lua]] if [[doom-module:][:completion company]]
-- [[doom-package:][terra-mode]]
+- [[doom-package:company-lua]] if [[doom-module::completion company]]
+- [[doom-package:terra-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/web/README.org
+++ b/modules/lang/web/README.org
@@ -15,26 +15,26 @@ ReactJS, Wordpress, Jekyll, Phaser, AngularJS, Djano, and more.
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~web-mode~ and ~css-mode~. Requires [[doom-module:][:tools lsp]] and a
+  Enable LSP support for ~web-mode~ and ~css-mode~. Requires [[doom-module::tools lsp]] and a
   langserver.
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][company-web]] if [[doom-module:][:completion company]]
-- [[doom-package:][counsel-css]] if [[doom-module:][:completion ivy]]
-- [[doom-package:][emmet-mode]]
-- [[doom-package:][haml-mode]]
-- [[doom-package:][helm-css-scss]] if [[doom-module:][:completion helm]]
-- [[doom-package:][less-css-mode]]
-- [[doom-package:][pug-mode]]
-- [[doom-package:][rainbow-mode]]
-- [[doom-package:][sass-mode]]
-- [[doom-package:][slim-mode]]
-- [[doom-package:][stylus-mode]]
-- [[doom-package:][sws-mode]]
-- [[doom-package:][web-mode]]
+- [[doom-package:company-web]] if [[doom-module::completion company]]
+- [[doom-package:counsel-css]] if [[doom-module::completion ivy]]
+- [[doom-package:emmet-mode]]
+- [[doom-package:haml-mode]]
+- [[doom-package:helm-css-scss]] if [[doom-module::completion helm]]
+- [[doom-package:less-css-mode]]
+- [[doom-package:pug-mode]]
+- [[doom-package:rainbow-mode]]
+- [[doom-package:sass-mode]]
+- [[doom-package:slim-mode]]
+- [[doom-package:stylus-mode]]
+- [[doom-package:sws-mode]]
+- [[doom-package:web-mode]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/lang/yaml/README.org
+++ b/modules/lang/yaml/README.org
@@ -11,11 +11,11 @@ This module provides support for the [[https://yaml.org/][YAML file format]] to 
 
 ** Module flags
 - +lsp ::
-  Enable LSP support for ~yaml-mode~. Requires [[doom-module:][:tools lsp]] and a langserver
+  Enable LSP support for ~yaml-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/redhat-developer/yaml-language-server][yaml-language-server]]).
 
 ** Packages
-- [[doom-package:][yaml-mode]]
+- [[doom-package:yaml-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/lang/zig/README.org
+++ b/modules/lang/zig/README.org
@@ -8,7 +8,7 @@ This module adds [[https://ziglang.org/][Zig]] support, with optional (but recom
 [[https://github.com/zigtools/zls][zls]].
 
 - Syntax highlighting
-- Syntax-checking ([[doom-package:][flycheck]])
+- Syntax-checking ([[doom-package:flycheck]])
 - Code completion and LSP integration (~zls~)
 
 ** Maintainers
@@ -22,10 +22,10 @@ This module adds [[https://ziglang.org/][Zig]] support, with optional (but recom
   this.
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
-  editing. Requires [[doom-module:][:tools tree-sitter]].
+  editing. Requires [[doom-module::tools tree-sitter]].
 
 ** Packages
-- [[doom-package:][zig-mode]]
+- [[doom-package:zig-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -52,8 +52,8 @@ systems are available for download from [[https://ziglang.org/download/]] or fro
 This module supports LSP integration. For it to work you'll need:
 
 1. zls installed,
-2. The [[doom-module:][:tools lsp]] module enabled. Only [[doom-package:][lsp-mode]] is supported for now,
-3. The [[doom-module:][+lsp]] flag on this module enabled.
+2. The [[doom-module::tools lsp]] module enabled. Only [[doom-package:lsp-mode]] is supported for now,
+3. The [[doom-module:+lsp]] flag on this module enabled.
 
 ** Keybinds
 | Binding           | Description         |

--- a/modules/os/macos/README.org
+++ b/modules/os/macos/README.org
@@ -13,8 +13,8 @@ This module provides extra functionality for macOS.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][ns-auto-titlebar]]
-- [[doom-package:][osx-trash]]
+- [[doom-package:ns-auto-titlebar]]
+- [[doom-package:osx-trash]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -37,8 +37,8 @@ This module requires a macOS environment.
 This module adds various macOS-specific launchers under the [[kbd:][SPC o]] prefix ([[kbd:][C-c
 o]] for users with Evil disabled).
 
-It also enables Keychain integration for [[doom-package:][auth-source]]. This is used by our [[doom-module:][:app
-irc]] and [[doom-module:][:tools magit]] modules, for instance.
+It also enables Keychain integration for [[doom-package:auth-source]]. This is used by our [[doom-module::app
+irc]] and [[doom-module::tools magit]] modules, for instance.
 
 To support GitHub Forge add an internet password like this to your keychain:
 | Field    | Value                   |

--- a/modules/os/tty/README.org
+++ b/modules/os/tty/README.org
@@ -23,9 +23,9 @@ This module configures Emacs for use in the terminal, by providing:
   connections or Tmux. However, this requires [[https://github.com/spudlyo/clipetty#terminals-that-support-osc-clipboard-operations][a supported terminal]].
 
 ** Packages
-- [[doom-package:][clipetty]] if [[doom-module:][+osc]]
-- [[doom-package:][evil-terminal-cursor-changer]] if [[doom-module:][:editor evil]]
-- [[doom-package:][xclip]] unless [[doom-module:][+osc]]
+- [[doom-package:clipetty]] if [[doom-module:+osc]]
+- [[doom-package:evil-terminal-cursor-changer]] if [[doom-module::editor evil]]
+- [[doom-package:xclip]] unless [[doom-module:+osc]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -45,7 +45,7 @@ need:
     - Linux: =xclip=, =xsel=, or =wl-clibpoard= (Wayland)
     - macOS: =pbcopy= and =pbpaste= (included with macOS)
     - Windows: =getclip= and =putclip= (cygwin)
-  - (If [[doom-module:][+osc]] is enabled) A terminal that supports OSC 52 escape codes, such as:
+  - (If [[doom-module:+osc]] is enabled) A terminal that supports OSC 52 escape codes, such as:
     xterm (unix), iTerm2 (macOS), alacritty (cross platform), kitty (macOS,
     linux), mintty (Windows), hterm (javascript), st (unix), mlterm (cross
     platform)

--- a/modules/term/README.org
+++ b/modules/term/README.org
@@ -6,9 +6,9 @@
 What's an operating system without a terminal? The modules in this category
 bring varying degrees of terminal emulation into Emacs.
 
-If you can't decide which to choose, I recommend [[doom-package:][vterm]] or [[doom-package:][eshell]]. [[doom-module:][:term vterm]]
+If you can't decide which to choose, I recommend [[doom-package:vterm]] or [[doom-package:eshell]]. [[doom-module::term vterm]]
 offers that best terminal emulation available but requires a few extra steps to
-get going. [[doom-module:][:term eshell]] works everywhere that Emacs runs, even Windows, and
+get going. [[doom-module::term eshell]] works everywhere that Emacs runs, even Windows, and
 provides a shell entirely implemented in Emacs Lisp.
 
 * Frequently asked questions

--- a/modules/term/eshell/README.org
+++ b/modules/term/eshell/README.org
@@ -6,7 +6,7 @@
 * Description :unfold:
 This module provides additional features for the built-in [[https://www.gnu.org/software/emacs/manual/html_mono/eshell.html][Emacs Shell]]
 
-The Emacs Shell or [[doom-package:][eshell]] is a shell-like command interpreter implemented in
+The Emacs Shell or [[doom-package:eshell]] is a shell-like command interpreter implemented in
 Emacs Lisp. It is an alternative to traditional shells such as =bash=, =zsh=,
 =fish=, etc. that is built into Emacs and entirely cross-platform.
 
@@ -19,19 +19,19 @@ Emacs Lisp. It is an alternative to traditional shells such as =bash=, =zsh=,
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][eshell-did-you-mean]]
-- [[doom-package:][eshell-up]]
-- [[doom-package:][eshell-z]]
-- [[doom-package:][esh-help]]
-- [[doom-package:][shrink-path]]
-- if [[doom-module:][:completion company]]
-  - [[doom-package:][fish-completion]]
-  - [[doom-package:][bash-completion]]
+- [[doom-package:eshell-did-you-mean]]
+- [[doom-package:eshell-up]]
+- [[doom-package:eshell-z]]
+- [[doom-package:esh-help]]
+- [[doom-package:shrink-path]]
+- if [[doom-module::completion company]]
+  - [[doom-package:fish-completion]]
+  - [[doom-package:bash-completion]]
 
 ** Hacks
 - Even with ~fish-completion-fallback-on-bash-p~ non-nil, fish must be installed
   for bash completion to work. This has been circumvented.
-- [[doom-package:][eshell-did-you-mean]] does not work on first invocation, so we manually invoke
+- [[doom-package:eshell-did-you-mean]] does not work on first invocation, so we manually invoke
   it once.
 
 ** TODO Changelog
@@ -59,7 +59,7 @@ This module requires either [[https://fishshell.com/][Fish shell]] or [[https://
 #+end_quote
 
 ** TERM name
-By default, [[doom-package:][eshell]] sets the =$TERM= variable to ~"xterm-256color"~, which helps
+By default, [[doom-package:eshell]] sets the =$TERM= variable to ~"xterm-256color"~, which helps
 with rendering various colours. As eshell is /not/ a terminal emulator, these
 will not always work 100%. Modifying ~eshell-term-name~ to your liking may help.
 

--- a/modules/term/shell/README.org
+++ b/modules/term/shell/README.org
@@ -8,8 +8,8 @@ Provides a REPL for your shell.
 
 #+begin_quote
  💡 =shell= is more REPL than terminal emulator. You can edit your command line
-    like you would any ordinary text in Emacs -- something you can't do in [[doom-package:][term]]
-    (without ~term-line-mode~, which can be unstable) or [[doom-package:][vterm]].
+    like you would any ordinary text in Emacs -- something you can't do in [[doom-package:term]]
+    (without ~term-line-mode~, which can be unstable) or [[doom-package:vterm]].
 
     Due to =shell='s simplicity, you're less likely to encounter edge cases
     (e.g. against your shell config), but it's also the least capable. TUI

--- a/modules/term/term/README.org
+++ b/modules/term/term/README.org
@@ -13,7 +13,7 @@
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][multi-term]]
+- [[doom-package:multi-term]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/term/vterm/README.org
+++ b/modules/term/vterm/README.org
@@ -8,7 +8,7 @@ This module provides a terminal emulator powered by libvterm. It is still in
 alpha and requires a component be compiled (=vterm-module.so=).
 
 #+begin_quote
- 💡 [[doom-package:][vterm]] is as good as terminal emulation gets in Emacs (at the time of
+ 💡 [[doom-package:vterm]] is as good as terminal emulation gets in Emacs (at the time of
     writing) and the most performant, as it is implemented in C. However, it
     requires extra steps to set up:
 
@@ -16,9 +16,9 @@ alpha and requires a component be compiled (=vterm-module.so=).
     - and =vterm-module.so= must be compiled, which depends on =libvterm=,
       =cmake=, and =libtool-bin=.
 
-    [[doom-package:][vterm]] will try to automatically build =vterm-module.so= when you first open
+    [[doom-package:vterm]] will try to automatically build =vterm-module.so= when you first open
     it, but this will fail on Windows, NixOS and Guix out of the box. Install
-    instructions for nix/guix can be found in the [[doom-module:][:term vterm]] module's
+    instructions for nix/guix can be found in the [[doom-module::term vterm]] module's
     documentation. There is no way to install vterm on Windows that I'm aware of
     (but perhaps with WSL?).
 #+end_quote
@@ -32,7 +32,7 @@ alpha and requires a component be compiled (=vterm-module.so=).
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][vterm]]
+- [[doom-package:vterm]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/ansible/README.org
+++ b/modules/tools/ansible/README.org
@@ -13,11 +13,11 @@
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][ansible]]
-- [[doom-package:][ansible-doc]]
-- [[doom-package:][company-ansible]] if [[doom-module:][:completion company]]
-- [[doom-package:][jinja2-mode]]
-- [[doom-package:][yaml-mode]]
+- [[doom-package:ansible]]
+- [[doom-package:ansible-doc]]
+- [[doom-package:company-ansible]] if [[doom-module::completion company]]
+- [[doom-package:jinja2-mode]]
+- [[doom-package:yaml-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/biblio/README.org
+++ b/modules/tools/biblio/README.org
@@ -19,12 +19,12 @@ selected so it should be possible to use without modifications.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][bibtex-completion]] if [[doom-module:][:completion ivy]] or [[doom-module:][:completion helm]]
-- [[doom-package:][parsebib]] if [[doom-module:][:completion ivy]] or [[doom-module:][:completion helm]] or [[doom-module:][:completion vertico]]
-- [[doom-package:][citar]] if [[doom-module:][:completion vertico]]
-- [[doom-package:][citar-embark]] if [[doom-module:][:completion vertico]]
-- [[doom-package:][helm-bibtex]] if [[doom-module:][:completion helm]]
-- [[doom-package:][ivy-bibtex]] if [[doom-module:][:completion ivy]]
+- [[doom-package:bibtex-completion]] if [[doom-module::completion ivy]] or [[doom-module::completion helm]]
+- [[doom-package:parsebib]] if [[doom-module::completion ivy]] or [[doom-module::completion helm]] or [[doom-module::completion vertico]]
+- [[doom-package:citar]] if [[doom-module::completion vertico]]
+- [[doom-package:citar-embark]] if [[doom-module::completion vertico]]
+- [[doom-package:helm-bibtex]] if [[doom-module::completion helm]]
+- [[doom-package:ivy-bibtex]] if [[doom-module::completion ivy]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -37,19 +37,18 @@ selected so it should be possible to use without modifications.
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
 There are no hard dependencies for this module, but this module can benefit from
-having a PDF reader and one of Doom's [[doom-module:][:completion]] modules.
+having a PDF reader and one of Doom's [[doom-module::completion]] modules.
 
 ** PDF viewing
 An application for opening PDF files is required. By default =DocView= is used
-though [[doom-module:][:tools pdf]] is highly recommended so PDFs can be viewed within Emacs.
+though [[doom-module::tools pdf]] is highly recommended so PDFs can be viewed within Emacs.
 
 ** Bibtex completion
-For vertico, helm, or ivy bibtex completion you should enable [[doom-module:][:completion
-vertico]], [[doom-module:][:completion helm]], or [[doom-module:][:completion ivy]] respectively.
+For vertico, helm, or ivy bibtex completion you should enable [[doom-module::completion vertico]], [[doom-module::completion helm]], or [[doom-module::completion ivy]] respectively.
 
 * Usage
-Both [[doom-package:][helm-bibtex]] (includes [[doom-package:][helm-bibtex]], [[doom-package:][ivy-bibtex]], and bibtex-completion code)
-and [[doom-package:][citar]] provide an extensive range of features so it is best to check their
+Both [[doom-package:helm-bibtex]] (includes [[doom-package:helm-bibtex]], [[doom-package:ivy-bibtex]], and bibtex-completion code)
+and [[doom-package:citar]] provide an extensive range of features so it is best to check their
 respective sites for a full list of features.
 
 On a high-level you can expect:
@@ -64,7 +63,7 @@ To understand the interaction between these packages this [[https://www.reddit.c
 explain the unique features and the overlapping functionality, if any.
 
 In addition, this module provides support for native Org-mode citations
-([[doom-package:][org-cite]]).
+([[doom-package:org-cite]]).
 
 * Configuration
 To override any defaults set by this module, do so in an ~(after! package ...)~
@@ -72,7 +71,7 @@ block in =$DOOMDIR/config.el=.
 
 ** Org-cite
 *** Processor configuration
-[[doom-package:][org-cite]] provides rich features and flexible configuration options via its
+[[doom-package:org-cite]] provides rich features and flexible configuration options via its
 "processor" capabilities.
 
 1. /insert/ provides =org-cite-insert= integration for inserting and editing
@@ -83,7 +82,7 @@ block in =$DOOMDIR/config.el=.
 
 This module makes the following processors available:
 1. The core =oc-basic=, =oc-natbib=, =oc-biblatex=, and =oc-csl=.
-2. [[doom-package:][citar]] for integration with [[doom-package:][vertico]] completion.
+2. [[doom-package:citar]] for integration with [[doom-package:vertico]] completion.
 
 The module configures these processors as follows for the different completion
 modules:
@@ -101,9 +100,9 @@ directory for your CSL styles:
 #+end_src
 
 ** Path configuration
-You must set the path variable for either [[doom-package:][citar]] (if using [[doom-module:][:completion vertico]])
-or [[doom-package:][bibtex-completion]] (if using [[doom-module::completion ivy][ivy]] or [[doom-module::completion helm][helm]]); this module will in turn set the
-[[var:][org-cite-global-bibliography]] variable to the same value:
+You must set the path variable for either [[doom-package:citar]] (if using [[doom-module::completion vertico]])
+or [[doom-package:bibtex-completion]] (if using [[doom-module::completion ivy][ivy]] or [[doom-module::completion helm][helm]]); this module will in turn set the
+[[var:org-cite-global-bibliography]] variable to the same value:
 #+begin_src emacs-lisp
 (setq! bibtex-completion-bibliography '("/path/to/references.bib"))
 #+end_src

--- a/modules/tools/debugger/README.org
+++ b/modules/tools/debugger/README.org
@@ -4,9 +4,9 @@
 #+since:    2.0.0
 
 * Description :unfold:
-Introduces a code debugger to Emacs, powered by [[doom-package:][realgud]] or [[doom-package:][dap-mode]] (LSP).
+Introduces a code debugger to Emacs, powered by [[doom-package:realgud]] or [[doom-package:dap-mode]] (LSP).
 
-This document will help you to configure [[doom-package:][dap-mode]] [[https://emacs-lsp.github.io/dap-mode/page/configuration/#native-debug-gdblldb][Native Debug(GDB/LLDB)]] as
+This document will help you to configure [[doom-package:dap-mode]] [[https://emacs-lsp.github.io/dap-mode/page/configuration/#native-debug-gdblldb][Native Debug(GDB/LLDB)]] as
 there is still not *enough* documentation for it.
 
 ** Maintainers
@@ -17,11 +17,11 @@ there is still not *enough* documentation for it.
   Enable support for [[https://microsoft.github.io/debug-adapter-protocol/][Debug Adapter Protocol]] (DAP) debuggers.
 
 ** Packages
-- [[doom-package:][realgud]]
-- [[doom-package:][realgud-trepan-ni]] if [[doom-module:][:lang javascript]]
-- if [[doom-module:][+lsp]]
-  - [[doom-package:][dap-mode]] 
-  - [[doom-package:][posframe]] 
+- [[doom-package:realgud]]
+- [[doom-package:realgud-trepan-ni]] if [[doom-module::lang javascript]]
+- if [[doom-module:+lsp]]
+  - [[doom-package:dap-mode]] 
+  - [[doom-package:posframe]] 
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/tools/direnv/README.org
+++ b/modules/tools/direnv/README.org
@@ -27,7 +27,7 @@ This module integrates direnv into Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][envrc]]
+- [[doom-package:envrc]]
 
 ** Hacks
 - ~envrc-mode~ has been modified to fail gracefully if ~direnv~ isn't available.
@@ -69,7 +69,7 @@ Or ~$ nix-env -i direnv~
 #+end_quote
 
 To make use of direnv you need a =.envrc= file in a directory. Any time you open
-a file or buffer in said directory, the [[doom-package:][envrc]] Emacs package will kick in,
+a file or buffer in said directory, the [[doom-package:envrc]] Emacs package will kick in,
 activate the local env, and inject it into Emacs for the current buffer.
 
 * TODO Configuration

--- a/modules/tools/docker/README.org
+++ b/modules/tools/docker/README.org
@@ -10,7 +10,7 @@ Emacs.
 Provides a major ~dockerfile-mode~ to edit =Dockerfiles=. Additional convenience
 functions allow images to be built easily.
 
-[[doom-package:][docker-tramp]] offers [[https://www.gnu.org/software/tramp/][TRAMP]] support for Docker containers.
+[[doom-package:docker-tramp]] offers [[https://www.gnu.org/software/tramp/][TRAMP]] support for Docker containers.
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -20,9 +20,9 @@ functions allow images to be built easily.
   Enable integration for the Dockerfile Language Server.
 
 ** Packages
-- [[doom-package:][docker]]
-- [[doom-package:][docker-tramp]]
-- [[doom-package:][dockerfile-mode]]
+- [[doom-package:docker]]
+- [[doom-package:docker-tramp]]
+- [[doom-package:dockerfile-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/editorconfig/README.org
+++ b/modules/tools/editorconfig/README.org
@@ -17,7 +17,7 @@ specification]]).
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][editorconfig-emacs]]
+- [[doom-package:editorconfig-emacs]]
  
 ** Hacks
 - Added logic to guess an extension-less file's type from its shebang line. For
@@ -25,9 +25,9 @@ specification]]).
   assuming its first line is ~#!/usr/bin/env python~. See
   ~+editorconfig-mode-alist~ for adding support for more languages.
 - *Special integration for =dtrt-indent=:* If the local editorconfig file
-  specifies ~indent_style~ or ~indent_size~, the [[doom-package:][dtrt-indent]] (which tries to
+  specifies ~indent_style~ or ~indent_size~, the [[doom-package:dtrt-indent]] (which tries to
   guess your indent settings by analyzing your text file) will bow out.
-- *Special integration for =ws-butler=:* this module will use [[doom-package:][ws-butler]] to
+- *Special integration for =ws-butler=:* this module will use [[doom-package:ws-butler]] to
   enforce ~trim_trailing_whitespace~.
 
 ** TODO Changelog

--- a/modules/tools/ein/README.org
+++ b/modules/tools/ein/README.org
@@ -13,7 +13,7 @@ Adds [[https://jupyter.org/][Jupyter]] notebook integration into Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][ein]]
+- [[doom-package:ein]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/eval/README.org
+++ b/modules/tools/eval/README.org
@@ -17,7 +17,7 @@ interface for opening and interacting with REPLs.
   minibuffer will be used anyway.
 
 ** Packages
-- [[doom-package:][quickrun]]
+- [[doom-package:quickrun]]
 
 ** Hacks
 - Quickrun has been modified to:
@@ -36,7 +36,7 @@ This module has no direct prerequisites.
 
 However, many languages will require that you install their interpreters, code
 runners and/or repls to power the functionality of this module. Visit the
-documentation of their respective [[doom-module:][:lang]] module for instructions.
+documentation of their respective [[doom-module::lang]] module for instructions.
 
 * TODO Usage
 #+begin_quote

--- a/modules/tools/gist/README.org
+++ b/modules/tools/gist/README.org
@@ -19,7 +19,7 @@ Adds the ability to manage, pull from, or push to your [[https://gist.github.com
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][gist]]
+- [[doom-package:gist]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -26,26 +26,26 @@ or synonyms.
 - +docsets ::
   Enable integration with Dash.app docsets.
 - +offline ::
-  Install and prefer offline dictionary/thesaurus (with [[doom-module:][+dictionary]]).
+  Install and prefer offline dictionary/thesaurus (with [[doom-module:+dictionary]]).
 
 ** Packages
-- [[doom-package:][dumb-jump]]
-- [[doom-package:][helm-xref]] if [[doom-module:][:completion helm]]
-- [[doom-package:][ivy-xref]] if [[doom-module:][:completion ivy]]
-- [[doom-package:][request]]
-- if [[doom-module:][+docsets]]
-  - [[doom-package:][dash-docs]]
-  - [[doom-package:][counsel-dash]] if [[doom-module:][:completion ivy]]
-  - [[doom-package:][helm-dash]] if [[doom-module:][:completion helm]]
-- if [[doom-module:][+dictionary]]
+- [[doom-package:dumb-jump]]
+- [[doom-package:helm-xref]] if [[doom-module::completion helm]]
+- [[doom-package:ivy-xref]] if [[doom-module::completion ivy]]
+- [[doom-package:request]]
+- if [[doom-module:+docsets]]
+  - [[doom-package:dash-docs]]
+  - [[doom-package:counsel-dash]] if [[doom-module::completion ivy]]
+  - [[doom-package:helm-dash]] if [[doom-module::completion helm]]
+- if [[doom-module:+dictionary]]
   - if macOS
-    - [[doom-package:][osx-dictionary]]
+    - [[doom-package:osx-dictionary]]
   - else
-    - [[doom-package:][define-word]]
-    - [[doom-package:][powerthesaurus]]
-    - if [[doom-module:][+offline]]
-      - [[doom-package:][wordnut]]
-      - [[doom-package:][synosaurus]]
+    - [[doom-package:define-word]]
+    - [[doom-package:powerthesaurus]]
+    - if [[doom-module:+offline]]
+      - [[doom-package:wordnut]]
+      - [[doom-package:synosaurus]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -60,9 +60,9 @@ or synonyms.
 This module has several optional dependencies:
 
 - ~ripgrep~ as a last-resort fallback for jump-to-definition/find-references.
-- ~sqlite3~ for Dash docset support (if you have [[doom-module:][+docsets]] enabled)
+- ~sqlite3~ for Dash docset support (if you have [[doom-module:+docsets]] enabled)
 - ~wordnet~ for offline dictionary and thesaurus support (if you have
-  [[doom-module:][+dictionary]] and [[doom-module:][+offline]] enabled).
+  [[doom-module:+dictionary]] and [[doom-module:+offline]] enabled).
 
 ** MacOS
 #+begin_src sh
@@ -102,7 +102,7 @@ following sources before giving up:
 1. Whatever ~:definition~ function is registered for the current buffer with the
    ~:lookup~ setting (see "Configuration" section).
 2. Any available xref backends.
-3. [[doom-package:][dumb-jump]] (a text search with aides to reduce false positives).
+3. [[doom-package:dumb-jump]] (a text search with aides to reduce false positives).
 3. An ordinary project-wide text search with =ripgrep=.
 5. If ~evil-mode~ is active, use ~evil-goto-definition~, which preforms a simple
    text search within the current buffer.
@@ -118,7 +118,7 @@ will try:
 
 1. Whatever ~:references~ function is registered for the current buffer with the
    ~:lookup~ setting (see [[*Configuration][Configuration]]).
-2. Any available [[doom-package:][xref]] backends.
+2. Any available [[doom-package:xref]] backends.
 3. An ordinary project-wide text search with ripgrep.
 
 If there are multiple results, you will be prompted to select one.
@@ -169,7 +169,7 @@ properties:
   Run when looking up the file for a symbol/string. Typically a file path. Used
   by ~+lookup/file~.
 - ~:xref-backend FN~ ::
-  Defines an [[doom-package:][xref]] backend, which implicitly provides ~:definition~ and
+  Defines an [[doom-package:xref]] backend, which implicitly provides ~:definition~ and
   ~:references~ handlers. If you specify them anyway, they will take precedence
   over the xref backend, however.
 

--- a/modules/tools/lsp/README.org
+++ b/modules/tools/lsp/README.org
@@ -6,33 +6,33 @@
 * Description :unfold:
 This module integrates [[https://langserver.org/][language servers]] into Doom Emacs. They provide features
 you'd expect from IDEs, like code completion, realtime linting, language-aware
-[[doom-package:][imenu]]/[[doom-package:][xref]] integration, jump-to-definition/references support, and more.
+[[doom-package:imenu]]/[[doom-package:xref]] integration, jump-to-definition/references support, and more.
 
 As of this writing, this is the state of LSP support in Doom Emacs:
 
 | Module           | Major modes                                             | Default language server                                       |
 |------------------+---------------------------------------------------------+---------------------------------------------------------------|
-| [[doom-module:][:lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls, clangd                                                  |
-| [[doom-module:][:lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
-| [[doom-module:][:lang csharp]]     | csharp-mode                                             | omnisharp                                                     |
-| [[doom-module:][:lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
-| [[doom-module:][:lang fsharp]]     | fsharp-mode                                             | Mono, .NET core                                               |
-| [[doom-module:][:lang go]]         | go-mode                                                 | go-langserver                                                 |
-| [[doom-module:][:lang haskell]]    | haskell-mode                                            | haskell-language-server                                       |
-| [[doom-module:][:lang java]]       | java-mode                                               | lsp-java                                                      |
-| [[doom-module:][:lang javascript]] | js2-mode, rjsx-mode, typescript-mode                    | ts-ls, deno-ls                                                |
-| [[doom-module:][:lang julia]]      | julia-mode                                              | LanguageServer.jl                                             |
-| [[doom-module:][:lang ocaml]]      | tuareg-mode                                             | ocaml-language-server                                         |
-| [[doom-module:][:lang php]]        | php-mode                                                | php-language-server                                           |
-| [[doom-module:][:lang purescript]] | purescript-mode                                         | purescript-language-server                                    |
-| [[doom-module:][:lang python]]     | python-mode                                             | lsp-python-ms                                                 |
-| [[doom-module:][:lang ruby]]       | ruby-mode                                               | solargraph                                                    |
-| [[doom-module:][:lang rust]]       | rust-mode                                               | rls                                                           |
-| [[doom-module:][:lang scala]]      | scala-mode                                              | metals                                                        |
-| [[doom-module:][:lang sh]]         | sh-mode                                                 | bash-language-server                                          |
-| [[doom-module:][:lang swift]]      | swift-mode                                              | sourcekit                                                     |
-| [[doom-module:][:lang web]]        | web-mode, css-mode, scss-mode, sass-mode, less-css-mode | vscode-css-languageserver-bin, vscode-html-languageserver-bin |
-| [[doom-module:][:lang zig]]        | zig-mode                                                | zls                                                           |
+| [[doom-module::lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls, clangd                                                  |
+| [[doom-module::lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
+| [[doom-module::lang csharp]]     | csharp-mode                                             | omnisharp                                                     |
+| [[doom-module::lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
+| [[doom-module::lang fsharp]]     | fsharp-mode                                             | Mono, .NET core                                               |
+| [[doom-module::lang go]]         | go-mode                                                 | go-langserver                                                 |
+| [[doom-module::lang haskell]]    | haskell-mode                                            | haskell-language-server                                       |
+| [[doom-module::lang java]]       | java-mode                                               | lsp-java                                                      |
+| [[doom-module::lang javascript]] | js2-mode, rjsx-mode, typescript-mode                    | ts-ls, deno-ls                                                |
+| [[doom-module::lang julia]]      | julia-mode                                              | LanguageServer.jl                                             |
+| [[doom-module::lang ocaml]]      | tuareg-mode                                             | ocaml-language-server                                         |
+| [[doom-module::lang php]]        | php-mode                                                | php-language-server                                           |
+| [[doom-module::lang purescript]] | purescript-mode                                         | purescript-language-server                                    |
+| [[doom-module::lang python]]     | python-mode                                             | lsp-python-ms                                                 |
+| [[doom-module::lang ruby]]       | ruby-mode                                               | solargraph                                                    |
+| [[doom-module::lang rust]]       | rust-mode                                               | rls                                                           |
+| [[doom-module::lang scala]]      | scala-mode                                              | metals                                                        |
+| [[doom-module::lang sh]]         | sh-mode                                                 | bash-language-server                                          |
+| [[doom-module::lang swift]]      | swift-mode                                              | sourcekit                                                     |
+| [[doom-module::lang web]]        | web-mode, css-mode, scss-mode, sass-mode, less-css-mode | vscode-css-languageserver-bin, vscode-html-languageserver-bin |
+| [[doom-module::lang zig]]        | zig-mode                                                | zls                                                           |
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -42,15 +42,15 @@ As of this writing, this is the state of LSP support in Doom Emacs:
   Use [[https://elpa.gnu.org/packages/eglot.html][Eglot]] instead of [[https://github.com/emacs-lsp/lsp-mode][LSP-mode]] to implement the LSP client in Emacs.
 - +peek ::
   Use ~lsp-ui-peek~ when looking up definitions and references with
-  functionality from the [[doom-module:][:tools lookup]] module.
+  functionality from the [[doom-module::tools lookup]] module.
 
 ** Packages
-- [[doom-package:][lsp-mode]]
-- [[doom-package:][lsp-ui]]
-- [[doom-package:][lsp-ivy]] ([[doom-module:][:completion ivy]])
-- [[doom-package:][helm-lsp]] ([[doom-module:][:completion helm]])
-- [[doom-package:][consult-lsp]] ([[doom-module:][:completion vertico]])
-- [[doom-package:][eglot]]
+- [[doom-package:lsp-mode]]
+- [[doom-package:lsp-ui]]
+- [[doom-package:lsp-ivy]] ([[doom-module::completion ivy]])
+- [[doom-package:helm-lsp]] ([[doom-module::completion helm]])
+- [[doom-package:consult-lsp]] ([[doom-module::completion vertico]])
+- [[doom-package:eglot]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -66,10 +66,10 @@ To get LSP working, you'll need to do three things:
 
 1. Enable this module,
 2. Install a language server appropriate for your targeted language(s).
-3. Enable the [[doom-module:][+lsp]] flag on the [[doom-module:][:lang]] modules you want to enable LSP support for.
+3. Enable the [[doom-module:+lsp]] flag on the [[doom-module::lang]] modules you want to enable LSP support for.
 
-Different languages will need different language servers, some of which [[doom-package:][lsp-mode]]
-will prompt you to auto-install, but [[doom-package:][eglot]] will not.
+Different languages will need different language servers, some of which [[doom-package:lsp-mode]]
+will prompt you to auto-install, but [[doom-package:eglot]] will not.
 
 A table that lists available language servers and how to install them can be
 found [[https://emacs-lsp.github.io/lsp-mode/page/languages/][on the lsp-mode project README]]. The documentation of the module for your
@@ -84,8 +84,8 @@ including instructions to register your own.
 #+end_quote
 
 ** LSP-powered project search
-Without the [[doom-module:][+eglot]] flag, and when [[doom-module:][:completion ivy]], [[doom-module:][:completion helm]] or
-[[doom-module:][:completion vertico]] is active, LSP is used to search a symbol indexed by the LSP
+Without the [[doom-module:+eglot]] flag, and when [[doom-module::completion ivy]], [[doom-module::completion helm]] or
+[[doom-module::completion vertico]] is active, LSP is used to search a symbol indexed by the LSP
 server:
 | Keybind | Description                         |
 |---------+-------------------------------------|
@@ -96,14 +96,14 @@ server:
 The two projects are large and actively developed, so without writing a novel,
 it can only be compared in (very) broad strokes:
 
-- [[doom-package:][lsp-mode]] tends to be more featureful, beginner-friendly (e.g. offers to
+- [[doom-package:lsp-mode]] tends to be more featureful, beginner-friendly (e.g. offers to
   install servers for you and has more [[https://emacs-lsp.github.io/lsp-mode][helpful documentation]]), and has a user
   experience that feels familiar to modern editors/IDEs, but at the cost of
   performance (at baseline) and complexity (it has more moving parts and
   reinvents a number of wheels to achieve a slicker UI, like ~lsp-ui-peek~,
   ~lsp-ui-sideline~, etc).
 
-- [[doom-package:][eglot]] has fewer bells and whistles: it relies on built-in Emacs functionality
+- [[doom-package:eglot]] has fewer bells and whistles: it relies on built-in Emacs functionality
   more (eldoc, xref, capf, project.el, etc), offers less pre-configuration for
   you, and is more performant than lsp-mode (again, at baseline). It also works
   with TRAMP out-of-the-box (lsp-mode needs some extra configuration).
@@ -115,7 +115,7 @@ it can only be compared in (very) broad strokes:
 #+end_quote
 
 All that said, it's easy to switch between the two implementations by swapping
-in/out the [[doom-module:][+lsp]] or [[doom-module:][+eglot]] flag when [[id:01cffea4-3329-45e2-a892-95a384ab2338][enabling this module]].
+in/out the [[doom-module:+lsp]] or [[doom-module:+eglot]] flag when [[id:01cffea4-3329-45e2-a892-95a384ab2338][enabling this module]].
 
 * TODO Configuration
 #+begin_quote
@@ -135,7 +135,7 @@ Check the entry in the [[../../../docs/faq.org][FAQ]] about "Doom can't find my 
 the correct ~PATH~"
 
 ** LSP/Eglot is not started automatically in my buffer
-Make sure that you have enabled the [[doom-module:][+lsp]] flag on the appropriate module(s) (in
+Make sure that you have enabled the [[doom-module:+lsp]] flag on the appropriate module(s) (in
 your ~doom!~ block in =$DOOMDIR/init.el=):
 #+begin_src diff
 :lang

--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -17,20 +17,20 @@ This module provides Magit, an interface to the Git version control system.
   Emacs. Will take a while on first run to build =emacsql-sqlite=.
 
 ** Packages
-- [[doom-package:][evil-magit]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][forge]] if [[doom-module:][+forge]]
-- [[doom-package:][code-review]] if [[doom-module:][+forge]]
-- [[doom-package:][magit]]
-- [[doom-package:][magit-gitflow]]
-- [[doom-package:][magit-todos]]
+- [[doom-package:evil-magit]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:forge]] if [[doom-module:+forge]]
+- [[doom-package:code-review]] if [[doom-module:+forge]]
+- [[doom-package:magit]]
+- [[doom-package:magit-gitflow]]
+- [[doom-package:magit-todos]]
 
 ** Hacks
-- [[doom-package:][magit]] has been modified to recognize =$XDG_CACHE_HOME/git/credential/socket=.
-- [[doom-package:][magit]] has been modified to invalidate the projectile cache when you check out
+- [[doom-package:magit]] has been modified to recognize =$XDG_CACHE_HOME/git/credential/socket=.
+- [[doom-package:magit]] has been modified to invalidate the projectile cache when you check out
   a new branch or commit.
-- [[doom-package:][magit]] has been modified to revert repo buffers (e.g. after changing branches)
+- [[doom-package:magit]] has been modified to revert repo buffers (e.g. after changing branches)
   when you later switch to them, rather than all at once.
-- [[doom-package:][forge]] was modified to defer compilation of emacsql-sqlite until you try to use
+- [[doom-package:forge]] was modified to defer compilation of emacsql-sqlite until you try to use
   forge, rather than when magit first loads (which could be as soon as startup).
 
 ** TODO Changelog
@@ -42,8 +42,8 @@ This module provides Magit, an interface to the Git version control system.
 
 This module requires:
 - [[https://git-scm.com/][Git]]
-- [[doom-module:][+forge]] requires [[https://magit.vc/manual/forge/Token-Creation.html#Token-Creation][a Github API token]]
-- [[doom-package:][code-review]] will also require a token setup (see [[https://github.com/wandersoncferreira/code-review#configuration][configuration]] for your particular forge)
+- [[doom-module:+forge]] requires [[https://magit.vc/manual/forge/Token-Creation.html#Token-Creation][a Github API token]]
+- [[doom-package:code-review]] will also require a token setup (see [[https://github.com/wandersoncferreira/code-review#configuration][configuration]] for your particular forge)
 
 * TODO Usage
 #+begin_quote

--- a/modules/tools/make/README.org
+++ b/modules/tools/make/README.org
@@ -13,7 +13,7 @@ This module adds commands for executing Makefile targets.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][makefile-executor]]
+- [[doom-package:makefile-executor]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/pass/README.org
+++ b/modules/tools/pass/README.org
@@ -14,11 +14,11 @@ This module provides an Emacs interface to [[https://www.passwordstore.org/][Pas
   Allow Emacs to use pass for authentication (via ~auth-source-pass~).
 
 ** Packages
-- [[doom-package:][helm-pass]] if [[doom-module:][:completion helm]]
-- [[doom-package:][ivy-pass]] if [[doom-module:][:completion ivy]]
-- [[doom-package:][pass]]
-- [[doom-package:][password-store]]
-- [[doom-package:][password-store-otp]]
+- [[doom-package:helm-pass]] if [[doom-module::completion helm]]
+- [[doom-package:ivy-pass]] if [[doom-module::completion ivy]]
+- [[doom-package:pass]]
+- [[doom-package:password-store]]
+- [[doom-package:password-store-otp]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/pdf/README.org
+++ b/modules/tools/pdf/README.org
@@ -7,12 +7,12 @@
 This module improves support for reading and interacting with PDF files in
 Emacs.
 
-It uses [[doom-package:][pdf-tools]], which is a replacement for the built-in ~doc-view-mode~ for
+It uses [[doom-package:pdf-tools]], which is a replacement for the built-in ~doc-view-mode~ for
 PDF files. The key difference being pages are not pre-rendered, but instead
 rendered on-demand and stored in memory; a much faster approach, especially for
 larger PDFs.
 
-Displaying PDF files is just one function of [[doom-package:][pdf-tools]]. See [[https://github.com/politza/pdf-tools][its project website]]
+Displaying PDF files is just one function of [[doom-package:pdf-tools]]. See [[https://github.com/politza/pdf-tools][its project website]]
 for details and videos.
 
 ** Maintainers
@@ -22,8 +22,8 @@ for details and videos.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][pdf-tools]]
-- [[doom-package:][saveplace-pdf-view]]
+- [[doom-package:pdf-tools]]
+- [[doom-package:saveplace-pdf-view]]
 
 ** TODO Hacks
 #+begin_quote
@@ -38,7 +38,7 @@ for details and videos.
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
 This module requires the =epdfinfo= program. Unless you're on Windows, the
-[[doom-package:][pdf-tools]] plugin will (re)build this program for you, if you issue the ~M-x
+[[doom-package:pdf-tools]] plugin will (re)build this program for you, if you issue the ~M-x
 pdf-tools-install~ command. See the next section for instructions on how to
 build the =epdfinfo= program on Windows.
 

--- a/modules/tools/prodigy/README.org
+++ b/modules/tools/prodigy/README.org
@@ -14,7 +14,7 @@ Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][prodigy]]
+- [[doom-package:prodigy]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/rgb/README.org
+++ b/modules/tools/rgb/README.org
@@ -18,8 +18,8 @@ to easily modify color values or formats.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][kurecolor]]
-- [[doom-package:][rainbow-mode]]
+- [[doom-package:kurecolor]]
+- [[doom-package:rainbow-mode]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/taskrunner/README.org
+++ b/modules/tools/taskrunner/README.org
@@ -9,7 +9,7 @@
 #+end_quote
 
 * Description :unfold:
-This module integrates [[doom-package:][taskrunner]] into Doom Emacs, which scraps runnable tasks
+This module integrates [[doom-package:taskrunner]] into Doom Emacs, which scraps runnable tasks
 from build systems like make, gradle, npm and the like.
 
 ** Maintainers
@@ -19,9 +19,9 @@ from build systems like make, gradle, npm and the like.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][emacs-taskrunner]]
-- [[doom-package:][helm-taskrunner]] if [[doom-module:][:completion helm]]
-- [[doom-package:][ivy-taskrunner]] if [[doom-module:][:completion ivy]]
+- [[doom-package:emacs-taskrunner]]
+- [[doom-package:helm-taskrunner]] if [[doom-module::completion helm]]
+- [[doom-package:ivy-taskrunner]] if [[doom-module::completion ivy]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/terraform/README.org
+++ b/modules/tools/terraform/README.org
@@ -15,8 +15,8 @@ run Terraform commands directly from Emacs.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][company-terraform]] if [[doom-package:][:completion company]]
-- [[doom-package:][terraform-mode]]
+- [[doom-package:company-terraform]] if [[doom-package::completion company]]
+- [[doom-package:terraform-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -36,25 +36,25 @@ This module requires the ~terraform~ executable to be installed and in your
 Syntax highlighting is provided from ~terraform-mode~ and ~hcl-mode~.
 
 ** Code formatting
-[[doom-module:][:tools terraform]] does not provide code formatting directly, but [[doom-module:][:editor format]]
+[[doom-module::tools terraform]] does not provide code formatting directly, but [[doom-module::editor format]]
 works with Terraform files.
 
 ** Code navigation
-Code navigation is supported through [[doom-package:][imenu]] from [[doom-package:][terraform-mode]].
+Code navigation is supported through [[doom-package:imenu]] from [[doom-package:terraform-mode]].
 
 ** Code completion
-Code completion of Terraform builtins is provided from [[doom-package:][company-terraform]] and
+Code completion of Terraform builtins is provided from [[doom-package:company-terraform]] and
 generally works well despite being generated through a [[https://github.com/rafalcieslak/emacs-company-terraform/blob/master/company-terraform-data.el][static (outdated) file]].
 
-[[doom-package:][company-terraform]] also provides code completion of resources within your
+[[doom-package:company-terraform]] also provides code completion of resources within your
 project.
 
 ** Documentation
-Documentation is accessible through the normal [[doom-package:][company]] show documentation
-functionality, thanks to [[doom-package:][company-terraform]].
+Documentation is accessible through the normal [[doom-package:company]] show documentation
+functionality, thanks to [[doom-package:company-terraform]].
 
 ** Executing Terraform commands
-[[doom-module:][:tools terraform]] provides commands under [[kbd:][<localleader>]] to run the most common
+[[doom-module::tools terraform]] provides commands under [[kbd:][<localleader>]] to run the most common
 Terraform operations:
 | key             | description              |
 |-----------------+--------------------------|

--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -27,9 +27,9 @@ It includes:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][evil-textobj-tree-sitter]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][tree-sitter]]
-- [[doom-package:][tree-sitter-langs]]
+- [[doom-package:evil-textobj-tree-sitter]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:tree-sitter]]
+- [[doom-package:tree-sitter-langs]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/tools/upload/README.org
+++ b/modules/tools/upload/README.org
@@ -22,7 +22,7 @@ The idea for this plug-in was to mimic the behavior of PhpStorm deployment funct
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][ssh-deploy]]
+- [[doom-package:ssh-deploy]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/deft/README.org
+++ b/modules/ui/deft/README.org
@@ -15,7 +15,7 @@ quickly jot down thoughts and easily retrieve them later.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][deft]]
+- [[doom-package:deft]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/doom-quit/README.org
+++ b/modules/ui/doom-quit/README.org
@@ -62,7 +62,7 @@ If you have any issues with this module do let me know
 
 * Appendix
 ** Variables
-- [[var:][+doom-quit-messages]]
+- [[var:+doom-quit-messages]]
 
 ** Functions
-- [[fn:][+doom-quit-fn]]
+- [[fn:+doom-quit-fn]]

--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -5,11 +5,11 @@
 
 * Description :unfold:
 This module gives Doom its signature look: powered by the [[doom-package:doom-themes][doom-one]] theme
-(loosely inspired by [[https://github.com/atom/one-dark-syntax][Atom's One Dark theme]]) and [[doom-package:][solaire-mode]]. Includes:
+(loosely inspired by [[https://github.com/atom/one-dark-syntax][Atom's One Dark theme]]) and [[doom-package:solaire-mode]]. Includes:
 
-- A custom folded-region indicator for [[doom-package:][hideshow]].
-- "Thin bar" fringe bitmaps for [[doom-package:][git-gutter-fringe]].
-- File-visiting buffers are slightly brighter (thanks to [[doom-package:][solaire-mode]]).
+- A custom folded-region indicator for [[doom-package:hideshow]].
+- "Thin bar" fringe bitmaps for [[doom-package:git-gutter-fringe]].
+- File-visiting buffers are slightly brighter (thanks to [[doom-package:solaire-mode]]).
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -20,8 +20,8 @@ This module gives Doom its signature look: powered by the [[doom-package:doom-th
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][doom-themes]]
-- [[doom-package:][solaire-mode]]
+- [[doom-package:doom-themes]]
+- [[doom-package:solaire-mode]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -72,7 +72,7 @@ core/core-ui.el has four relevant variables:
 - ~doom-variable-pitch-font~ :: the font to use when ~variable-pitch-mode~ is active
   (or where the ~variable-pitch~ face is used).
 - ~doom-unicode-font~ :: the font used to display unicode symbols. This is
-  ignored if the [[doom-module:][:ui unicode]] module is enabled.
+  ignored if the [[doom-module::ui unicode]] module is enabled.
 
 #+begin_src emacs-lisp
 (setq doom-font (font-spec :family "Fira Mono" :size 12)
@@ -90,7 +90,7 @@ If you're seeing strange unicode symbols, this is likely because you don't have
 all-the-icons-install-fonts~.
 
 ** Ugly background colors in tty Emacs for daemon users
-[[doom-package:][solaire-mode]] is an aesthetic plugin that makes non-file-visiting buffers darker
+[[doom-package:solaire-mode]] is an aesthetic plugin that makes non-file-visiting buffers darker
 than the rest of the Emacs' frame (to visually differentiate temporary windows
 or sidebars from editing windows). This looks great in GUI Emacs, but can look
 questionable in the terminal.

--- a/modules/ui/emoji/README.org
+++ b/modules/ui/emoji/README.org
@@ -20,7 +20,7 @@ style, or unicode styles), as well as convert certain text patterns (e.g.
   Include unicode emojis like 🙂.
 
 ** Packages
-- [[doom-package:][emojify]]
+- [[doom-package:emojify]]
  
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/hl-todo/README.org
+++ b/modules/ui/hl-todo/README.org
@@ -16,7 +16,7 @@ This module adds syntax highlighting for various tags in code comments, such as
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][hl-todo]]
+- [[doom-package:hl-todo]]
  
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/hydra/README.org
+++ b/modules/ui/hydra/README.org
@@ -23,7 +23,7 @@ start with:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][hydra]]
+- [[doom-package:hydra]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/indent-guides/README.org
+++ b/modules/ui/indent-guides/README.org
@@ -13,7 +13,7 @@
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][highlight-indent-guides]]
+- [[doom-package:highlight-indent-guides]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/ligatures/README.org
+++ b/modules/ui/ligatures/README.org
@@ -85,7 +85,7 @@ emacs, this is implemented in two different ways :
   which haves the ligatures as separate unicode symbols, and using
   prettify-symbols-mode, =->=-like combinations are manually listed and replaced
   with the correct symbol. The mapping between =->=-like sequences and unicode
-  values in the font are font-specific ; therefore [[doom-module:][+fira]], [[doom-module:][+iosevka]]... files and
+  values in the font are font-specific ; therefore [[doom-module:+fira]], [[doom-module:+iosevka]]... files and
   specific fonts are necessary for it to work.
 - composition-function-table method :: regexps are used to match all the usual
   sequences which are composed into ligatures. These regexps are passed to emacs
@@ -225,8 +225,8 @@ if you don't like the symbols chosen you can change them by using:
 This can usually be fixed by doing one of the following:
 
 - Make sure Symbola (the font) is installed on your system.
-- Otherwise, change [[var:][doom-unicode-font]] (set to Symbola by default).
-- Disable the [[doom-module:][:ui unicode]] module. It not only overrides [[var:][doom-unicode-font]], but
+- Otherwise, change [[var:doom-unicode-font]] (set to Symbola by default).
+- Disable the [[doom-module::ui unicode]] module. It not only overrides [[var:doom-unicode-font]], but
   should only be used as a last resort.
 
 * Frequently asked questions

--- a/modules/ui/minimap/README.org
+++ b/modules/ui/minimap/README.org
@@ -16,7 +16,7 @@ feature found in many other editors.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][minimap]]
+- [[doom-package:minimap]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/modeline/README.org
+++ b/modules/ui/modeline/README.org
@@ -5,7 +5,7 @@
 
 * Description :unfold:
 This module provides an Atom-inspired, minimalistic modeline for Doom Emacs,
-powered by the [[doom-package:][doom-modeline]] package (where you can find screenshots).
+powered by the [[doom-package:doom-modeline]] package (where you can find screenshots).
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -15,12 +15,12 @@ powered by the [[doom-package:][doom-modeline]] package (where you can find scre
 ** Module flags
 - +light ::
   Enable a lighter, less featureful version of the modeline that does not depend
-  on [[doom-package:][doom-modeline]], which has performances issues in some cases.
+  on [[doom-package:doom-modeline]], which has performances issues in some cases.
 
 ** Packages
-- [[doom-package:][anzu]]
-- [[doom-package:][doom-modeline]] unless [[doom-module:][+light]]
-- [[doom-package:][evil-anzu]] if [[doom-module:][:editor evil]]
+- [[doom-package:anzu]]
+- [[doom-package:doom-modeline]] unless [[doom-module:+light]]
+- [[doom-package:evil-anzu]] if [[doom-module::editor evil]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/nav-flash/README.org
+++ b/modules/ui/nav-flash/README.org
@@ -20,7 +20,7 @@ make it easy to follow after big operations.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][nav-flash]]
+- [[doom-package:nav-flash]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -35,16 +35,16 @@ make it easy to follow after big operations.
 /This module has no external requirements./
 
 * Usage
-By default, [[doom-package:][nav-flash]] will be triggered whenever [[fn:][recenter]] is called or an entry
-is added to the jump-list (managed by [[doom-package:][better-jumper]]).
+By default, [[doom-package:nav-flash]] will be triggered whenever [[fn:recenter]] is called or an entry
+is added to the jump-list (managed by [[doom-package:better-jumper]]).
 
-[[fn:][recenter]] is called after many hooks and commands, such as:
-- [[var:][better-jumper-post-jump-hook]]
-- [[var:][rtags-after-find-file-hook]]
-- [[var:][org-follow-link-hook]]
-- [[var:][imenu-after-jump-hook]]
-- [[var:][counsel-grep-post-action-hook]]
-- [[var:][dumb-jump-after-jump-hook]]
+[[fn:recenter]] is called after many hooks and commands, such as:
+- [[var:better-jumper-post-jump-hook]]
+- [[var:rtags-after-find-file-hook]]
+- [[var:org-follow-link-hook]]
+- [[var:imenu-after-jump-hook]]
+- [[var:counsel-grep-post-action-hook]]
+- [[var:dumb-jump-after-jump-hook]]
 
 * TODO Configuration
 #+begin_quote

--- a/modules/ui/neotree/README.org
+++ b/modules/ui/neotree/README.org
@@ -8,7 +8,7 @@ This module brings a side panel for browsing project files, inspired by vim's
 NERDTree.
 
 #+begin_quote
- 💡 Sure, there's [[doom-package:][dired]] and [[doom-package:][projectile]], but sometimes I'd like a bird's eye view
+ 💡 Sure, there's [[doom-package:dired]] and [[doom-package:projectile]], but sometimes I'd like a bird's eye view
     of a project.
 #+end_quote
 
@@ -19,7 +19,7 @@ NERDTree.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][neotree]]
+- [[doom-package:neotree]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/ui/ophints/README.org
+++ b/modules/ui/ophints/README.org
@@ -8,7 +8,7 @@ This module provides op-hints (operation hinting), i.e. visual feedback for
 certain operations. It highlights regions of text that the last operation (like
 yank) acted on.
 
-Uses [[doom-package:][evil-goggles]] for evil users and [[doom-package:][volatile-highlights]] otherwise.
+Uses [[doom-package:evil-goggles]] for evil users and [[doom-package:volatile-highlights]] otherwise.
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -19,8 +19,8 @@ Uses [[doom-package:][evil-goggles]] for evil users and [[doom-package:][volatil
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][evil-goggles]] if [[doom-module:][:editor evil]]
-- [[doom-package:][volatile-highlights]] unless [[doom-module:][:editor evil]]
+- [[doom-package:evil-goggles]] if [[doom-module::editor evil]]
+- [[doom-package:volatile-highlights]] unless [[doom-module::editor evil]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/popup/README.org
+++ b/modules/ui/popup/README.org
@@ -31,20 +31,20 @@ clean up after itself and kill off buffers I mark as transient.
 /This module doesn't install any packages./
 
 ** Hacks
-- [[doom-package:][help-mode]] has been advised to follow file links in the buffer you were in
+- [[doom-package:help-mode]] has been advised to follow file links in the buffer you were in
   before entering the popup, rather than in a new window.
-- [[doom-package:][wgrep]] buffers are advised to close themselves when aborting or committing
+- [[doom-package:wgrep]] buffers are advised to close themselves when aborting or committing
   changes.
-- [[doom-package:][persp-mode]] is advised to restore popup windows when loading a session from
+- [[doom-package:persp-mode]] is advised to restore popup windows when loading a session from
   file.
 - Interactive calls to ~windmove-*~ commands (used by ~evil-window-*~ commands)
   will ignore the ~no-other-window~ window parameter, allowing you to switch to
   popup windows as if they're ordinary windows.
 - ~balance-windows~ has been advised to close popups while it does its business,
   then restore them afterwards.
-- [[doom-package:][neotree]] advises ~balance-windows~, which causes major slow-downs when paired
+- [[doom-package:neotree]] advises ~balance-windows~, which causes major slow-downs when paired
   with our ~balance-window~ advice, so we removes neotree's advice.
-- [[doom-package:][org-mode]] is an ongoing (and huge) effort. It has a scorched-earth window
+- [[doom-package:org-mode]] is an ongoing (and huge) effort. It has a scorched-earth window
   management system I'm not fond of. ie. it kills all windows and monopolizes
   the frame. On top of that, it /really/ likes to use ~switch-to-buffer~ for
   most of its buffer management, which completely bypasses

--- a/modules/ui/tabs/README.org
+++ b/modules/ui/tabs/README.org
@@ -13,7 +13,7 @@ This module adds an Atom-esque tab bar to the Emacs UI.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][centaur-tabs]]
+- [[doom-package:centaur-tabs]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/treemacs/README.org
+++ b/modules/ui/treemacs/README.org
@@ -10,9 +10,9 @@ system outlines of your projects in a simple tree layout allowing quick
 navigation and exploration, while also possessing basic file management
 utilities. It includes:
 
-- Integration with Git (if [[doom-module:][:tools magit]] is enabled)
-- Integration with Evil (if [[doom-module:][:editor evil +everywhere]] is enabled)
-- Workspace awareness (if [[doom-module:][:ui workspaces]] is enabled)
+- Integration with Git (if [[doom-module::tools magit]] is enabled)
+- Integration with Evil (if [[doom-module::editor evil +everywhere]] is enabled)
+- Workspace awareness (if [[doom-module::ui workspaces]] is enabled)
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
@@ -24,12 +24,12 @@ utilities. It includes:
   Enable ~lsp-treemacs~ integration and add shortcuts for common commands.
 
 ** Packages
-- [[doom-package:][lsp-treemacs]] if [[doom-module:][+lsp]]
-- [[doom-package:][treemacs]]
-- [[doom-package:][treemacs-evil]] if [[doom-module:][:editor evil +everywhere]]
-- [[doom-package:][treemacs-magit]] if [[doom-module:][:tools magit]]
-- [[doom-package:][treemacs-persp]] if [[doom-module:][:ui workspaces]]
-- [[doom-package:][treemacs-projectile]]
+- [[doom-package:lsp-treemacs]] if [[doom-module:+lsp]]
+- [[doom-package:treemacs]]
+- [[doom-package:treemacs-evil]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:treemacs-magit]] if [[doom-module::tools magit]]
+- [[doom-package:treemacs-persp]] if [[doom-module::ui workspaces]]
+- [[doom-package:treemacs-projectile]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -41,7 +41,7 @@ utilities. It includes:
 * Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-If =python3= is present on your =$PATH=, [[doom-package:][treemacs]] will use it to display git
+If =python3= is present on your =$PATH=, [[doom-package:treemacs]] will use it to display git
 status for files.
 
 * TODO Usage

--- a/modules/ui/unicode/README.org
+++ b/modules/ui/unicode/README.org
@@ -29,7 +29,7 @@ When this module is enabled:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][unicode-fonts]]
+- [[doom-package:unicode-fonts]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/vc-gutter/README.org
+++ b/modules/ui/vc-gutter/README.org
@@ -14,8 +14,8 @@ Supports Git, Svn, Hg, and Bzr.
 
 ** Module flags
 - +diff-hl ::
-  Use [[doom-package:][diff-hl]] instead of git-gutter to power the VC gutter. It is a little
-  faster, but is slightly more prone to visual glitching. [[doom-package:][diff-hl]] is intended to
+  Use [[doom-package:diff-hl]] instead of git-gutter to power the VC gutter. It is a little
+  faster, but is slightly more prone to visual glitching. [[doom-package:diff-hl]] is intended to
   replace git-gutter at some point in the future.
 - +pretty ::
   Apply some stylistic defaults to the fringe, enabling thin bars in the fringe.
@@ -26,20 +26,20 @@ Supports Git, Svn, Hg, and Bzr.
   diff-hl's faces (like modus-themes does).
 
 ** Packages
-- [[doom-package:][git-gutter-fringe]] unless [[doom-module:][+diff-hl]]
-- [[doom-package:][diff-hl]] if [[doom-module:][+diff-hl]]
+- [[doom-package:git-gutter-fringe]] unless [[doom-module:+diff-hl]]
+- [[doom-package:diff-hl]] if [[doom-module:+diff-hl]]
 
 ** Hacks
 - The VC gutter will be updated when pressing ESC, leaving insert mode (evil
   users), or refocusing the frame or window where it is active.
-- If [[doom-module:][+pretty]] is enabled
+- If [[doom-module:+pretty]] is enabled
   - The fringes that both git-gutter-fringe and diff-hl define will be replaced
     with a set of thin bars. This achieves a slicker look closer to git-gutter's
     appearance in VSCode or Sublime Text, but may look weird for themes that
     swap their faces' :foreground and :background (like modus-themes).
   - The fringes are moved to the outside of the margins (closest to the frame
     edge), so they have some breathing space away from the buffer's contents.
-- If [[doom-package:][+diff-hl]] is enabled:
+- If [[doom-package:+diff-hl]] is enabled:
   - ~diff-hl-revert-hunk~ displays a preview popup of the hunk being reverted.
     It takes up ~50% of the frame, by default, whether you're reverting 2 lines
     or 20. Since this isn't easily customized, it has been advised to shrink

--- a/modules/ui/vi-tilde-fringe/README.org
+++ b/modules/ui/vi-tilde-fringe/README.org
@@ -15,7 +15,7 @@ Displays a tilde(~) in the left fringe to indicate an empty line, similar to Vi.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][vi-tilde-fringe]]
+- [[doom-package:vi-tilde-fringe]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/window-select/README.org
+++ b/modules/ui/window-select/README.org
@@ -7,11 +7,11 @@
 This module provides several methods for selecting windows without the use of
 the mouse or spatial navigation (e.g. [[kbd:][C-w {h,j,k,l}]]).
 
-The command ~other-window~ is remapped to either [[doom-package:][switch-window]] or [[doom-package:][ace-window]],
+The command ~other-window~ is remapped to either [[doom-package:switch-window]] or [[doom-package:ace-window]],
 depending on which backend you've enabled. It is bound to [[kbd:][C-x o]] (and [[kbd:][C-w C-w]] for
 evil users).
 
-It also provides numbered windows and selection with the [[doom-package:][winum]] package, if
+It also provides numbered windows and selection with the [[doom-package:winum]] package, if
 desired. Evil users can jump to window N in [[kbd:][C-w <N>]] (where N is a number between
 0 and 9). Non evil users have [[kbd:][C-x w <N>]] instead.
 
@@ -20,14 +20,14 @@ desired. Evil users can jump to window N in [[kbd:][C-w <N>]] (where N is a numb
 
 ** Module flags
 - +numbers ::
-  Enable numbered windows and window selection (using [[doom-package:][winum]]).
+  Enable numbered windows and window selection (using [[doom-package:winum]]).
 - +switch-window ::
-  Use the [[doom-package:][switch-window]] package as the backend, instead of ace-window ([[doom-package:][avy]]).
+  Use the [[doom-package:switch-window]] package as the backend, instead of ace-window ([[doom-package:avy]]).
 
 ** Packages
-- [[doom-package:][ace-window]] unless [[doom-module:][+switch-window]]
-- [[doom-package:][switch-window]] if [[doom-module:][+switch-window]]
-- [[doom-package:][winum]] if [[doom-module:][+numbers]]
+- [[doom-package:ace-window]] unless [[doom-module:+switch-window]]
+- [[doom-package:switch-window]] if [[doom-module:+switch-window]]
+- [[doom-package:winum]] if [[doom-module:+numbers]]
 
 ** Hacks
 /No hacks documented for this module./
@@ -52,7 +52,7 @@ desired. Evil users can jump to window N in [[kbd:][C-w <N>]] (where N is a numb
 #+end_quote
 
 This module provides two backends, both providing the same functionality, but
-with different visual cues. They are [[doom-package:][ace-window]] and [[doom-package:][switch-window]].
+with different visual cues. They are [[doom-package:ace-window]] and [[doom-package:switch-window]].
 
 ** ace-window
 The first character of the buffers changes to a highlighted, user-selectable

--- a/modules/ui/workspaces/README.org
+++ b/modules/ui/workspaces/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.0
 
 * Description :unfold:
-This module adds support for workspaces, powered by [[doom-package:][persp-mode]], as well as a API
+This module adds support for workspaces, powered by [[doom-package:persp-mode]], as well as a API
 for manipulating them.
 
 #+begin_quote
@@ -25,7 +25,7 @@ for manipulating them.
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][persp-mode]]
+- [[doom-package:persp-mode]]
 
 ** TODO Hacks
 #+begin_quote

--- a/modules/ui/zen/README.org
+++ b/modules/ui/zen/README.org
@@ -6,7 +6,7 @@
 * Description :unfold:
 This module provides two minor modes that make Emacs into a more comfortable
 writing or coding environment. Folks familiar with "distraction-free" or "zen"
-modes from other editors -- or [[doom-package:][olivetti]], [[doom-package:][sublimity]], and [[doom-package:][tabula-rasa]] (Emacs
+modes from other editors -- or [[doom-package:olivetti]], [[doom-package:sublimity]], and [[doom-package:tabula-rasa]] (Emacs
 plugins) -- will feel right at home.
 
 These modes are:
@@ -33,8 +33,8 @@ These modes are:
 /This module has no flags./
 
 ** Packages
-- [[doom-package:][mixed-pitch]]
-- [[doom-package:][writeroom-mode]]
+- [[doom-package:mixed-pitch]]
+- [[doom-package:writeroom-mode]]
 
 ** Hacks
 + Doom has disabled all of writeroom-mode's "global" effects


### PR DESCRIPTION
As discussed on Discord, this is the first half of a revamp to doc links, changing the format to `[[protocol:path]]` from `[[protocol:][path]]`. The second half of the revamp is making these links prettier, but that's still being worked on.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
