### PR TITLE
bump: :ui treemacs

### DIFF
--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/treemacs/packages.el
 
-(package! treemacs :pin "e4bb236bd5cd7c077c2207b33d2699485c405536")
+(package! treemacs :pin "12e0393163c290cd04667e18275f2f6368bf3286")
 ;; These packages have no :pin because they're in the same repo
 (when (modulep! :editor evil +everywhere)
   (package! treemacs-evil))


### PR DESCRIPTION
`treemacs` updated the interface to `treemacs-initialize` recently:

https://github.com/Alexander-Miller/treemacs/commit/20765acd38e00faa46a72b9a2cf63a7b451c6850#diff-36f7ea49dcbb6f011b9faf5f012271328ac46515b4f161214001917cbc2ef6b2L1023-R1053

The currently pinned version of `lsp-treemacs` expects the new interface, but treemacs is pinned to an older commit, before the interface was changed. This causes `dap-mode` to error out when launching the UI debugger, meaning `dap-debug` is unusable:

https://github.com/emacs-lsp/lsp-treemacs/issues/145#issuecomment-1274966247

Update the pin so `treemacs` is serving the new interface, plus some other additions.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I ~~need more time to finish it.~~ will not be working on it further.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
