### PR TITLE
bump: :lang scheme geiser

### DIFF
--- a/modules/lang/scheme/packages.el
+++ b/modules/lang/scheme/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/scheme/packages.el
 
-(when (package! geiser :pin "550d57d347b6a2387d633c3da90460106dfcd3e3")
+(when (package! geiser :pin "04dbdacfeca0190856abad859360da4bb873f9dd")
   (package! macrostep-geiser :pin "f6a2d5bb96ade4f23df557649af87ebd0cc45125")
   (when (modulep! +chez)
     (package! geiser-chez :pin "48427d4aecc6fed751d266673f1ce2ad57ddbcfc"))
@@ -14,7 +14,7 @@
   (when (modulep! +gauche)
     (package! geiser-gauche :pin "8ff743f6416f00751e24aef8b9791501a40f5421"))
   (when (modulep! +guile)
-    (package! geiser-guile :pin "b2d6f398e33c0f140dcde5adc91117aa7de4463d")
+    (package! geiser-guile :pin "f5e82dc0f5a076335f201885a7edbefaa1ad435f")
     (when (modulep! :checkers syntax)
       (package! flycheck-guile
         :recipe (:host github :repo "flatwhatson/flycheck-guile")


### PR DESCRIPTION
emacsmirror/geiser@550d57d347b6 -> emacsmirror/geiser@04dbdacfeca0 
emacsmirror/geiser-guile@b2d6f398e33c -> emacsmirror/geiser-guile@f5e82dc0f5a0

Currently, Scheme code can't be executed in `org-mode` due to a missing `run-geiser` function. This was fixed in a more recent commit, which this PR includes.

Fixes #6916 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
