### PR TITLE
nit(doc): clone to .config/emacs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ doctor` to check for any that you may have missed.
 
 # Install
 ``` sh
-git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.emacs.d
-~/.emacs.d/bin/doom install
+git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
+~/.config/emacs/bin/doom install
 ```
 
 Then [read our Getting Started guide][getting-started] to be walked through
 installing, configuring and maintaining Doom Emacs.
 
-It's a good idea to add `~/.emacs.d/bin` to your `PATH`! Other `bin/doom`
+It's a good idea to add `~/.config/emacs/bin` to your `PATH`! Other `bin/doom`
 commands you should know about:
 
 + `doom sync` to synchronize your private config with Doom by installing missing


### PR DESCRIPTION
Since support moved to Emacs 27+, all versions should support cloning to .config/emacs.

Maybe it would be worth adding a command that moves or deletes legacy configuration locations.

The PR is mostly created as a glorified TODO item

References: doomemacs/.github#2