### PR TITLE
fix(lsp): stop logging project root

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -79,11 +79,12 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
   (add-hook! 'lsp-mode-hook
     (defun +lsp-display-guessed-project-root-h ()
       "Log what LSP things is the root of the current project."
-      ;; Makes it easier to detect root resolution issues.
-      (when-let (path (buffer-file-name (buffer-base-buffer)))
-        (if-let (root (lsp--calculate-root (lsp-session) path))
-            (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
-          (lsp--info "Could not guess project root."))))
+      ;; Makes it easier to detect root resolution issues if auto-guess-root is on.
+      (when lsp-auto-guess-root
+        (when-let (path (buffer-file-name (buffer-base-buffer)))
+          (if-let (root (lsp--calculate-root (lsp-session) path))
+              (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
+            (lsp--info "Could not guess project root.")))))
     #'+lsp-optimization-mode)
 
   (when (modulep! :completion company)

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -76,16 +76,7 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
           (setq-local flycheck-checker old-checker))
       (apply fn args)))
 
-  (add-hook! 'lsp-mode-hook
-    (defun +lsp-display-guessed-project-root-h ()
-      "Log what LSP things is the root of the current project."
-      ;; Makes it easier to detect root resolution issues if auto-guess-root is on.
-      (when lsp-auto-guess-root
-        (when-let (path (buffer-file-name (buffer-base-buffer)))
-          (if-let (root (lsp--calculate-root (lsp-session) path))
-              (lsp--info "Guessed project root is %s" (abbreviate-file-name root))
-            (lsp--info "Could not guess project root.")))))
-    #'+lsp-optimization-mode)
+  (add-hook! 'lsp-mode-hook #'+lsp-optimization-mode)
 
   (when (modulep! :completion company)
     (add-hook! 'lsp-completion-mode-hook


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->

This is an important fix IMO since `lsp-auto-guess-root` is disabled by default for a long time ⚠️, after long debugging why when finding the definition with LSP of a library file, like a external jar or dependency, even if lsp consider that file as part of the current workspace, doom would still ask for the project root, which doesn't make sense, this is a 2 year bug introduced after calling `lsp--calculate-root` which asks for project root interactively.

Since the custom hook function `+lsp-display-guessed-project-root-h` was created just to log when a project root was guessed, it should check the `lsp-auto-guess-root`

Example of wrongly prompt:
![image](https://user-images.githubusercontent.com/7820865/197401016-ce4c1a76-5be1-40e8-a961-b36879409783.png)
