### PR TITLE
tweak: kill-current-buffer: suppress prompt for dired-mode buffers

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -206,6 +206,7 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
            (let ((visible-p (delq (selected-window) (get-buffer-window-list buf nil t))))
              (unless visible-p
                (when (and (buffer-modified-p buf)
+                          (not (memq major-mode '(dired-mode)))
                           (not (y-or-n-p
                                 (format "Buffer %s is modified; kill anyway?"
                                         buf))))


### PR DESCRIPTION
In dired buffers, `(buffer-modified-p (current-buffer))` frequently returns t although no modifications have been made. Which makes `doom--switch-to-fallback-buffer-maybe-a's `y-or-n-p' is always asked.

Fix by checking if current `major-mode` isn't `dired-mode`. We may need a more generic checker like `derived-mode-p` if needed.

<!-- ⚠️ Please do not ignore this template! 

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
References #0000
Replaces #0000
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
