### PR TITLE
fix(lookup): require consult in +lookup/in-docsets

### DIFF
--- a/modules/tools/lookup/autoload/docsets.el
+++ b/modules/tools/lookup/autoload/docsets.el
@@ -103,6 +103,7 @@ installed with `dash-docs-install-docset'."
         (query (doom-thing-at-point-or-region query)))
     (doom-log "Searching docsets %s" dash-docs-docsets)
     (cond ((modulep! :completion vertico)
+           (require 'consult)
            (dash-docs-initialize-debugging-buffer)
            (dash-docs-create-buffer-connections)
            (dash-docs-create-common-connections)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

When `(lookup +docsets)` enabled, open Doom Emacs, `SPC s k` shows error: `Symbol’s function definition is void: consult--async-throttle`.

This is due to `consult` not loaded.

References [Discord thread](https://discord.com/channels/406534637242810369/1046468107822170142)

- modules/tools/lookup/autoload/docsets.el (`+lookup/in-docsets`): require consult for `vertico` completion

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->

