### PR TITLE
fix(mu4e): Do not shadow `mu4e` arguments

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -52,7 +52,7 @@ default/fallback account."
 (add-hook 'mu4e-main-mode-hook #'+mu4e-init-h)
 
 ;;;###autoload
-(defun =mu4e ()
+(defun =mu4e (&optional background)
   "Start email client."
   (interactive)
   (require 'mu4e)
@@ -91,7 +91,7 @@ default/fallback account."
           (switch-to-buffer view-buffer)
         (if (and headers-buffer (not (eq headers-buffer (current-buffer))))
             (switch-to-buffer headers-buffer)
-          (mu4e))))))
+          (mu4e background))))))
 
 ;;;###autoload
 (defun +mu4e/compose ()


### PR DESCRIPTION
`(mu4e)` accepts an optional argument, `background`, which is useful if you want to jump straight to `mu4e-headers-mode`. `=mu4e` does useful things in addition, but ignores this parameter. It should pass it on.

(In general, `=FUNC` commands should not mask optional arguments, if any.)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.