### PR TITLE
fix: modify __DOOMSTEP syntax for netbsd

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -5,7 +5,7 @@
 :; tmpdir=`$emacs --eval '(princ (temporary-file-directory))' 2>/dev/null`
 :; [ -z "$tmpdir" ] && { >&2 echo "Error: failed to run Emacs with command '$EMACS'"; >&2 echo; >&2 echo "Are you sure Emacs is installed and in your \$PATH?"; exit 1; }
 :; export __DOOMPID="${__DOOMPID:-$$}"
-:; export __DOOMSTEP="$((__DOOMSTEP+1))"
+:; export __DOOMSTEP="${__DOOMSTEP+1:0}"
 :; export __DOOMGEOM="${__DOOMGEOM:-`tput cols 2>/dev/null`x`tput lines 2>/dev/null`}"
 :; export __DOOMGPIPE=${__DOOMGPIPE:-$__DOOMPIPE}
 :; export __DOOMPIPE=; [ -t 0 ] || __DOOMPIPE="${__DOOMPIPE}0"; [ -t 1 ] || __DOOMPIPE="${__DOOMPIPE}1"


### PR DESCRIPTION
References #6615 

As noted in https://github.com/doomemacs/doomemacs/issues/6615#issuecomment-1330835475, trying to run `doom install` on netbsd ksh/sh fails with the following error:

```
$ ~/.emacs.d/bin/doom install
~/.emacs.d/bin/doom install
/sdf/arpa/tz/myhomedir/.emacs.d/bin/doom: arith: syntax error: "__DOOMSTEP+1"
```

This replaces `"$((__DOOMSTEP+1))"` with `"${__DOOMSTEP+1:0}"` to ensure that the variable is always set before incrementing.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.