### PR TITLE
bump: :lang org-contrib

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -31,7 +31,7 @@
 (package! org-contrib
   :recipe (:host github
            :repo "emacsmirror/org-contrib")
-  :pin "0740bd3fe69c4b327420185d931dcf0a9900a80e")
+  :pin "aa104c0bbc3113f6d3d167b20bd8d6bf6a285f0f")
 
 (package! avy)
 (package! htmlize :pin "dd27bc3f26efd728f2b1f01f9e4ac4f61f2ffbf9")


### PR DESCRIPTION
emacsmirror/org-contrib@0740bd3fe69c -> emacsmirror/org-contrib@aa104c0bbc31

* modules/lang/org/packages.el (org-contrib): bump to commit aa104c0bbc31

Fix: #6881

<!-- ⚠️ Please do not ignore this template! -->

Looks like emacsmirror/org-contrib@0740bd3 does not exist anymore, replacing it with corresponding  emacsmirror/org-contrib@aa104c0

Fixes #6881 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
