### PR TITLE
fix(python): repl: respect python-shell-dedicated

### DIFF
--- a/modules/lang/python/autoload/python.el
+++ b/modules/lang/python/autoload/python.el
@@ -29,16 +29,17 @@ falling back on searching your PATH."
     (user-error "`python-shell-interpreter' isn't set"))
   (pop-to-buffer
    (process-buffer
-    (if-let* ((pipenv (+python-executable-find "pipenv"))
-              (pipenv-project (pipenv-project-p)))
-        (let ((default-directory pipenv-project)
-              (python-shell-interpreter-args
-               (format "run %s %s"
-                       python-shell-interpreter
-                       python-shell-interpreter-args))
-              (python-shell-interpreter pipenv))
-          (run-python nil nil t))
-      (run-python nil nil t)))))
+    (let ((dedicated (bound-and-true-p python-shell-dedicated)))
+      (if-let* ((pipenv (+python-executable-find "pipenv"))
+                (pipenv-project (pipenv-project-p)))
+          (let ((default-directory pipenv-project)
+                (python-shell-interpreter-args
+                 (format "run %s %s"
+                         python-shell-interpreter
+                         python-shell-interpreter-args))
+                (python-shell-interpreter pipenv))
+            (run-python nil dedicated t))
+        (run-python nil dedicated t))))))
 
 ;;;###autoload
 (defun +python/open-ipython-repl ()


### PR DESCRIPTION
For Emacs 29 whose branch has been cut, respect `python-shell-dedicated` for `+python/open-repl`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
