### PR TITLE
tweak(ansible): also match tasks/main.yaml

### DIFF
--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -32,4 +32,4 @@
 (def-project-mode! +ansible-yaml-mode
   :modes '(yaml-mode)
   :add-hooks '(ansible ansible-auto-decrypt-encrypt ansible-doc-mode)
-  :files (or "roles/" "tasks/main.yml"))
+  :files (or "roles/" "tasks/main.yml" "tasks/main.yaml"))


### PR DESCRIPTION
IDK if this literally closes #1139, but it's relevant.

Although it's common to use the extension `.yml` rather than `.yaml` for yaml files in ansible projects, this is not required except in like 1 or 2 cases, and also `.yaml` is a much better extension for yaml files and I will fight anyone who disagrees IRL.

AFAICT, there isn't a way to use a regexp here (i.e. `:match` isn't `:files` but with regexps) , so I just added the other path to the disjunction, but if the reviewer knows otherwise LMK.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

