### PR TITLE
Fixes for Scheme/Geiser REPL integration

### DIFF
--- a/modules/lang/scheme/autoload.el
+++ b/modules/lang/scheme/autoload.el
@@ -69,5 +69,5 @@ property lists and names starting with 'default'."
 (defun +scheme/open-repl ()
   "Open the Scheme REPL."
   (interactive)
-  (call-interactively #'switch-to-geiser)
+  (call-interactively #'geiser-repl-switch)
   (current-buffer))

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -23,7 +23,7 @@
   (set-popup-rules!
     '(("^\\*[gG]eiser \\(dbg\\|xref\\|messages\\)\\*$" :slot 1 :vslot -1)
       ("^\\*Geiser documentation\\*$" :slot 2 :vslot 2 :select t :size 0.35)
-      ("^\\* [A-Za-z0-9_-]+ REPL \\*" :size 0.3 :quit nil :ttl nil)))
+      ("^\\*Geiser .+ REPL" :size 0.3 :quit nil :ttl nil)))
   
   (map! :localleader
         (:map (scheme-mode-map geiser-repl-mode-map)

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -30,7 +30,7 @@
   
   (map! :localleader
         (:map (scheme-mode-map geiser-repl-mode-map)
-         :desc "Toggle REPL"                  "'"  #'switch-to-geiser
+         :desc "Toggle REPL"                  "'"  #'geiser-repl-switch
          :desc "Connect to external Scheme"   "\"" #'geiser-connect
          :desc "Toggle type of brackets"      "["  #'geiser-squarify
          :desc "Insert lambda"                "\\" #'geiser-insert-lambda

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -14,7 +14,10 @@
         geiser-repl-history-filename (concat doom-cache-dir "geiser-history"))
 
   (after! scheme  ; built-in
-    (set-repl-handler! 'scheme-mode #'+scheme/open-repl)
+    (set-repl-handler! 'scheme-mode #'+scheme/open-repl
+      :persist t
+      :send-region #'geiser-eval-region
+      :send-buffer #'geiser-eval-buffer)
     (set-eval-handler! 'scheme-mode #'geiser-eval-region)
     (set-lookup-handlers! '(scheme-mode geiser-repl-mode)
       :definition #'geiser-edit-symbol-at-point

--- a/modules/lang/scheme/packages.el
+++ b/modules/lang/scheme/packages.el
@@ -1,6 +1,11 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/scheme/packages.el
 
+(when (< emacs-major-version 29)
+  (package! scheme
+    :recipe (:host gitlab :repo "flatwhatson/scheme-mode")
+    :pin "aaef1f88cc34e8b6e07c207f9b8caff33f6e0740"))
+
 (when (package! geiser :pin "e54d5e6dc659c252d10c4280f4c4d78d38623df5")
   (package! macrostep-geiser :pin "f6a2d5bb96ade4f23df557649af87ebd0cc45125")
   (when (modulep! +chez)


### PR DESCRIPTION
Fix the popup rule not matching Geiser buffers (buffer naming changed upstream).

Fix repl/eval behavior to use `geiser-eval-region` instead of the default `+eval/send-region-to-repl` which doesn't work properly with Geiser.

Replaced calls to deprecated `switch-to-geiser` to avoid warning messages.

Introduced a scheme-mode package which backports `scheme-mode` fixes from master for Emacs <29.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
