### PR TITLE
docs(grammar): add nixos languagetool config

### DIFF
--- a/modules/checkers/grammar/README.org
+++ b/modules/checkers/grammar/README.org
@@ -33,6 +33,14 @@ It is available from either https://languagetool.org/ or your OS's package
 manager. E.g.
 - macOS: ~$ brew install languagetool~
 - Arch Linux: ~$ pacman -S languagetool~
+- NixOS:
+#+begin_src nix
+{
+  environment.systemPackages = with pkgs; [
+    languagetool
+  ];
+}
+#+end_src
 
 This module tries to guess the location of =languagetool-commandline.jar=. If
 you get a warning that Doom ~couldn't find languagetool-commandline.jar~, you
@@ -60,8 +68,14 @@ This minor mode highlights weasel words, duplication and passive voice.
 
 * TODO Configuration
 #+begin_quote
- 🔨 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
+ 🔨 /This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
+
+** NixOS
+#+begin_src elisp
+(after! langtool
+  (setq langtool-bin (executable-find "languagetool-commandline")))
+#+end_src
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]


### PR DESCRIPTION
The setup required for NixOS with LanguageTool is not as simple as installing LanguageTool and enabling the module. NixOS builds both the UI, CLI, and server jars. So, Emacs has to focus the correct script to start the CLI version.

The contribution docs indicate changes to docs itself should be done on the `rewrite-docs` branch, but this one hasn't been updated with the latest changes, and it seemed other PR have been merged onto master which were docs related.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
=> Green light was given on Discord by @hlissner, even though it's part of the do-not-pr list.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).