### PR TITLE
fix(org): update org-attach-store-link-p default

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -476,7 +476,7 @@ relative to `org-directory', unless it is an absolute path."
 
 (defun +org-init-attachments-h ()
   "Sets up org's attachment system."
-  (setq org-attach-store-link-p t     ; store link after attaching files
+  (setq org-attach-store-link-p 'attached     ; store link after attaching files
         org-attach-use-inheritance t) ; inherit properties from parent nodes
 
   ;; Autoload all these commands that org-attach doesn't autoload itself


### PR DESCRIPTION
Org-mode's behavior when org-attach-store-link-p is 't' recently
changed. See:

Commit: 0d60013f0e3980fab959542eeb171ab9a02b450c
https://git.savannah.gnu.org/cgit/emacs/org-mode.git

When the value of org-attach-store-link-p is 't' org-store-link now
suggests a 'file:' link to the attachment's original location. Setting
the value to 'attached' instead suggests an 'attachment:' link utilizing
the attachment directory.

Fix: #6952

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
