### PR TITLE
fix(evil): evil-jump-forward not working under tty

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -424,7 +424,7 @@ directives. By default, this only recognizes C directives.")
 ;;   zu{q,w} - undo last marking
 
 (map! :v  "@"     #'+evil:apply-macro
-      :m  [C-i]   #'evil-jump-forward
+      :m  (if (display-graphic-p) [C-i] "TAB")  #'evil-jump-forward
 
       ;; implement dictionary keybinds
       ;; evil already defines 'z=' to `ispell-word' = correct word at point


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Fix `evil-jump-forward` does not bind to `TAB` when using emacs under a terminal.

See #6714.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
