### PR TITLE
fix(cli): double quotes break org-capture

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -34,6 +34,9 @@ case "$str" in
   -) str=$(cat) ;;
 esac
 
+# escape any double quotes in the string
+str=$(echo $str | sed -e 's/"/\\"/g')
+
 # Fix incompatible terminals that cause odd 'not a valid terminal' errors
 [ "$TERM" = "alacritty" ] && export TERM=xterm-256color
 


### PR DESCRIPTION
Repro:

`org-capture "hello \" there"`

Before:

`*ERROR*: End of file during parsing`

After:

Successful launch of `org-capture`

-----
I'm far from a `sh` wizard so if there's a better way to fix this I'm happy to change it but this Works On My Machine (tm).

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
  - Not that I could find, apologies if I missed it
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
