### PR TITLE
docs: use floating point for font sizes

### DIFF
--- a/docs/faq.org
+++ b/docs/faq.org
@@ -259,10 +259,10 @@ Each of these variables accept one of:
 For example:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
-(setq doom-font (font-spec :family "JetBrainsMono" :size 12 :weight 'light)
-      doom-variable-pitch-font (font-spec :family "DejaVu Sans" :size 13)
+(setq doom-font (font-spec :family "JetBrainsMono" :size 12.0 :weight 'light)
+      doom-variable-pitch-font (font-spec :family "DejaVu Sans" :size 13.0)
       doom-unicode-font (font-spec :family "Symbola")
-      doom-big-font (font-spec :family "JetBrainsMono" :size 24))
+      doom-big-font (font-spec :family "JetBrainsMono" :size 24.0))
 #+end_src
 
 #+begin_quote

--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -1015,7 +1015,7 @@ If your configuration needs are simple, the ~use-package!~, ~after!~,
 
 #+BEGIN_SRC emacs-lisp
 ;;; ~/.doom.d/config.el (example)
-(setq doom-font (font-spec :family "Fira Mono" :size 12))
+(setq doom-font (font-spec :family "Fira Mono" :size 12.0))
 
 ;; Takes a feature symbol or a library name (string)
 (after! evil

--- a/templates/config.example.el
+++ b/templates/config.example.el
@@ -21,8 +21,8 @@
 ;; See 'C-h v doom-font' for documentation and more examples of what they
 ;; accept. For example:
 ;;
-;;(setq doom-font (font-spec :family "Fira Code" :size 12 :weight 'semi-light)
-;;      doom-variable-pitch-font (font-spec :family "Fira Sans" :size 13))
+;;(setq doom-font (font-spec :family "Fira Code" :size 12.0 :weight 'semi-light)
+;;      doom-variable-pitch-font (font-spec :family "Fira Sans" :size 13.0))
 ;;
 ;; If you or Emacs can't find your font, use 'M-x describe-font' to look them
 ;; up, `M-x eval-region' to execute elisp code, and 'M-x doom/reload-font' to


### PR DESCRIPTION
As mentioned in #6131, when using a non-standard DPI, setting `:size` as an integer will be converted to pixel size and it does not account for DPI settings. Instead, when using a float, this is converted to point size and DPI is respected.

References #6131

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

I can also add a sentence about that in `lisp/doom-ui.el` if this could be useful.