### PR TITLE
bump: :app calendar

### DIFF
--- a/modules/app/calendar/packages.el
+++ b/modules/app/calendar/packages.el
@@ -5,4 +5,4 @@
 (package! calfw-org :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! calfw-cal :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! calfw-ical :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
-(package! org-gcal :pin "f8075bd8eac7288eea1060077ca103d5fd01fb65")
+(package! org-gcal :pin "3cc48a989ac859a97d25964c28874317a6e1672a")


### PR DESCRIPTION
kidd/org-gcal@f8075bd8eac7-> kidd/org-gcal@3cc48a989ac8

Update org-gcal to 0.4.2, which addresses the deprecated oauth flow

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
