### PR TITLE
fix(highlight-indent-guides): for terminal users

### DIFF
--- a/modules/ui/indent-guides/config.el
+++ b/modules/ui/indent-guides/config.el
@@ -6,17 +6,13 @@
   (setq highlight-indent-guides-method 'character
         highlight-indent-guides-suppress-auto-error t)
   :config
-  (defun +indent-guides-init-faces-h (&rest _)
-    (when (display-graphic-p)
-      (highlight-indent-guides-auto-set-faces)))
-
   ;; HACK `highlight-indent-guides' calculates its faces from the current theme,
   ;;      but is unable to do so properly in terminal Emacs, where it only has
   ;;      access to 256 colors. So if the user uses a daemon we must wait for
   ;;      the first graphical frame to be available to do.
-  (add-hook 'doom-load-theme-hook #'+indent-guides-init-faces-h)
+  (add-hook 'doom-load-theme-hook #'highlight-indent-guides-auto-set-faces)
   (when doom-theme
-    (+indent-guides-init-faces-h))
+    (highlight-indent-guides-auto-set-faces))
 
   ;; `highlight-indent-guides' breaks when `org-indent-mode' is active
   (add-hook! 'org-mode-local-vars-hook


### PR DESCRIPTION
`(when (display-graphic-p))` is always `nil` for terminal emacs

I tested it on my machine, I run emacs as daemon in kitty terminal.

Before this change:
- start emacs
- `highlight-indent-guides-mode` is on (through `:ui indent-guides`)
- however there are *no* indent lines visible
- changing doom themes manually with `load-theme` allows indent guides to be shown. Manually calling `highlight-indent-guides-auto-set-faces` has the same effect.

After change:
- start emacs
- indent-guides are displayed on files without any issue

-----

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off. 🤣 