### PR TITLE
fix(clojure): undefined face on +light modeline

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -130,7 +130,7 @@
       (defun +clojure--cider-connected-update-modeline ()
         "Update modeline with cider connection state."
         (let* ((connected (cider-connected-p))
-               (face (if connected 'warning 'breakpoint-disabled))
+               (face (if connected 'warning 'shadow))
                (label (if connected "Cider connected" "Cider disconnected")))
           (+clojure--cider-set-modeline face label))))
 


### PR DESCRIPTION
Introduced in #5730. `breakpoint-disabled` is defined in `gdb-mi.el`, not sure why that specifically was used here, but `shadow` is better than spamming `*Messages*`.