### PR TITLE
fix(ligatures): fixed set-fontset-font not found

### DIFF
--- a/modules/ui/ligatures/config.el
+++ b/modules/ui/ligatures/config.el
@@ -206,7 +206,8 @@ and cannot run in."
                (or (alist-get ',id +ligatures--font-alist)
                    (error "No ligature font called %s" ',id))
              (when range
-               (set-fontset-font t range name nil 'prepend))
+               (when (fboundp 'set-fontset-font)
+                 (set-fontset-font t range name nil 'prepend)))
              (setq-default prettify-symbols-alist
                            (append (default-value 'prettify-symbols-alist)
                                    (mapcar #'+ligatures--correct-symbol-bounds ,alist-var)))))


### PR DESCRIPTION
I was having an issue using emacs in the terminal while having ligatures enabled in the doom config. I could not any command that opened a menu(e.g. space + space, space + /, etc) I traced the issue to a missing check for set-fontset-font in the ligature init. Adding a check for whether the function was defined before calling it fixed the issue. 

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
