### PR TITLE
fix(cli): split tput call into separate calls

### DIFF
--- a/bin/doomscript
+++ b/bin/doomscript
@@ -58,7 +58,7 @@ fi
 # the comments at the top of bin/doom for explanations.
 export __DOOMPID="${__DOOMPID:-$$}"
 export __DOOMSTEP="$((__DOOMSTEP+1))"
-export __DOOMGEOM="${__DOOMGEOM:-$(tput cols lines 2>/dev/null)}"
+export __DOOMGEOM="${__DOOMGEOM:-$(tput cols 2>/dev/null)x$(tput lines 2>/dev/null)}"
 export __DOOMGPIPE="${__DOOMGPIPE:-$__DOOMPIPE}"
 export __DOOMPIPE=
 [ -t 0 ] || __DOOMPIPE="${__DOOMPIPE}0"


### PR DESCRIPTION
Sync definition of __DOOMGEOM in bin/doomscript with corresponding variable of bin/doom.

* bin/doomscript (__DOOMGEOM): split tput call into two separate calls

Ref: beef0aef0211

<!-- ⚠️ Please do not ignore this template! -->

The tput call of __DOOMGEOM of bin/doom has been splitted into two tput calls by commit beef0aef0211 but the defintion for the same variable in bin/doomscript still use the old definition.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
