### PR TITLE
docs: fix minimum Emacs version in index

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -1,7 +1,7 @@
 #+TITLE: Doom Emacs Documentation
 #+STARTUP: nofold
 
-Doom is a configuration framework for [[https://www.gnu.org/software/emacs/][GNU Emacs 26.3+]] tailored for Emacs
+Doom is a configuration framework for [[https://www.gnu.org/software/emacs/][GNU Emacs 27.1+]] tailored for Emacs
 bankruptcy veterans who want less framework in their frameworks and the
 performance of a hand rolled config (or better). It can be a foundation for your
 own config or a resource for Emacs enthusiasts to learn more about our favorite


### PR DESCRIPTION
The minimum supported version is 27.1. Remove mention of Emacs 26.3.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

The documentation is on the "no PR" list. Feel free to discard.