### PR TITLE
bump: :lang scala

### DIFF
--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/scala/packages.el
 
 (package! sbt-mode :pin "9fe1e8807c22cc1dc56a6233e000969518907f4d")
-(package! scala-mode :pin "598cb680f321d9609295aa9b4679040cc703b602")
+(package! scala-mode :pin "5d7cf21c37e345c49f921fe5111a49fd54efd1e0")
 
 (when (modulep! +lsp)
-  (package! lsp-metals :pin "097d6021a4ff0eae704cc3074e064c9509c5cafc"))
+  (package! lsp-metals :pin "a2df7263ece6ac69214e41c52d66aab8d3f650eb"))


### PR DESCRIPTION
hvesalai/emacs-scala-mode@598cb680f321 -> hvesalai/emacs-scala-mode@5d7cf21c37e3 emacs-lsp/lsp-metals@097d6021a4ff -> emacs-lsp/lsp-metals@a2df7263ece6

Upgrades scala-mode & lsp-metals. Bumping lsp-metals fixes an incompatibility with a recent treemacs change.

Fixes https://github.com/doomemacs/doomemacs/issues/6961

-----
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
