### PR TITLE
fix(god): enable god-mode on init

### DIFF
--- a/modules/editor/god/config.el
+++ b/modules/editor/god/config.el
@@ -1,7 +1,7 @@
 ;;; editor/god/config.el -*- lexical-binding: t; -*-
 
 (use-package! god-mode
-  :hook (doom-after-modules-init . god-mode-all)
+  :hook (doom-after-modules-config . god-mode-all)
   :config
   (add-hook 'post-command-hook #'+god--configure-cursor-and-modeline-h)
   (add-hook 'overwrite-mode-hook #'+god--toggle-on-overwrite-h)

--- a/modules/editor/god/packages.el
+++ b/modules/editor/god/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/god/packages.el
 
-(package! god-mode :pin "fac7d26ecde1be5b0bf6bd6e0ec5b4895be13906")
+(package! god-mode :pin "49c1a1753188e5b2788b8c1f1f9fbd1264460bab")


### PR DESCRIPTION
Enabling god-mode was broken in 7a2be67efadf63f28b948849240f78508579fb3e.
Fixes #6954.
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
