### PR TITLE
fix(lsp): don't prompt twice when selecting root

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -76,16 +76,16 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
           (setq-local flycheck-checker old-checker))
       (apply fn args)))
 
-  (defadvice! +lsp-display-guessed-project-root (root)
-    "Log what LSP things is the root of the current project."
-    ;; Makes it easier to detect root resolution issues.
-    :filter-return #'lsp--calculate-root
-    (if root
-        (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
-      (lsp--info "Could not guess project root."))
-    root)
-
-  (add-hook! 'lsp-mode-hook #'+lsp-optimization-mode)
+  (add-hook! 'lsp-mode-hook
+    (defun +lsp-display-guessed-project-root-h ()
+      "Log what LSP thinks is the root of the current project (if it was guessed automatically)."
+      ;; Makes it easier to detect root resolution issues.
+      (if lsp-auto-guess-root
+          (let (path (buffer-file-name (buffer-base-buffer)))
+            (if-let (root (lsp--calculate-root (lsp-session) path))
+                (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
+              (lsp--info "Could not guess project root.")))))
+    #'+lsp-optimization-mode)
 
   (when (modulep! :completion company)
     (add-hook! 'lsp-completion-mode-hook

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -76,15 +76,16 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
           (setq-local flycheck-checker old-checker))
       (apply fn args)))
 
-  (add-hook! 'lsp-mode-hook
-    (defun +lsp-display-guessed-project-root-h ()
-      "Log what LSP things is the root of the current project."
-      ;; Makes it easier to detect root resolution issues.
-      (when-let (path (buffer-file-name (buffer-base-buffer)))
-        (if-let (root (lsp--calculate-root (lsp-session) path))
-            (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
-          (lsp--info "Could not guess project root."))))
-    #'+lsp-optimization-mode)
+  (defadvice! +lsp-display-guessed-project-root (root)
+    "Log what LSP things is the root of the current project."
+    ;; Makes it easier to detect root resolution issues.
+    :filter-return #'lsp--calculate-root
+    (if root
+        (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
+      (lsp--info "Could not guess project root."))
+    root)
+
+  (add-hook! 'lsp-mode-hook #'+lsp-optimization-mode)
 
   (when (modulep! :completion company)
     (add-hook! 'lsp-completion-mode-hook


### PR DESCRIPTION
When the lsp root can't be computed automatically (via `lsp--calculate-root`), lsp-mode will prompt the user to select it.

Doom's logging hook was calling `lsp--calculate-root` again to know what to log (assuming it would just compute it again based on directory structure), which means we would sometimes as the user to select the root twice.

Here we reimplement the logging using advice instead so we can piggyback on the first call and log whatever it returns.

I didn't find this reported as an issue and the fix was trivial once I found the problem so I decided to just go ahead and make a PR. Hope that works!

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
