### PR TITLE
fix(window-select): unset winum-auto-setup-mode-line sooner

### DIFF
--- a/modules/ui/window-select/config.el
+++ b/modules/ui/window-select/config.el
@@ -25,10 +25,10 @@
   :when (modulep! +numbers)
   :after-call doom-switch-window-hook
   :config
-  (winum-mode +1)
   ;; winum modifies `mode-line-format' in a destructive manner. I'd rather leave
   ;; it to modeline plugins (or the user) to add this if they want it.
   (setq winum-auto-setup-mode-line nil)
+  (winum-mode +1)
   (map! :map evil-window-map
         "0" #'winum-select-window-0-or-10
         "1" #'winum-select-window-1


### PR DESCRIPTION
winum-atuo-setup-mode-line should be set first before calling winum-mode


```emacs-lisp
(define-minor-mode winum-mode
  "A minor mode that allows for managing windows based on window numbers."
  nil
  nil
  winum-keymap
  :global t
  (if winum-mode
      (winum--init)
    (winum--deinit)))
```

`winum-mode` calls `winum--init`


```emacs-lisp
(defun winum--init ()
  "Initialize winum-mode."
  (setq winum--window-count (length (winum--window-list)))
  (if (eq winum-scope 'frame-local)
      (setq winum--frames-table (make-hash-table :size winum--max-frames))
    (setq winum--numbers-table (make-hash-table :size winum--window-count)))
  (when winum-auto-setup-mode-line
    (winum--install-mode-line))
  (add-hook 'minibuffer-setup-hook 'winum--update)
  (add-hook 'window-configuration-change-hook 'winum--update)
  (dolist (frame (frame-list))
    (select-frame frame)
    (winum--update)))
```

`winum-auto-setup-mode-line` will be used here.

Therefore, we need to set it before calling `winum-mode`.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


