### PR TITLE
docs(evil): add a faq on the system clipboard

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -222,6 +222,24 @@ modify the syntax-table in all buffers of some mode, e.g.
 (add-hook! 'js2-mode-hook (modify-syntax-entry ?_ "w"))
 #+end_src
 
+** How do I disable the synchronization between the kill ring and the system clipboard?
+
+In vim, operations that put or delete text (kill and yank in Emacs terminology) act on the
+unnamed register by default. The unnamed register unrelated the system clipboard. Evil
+uses the kill ring instead of the unnamed register. As the kill ring is synchronized with
+the system clipboard by default, operations like [[kbd:][dd]] or [[kbd:][cw]] place the
+killed text in the system clipboard, surprisingly so for users who are used to the vim
+behavior.
+
+The synchronization between the system clipboard and kill ring can be disabled, making
+these operations behave closer to their vim counterparts:
+#+begin_src emacs-lisp
+(setq select-enable-clipboard nil)
+#+end_src
+
+Like in vim, the clipboard can still be accessed by using the [[kbd:][+]] register,
+e.g. [[kbd:]["+dd]] or [[kbd:]["+cw]].
+
 * TODO Appendix
 #+begin_quote
  🔨 This module has no appendix yet. [[doom-contrib-module:][Write one?]]


### PR DESCRIPTION
Include a section in the faq describing how to disable the synchronization between the kill ring and the system clipboard.

I encountered this myself (and needed a while to figure it out as an Emacs beginner) and have seen the question a few times on the doom Discord, so I think that it is worth documenting.  Especially as it can be very surprising for vim users (speaking from experience).

If you disagree that it is something not worth documenting or should be documented elsewhere, feel free to close the PR without a merge :) .

I hope that I got the commit format right this time :)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
