### PR TITLE
fix(cli): doctor: pluralizing single errors/warnings

### DIFF
--- a/lisp/cli/doctor.el
+++ b/lisp/cli/doctor.el
@@ -282,7 +282,7 @@ in."
                      (list doom-doctor--errors "error" 'red)))
     (when (car msg)
       (print! (color (nth 2 msg)
-                     (if (cdr msg)
+                     (if (cdar msg)
                          "There are %d %ss!"
                        "There is %d %s!")
                      (length (car msg)) (nth 1 msg)))))


### PR DESCRIPTION
Currently final report of `doom doctor` is always printed in plural form, even if there is only 1 warnings or message. This change fixes it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
