### PR TITLE
feat: add doom/copy-this-file-and-open

### DIFF
--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -442,7 +442,9 @@ If FORCE-P, overwrite the destination file if it exists, without confirmation."
 
 ;;;###autoload
 (defun doom/copy-this-file-and-open (new-path &optional force-p)
-  "Copy current buffer's file to NEW-PATH, and then open the file."
+  "Copy current buffer's file to NEW-PATH, and then open the file.
+
+If FORCE-P, overwrite the destination file if it exists, without confirmation."
   (interactive
    (list (read-file-name "Copy file to: ")
          current-prefix-arg))

--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -441,6 +441,15 @@ If FORCE-P, overwrite the destination file if it exists, without confirmation."
     (message "File copied to %S" (abbreviate-file-name new-path))))
 
 ;;;###autoload
+(defun doom/copy-this-file-and-open (new-path &optional force-p)
+  "Copy current buffer's file to NEW-PATH, and then open the file."
+  (interactive
+   (list (read-file-name "Copy file to: ")
+         current-prefix-arg))
+  (doom/copy-this-file new-path force-p)
+  (find-file (expand-file-name new-path)))
+
+;;;###autoload
 (defun doom/move-this-file (new-path &optional force-p)
   "Move current buffer's file to NEW-PATH.
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I found that `doom/copy-this-file` is not very convenient. When I copy a file, normally, the next step would be to edit it. So I have to execute a find-file command to open that new file. And many times I forgot to open the new file, just edit the origin buffer. Sometimes it take a while to notice it.

So I added a new function `doom/copy-this-file-and-open`. It copy the file of current buffer and then open the new file, then switch immediately to the new buffer.

It can also be bind to some convenient key:

```(map! :leader :desc "Copy this file and open" :n "f c" #'doom/copy-this-file-and-open)```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
