### PR TITLE
docs: updated symlink command for homebrew emacs-mac install in getting_started.org

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -294,7 +294,7 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
   brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  ln -s /opt/homebrew/Cellar/emacs-mac/emacs-28.2-mac-9.1/Emacs.app /Applications/Emacs.app
   #+END_SRC
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have


### PR DESCRIPTION
For me, homebrew installed emacs-mac in a different location; so the provided symlink command failed. This is the command that was correct for my installation.

I couldn't find any open issues that looked like this issue.

Fixes #0000
References #0000
Replaces #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


