### PR TITLE
feat(javascript): add coffee-mode

### DIFF
--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -11,7 +11,8 @@ This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.t
 - Refactoring commands ([[doom-package:js2-refactor]])
 - Syntax checking ([[doom-package:flycheck]])
 - Browser code injection with [[doom-package:skewer-mode]]
-- Coffeescript & JSX support
+- Coffeescript ([[doom-package:coffee-mode]])
+- JSX support
 - Jump-to-definitions and references support ([[doom-package:xref]])
 
 ** Maintainers
@@ -29,8 +30,10 @@ This module adds [[https://www.javascript.com/][JavaScript]] and [[https://www.t
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
   editing. Requires [[doom-module::tools tree-sitter]].
+- +coffeescript :: Enables support for [[https://coffeescript.org/][Coffeescript]].
 
 ** Packages
+- [[doom-package:coffee-mode]]* if [[doom-module::+coffeescript]]
 - [[doom-package:js2-refactor]]
 - [[doom-package:nodejs-repl]]
 - [[doom-package:npm-mode]]

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -162,6 +162,9 @@
     ;; `emmet-mode' is used.
     emmet-expand-jsx-className? t))
 
+(use-package! coffee-mode
+  :when (modulep! +coffeescript)
+  :hook (coffee-mode . rainbow-delimiters-mode))
 
 ;;
 ;;; Tools

--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -4,6 +4,8 @@
 ;; Major modes
 (package! rjsx-mode :pin "b697fe4d92cc84fa99a7bcb476f815935ea0d919")
 (package! typescript-mode :pin "88f317f0b6aef8f8d232e912fdbc679799580c56")
+(when (modulep! +coffeescript)
+  (package! coffee-mode :pin "35a41c7d8233eac0b267d9593e67fb8b6235e134"))
 
 ;; Tools
 (package! js2-refactor :pin "a0977c4ce1918cc266db9d6cd7a2ab63f3a76b9a")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I noticed when opening coffeescript files that coffee-mode is missing; I added the latest commit (pinned) for it here.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
