### PR TITLE
bump: :ui modeline

### DIFF
--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -2,7 +2,7 @@
 ;;; ui/modeline/packages.el
 
 (unless (modulep! +light)
-  (package! doom-modeline :pin "bed80b82d7bf4bd85904d9b093ab690b7bcbac1c")
+  (package! doom-modeline :pin "b66d5e5006df4cedb1119da3d83fd6c08965b830")
   (package! compat :pin "cc1924fd8b3f9b75b26bf93f084ea938c06f9615"))
 (package! anzu :pin "5abb37455ea44fa401d5f4c1bdc58adb2448db67")
 (when (modulep! :editor evil)


### PR DESCRIPTION
seagle0128/doom-modeline@bed80b82d7bf -> seagle0128/doom-modeline@b66d5e5006df

- Fixes error with eglot 1.9 (due to rename of eglot--major-mode)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

Consider this a bug request as I understand you don't want PR for modules for now.