### PR TITLE
`:completion vertico` updates

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -292,12 +292,6 @@ orderless."
             '(projectile-switch-project . project-file)))
 
 
-(use-package! embark-consult
-  :after (embark consult)
-  :config
-  (add-hook 'embark-collect-mode-hook #'consult-preview-at-point-mode))
-
-
 (use-package! wgrep
   :commands wgrep-change-to-wgrep-mode
   :config (setq wgrep-auto-save-buffer t))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,27 +4,27 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "8078b8cb940d6b2fe7578bc2e9c7cf1838cd092f")
+  :pin "801ad3143d26653384f4c25bad44f7c098dd704c")
 
-(package! orderless :pin "6b86527b30ef96e047d97e314ac640a410891d1f")
+(package! orderless :pin "004cee6b8e01f8eb0cb1c683d0a637b14890600f")
 
-(package! consult :pin "76aab86015c3d7628dbd5f92b2dd8ab9aeadac8d")
+(package! consult :pin "e4e2af1a2d06d40461d975b74ea3cc863cd18085")
 (package! compat :pin "056e3ccffc716990dcb7b33273453d5fce0402de")
-(package! consult-dir :pin "8abf62df088de87175e98adf8f6f5fb93515004c")
+(package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
-  (package! consult-flycheck :pin "9b40f136c017fadf6239d7602d16bf73b4ad5198"))
+  (package! consult-flycheck :pin "7a10be316d728d3384fa25574a30857c53fb3655"))
 
-(package! embark :pin "3add321d7442973413fb92a4052f8d0ad6915829")
-(package! embark-consult :pin "3add321d7442973413fb92a4052f8d0ad6915829")
+(package! embark :pin "09da327d43793f0b30114ee80d82ef587124462a")
+(package! embark-consult :pin "09da327d43793f0b30114ee80d82ef587124462a")
 
-(package! marginalia :pin "7f5bf7818b8c5a88cc3e7011d561655b287570e3")
+(package! marginalia :pin "c68164c56485e1ef855c2d12e4393f5f55ca2b12")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (modulep! +icons)
-  (package! all-the-icons-completion :pin "286e2c064a1298be0d8d4100dc91d7a7a554d04a"))
+  (package! all-the-icons-completion :pin "4da28584a1b36b222e0e78d46fd8d46bbd9116c7"))
 
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "46aa1dffd18dc9500c04f0b61524b0625b7b5429"))
+    :pin "61a88aec07669d0399bbc6699740975d0d5ff721"))


### PR DESCRIPTION
---
refactor!(vertico): remove consult-preview-at-point-mode hook

BREAKING CHANGE: That function is only meant to be used in
the *Completions* buffer, which is only relevant if you're using embark
and consult without vertico. While it doesn't hurt, it's mostly unclear
why it's there in the first place when reading the modules

---
bump: :completion vertico

iyefrat/all-the-icons-completion@286e2c064a12 -> iyefrat/all-the-icons-completion@4da28584a1b3
karthink/consult-dir@8abf62df088d -> karthink/consult-dir@ed8f0874d26f
minad/consult-flycheck@9b40f136c017 -> minad/consult-flycheck@7a10be316d72
minad/consult@76aab86015c3 -> minad/consult@e4e2af1a2d06
minad/marginalia@7f5bf7818b8c -> minad/marginalia@c68164c56485
minad/vertico@8078b8cb940d -> minad/vertico@801ad3143d26
oantolin/embark@3add321d7442 -> oantolin/embark@09da327d4379
oantolin/orderless@6b86527b30ef -> oantolin/orderless@004cee6b8e01
tumashu/vertico-posframe@46aa1dffd18d -> tumashu/vertico-posframe@61a88aec0766