### PR TITLE
fix(docker): load docker-tramp conditionnally

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -185,7 +185,7 @@ orderless."
          ("C-x C-d" . consult-dir)
          ("C-x C-j" . consult-dir-jump-file))
   :config
-  (when (modulep! :tools docker)
+  (when (and (not EMACS29+) (modulep! :tools docker))
     (defun +vertico--consult-dir-docker-hosts ()
       "Get a list of hosts from docker."
       (when (require 'docker-tramp nil t)

--- a/modules/tools/docker/packages.el
+++ b/modules/tools/docker/packages.el
@@ -2,5 +2,6 @@
 ;;; tools/docker/packages.el
 
 (package! docker :pin "44f0bbec9b3deb027d17f4c10d8ec4106ed89dfb")
-(package! docker-tramp :pin "930d7b46c180d8a13240a028c1b40af84f2a3219")
+(unless EMACS29+
+  (package! docker-tramp :pin "930d7b46c180d8a13240a028c1b40af84f2a3219"))
 (package! dockerfile-mode :pin "b63a3d12b7dea0cb9efc7f78d7ad5672ceab2a3f")


### PR DESCRIPTION
Trying to use `docker-tramp` in Emacs in version 29 or more triggers a warning[^1] about `docker-tramp` being deprecated in favour of `tramp-container`, apparently stopping the loading of modules altogether. This lead at least notably to `:config default` not being loaded, so no binding is available in my sessions without that fix (EDIT: I'm finally not sure, couldn't repro the "no modules loading" part on other computers)

[^1]: https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/net/tramp-compat.el?h=emacs-29#n53

```lisp
(with-eval-after-load 'docker-tramp
  (warn (concat "Package `docker-tramp' has been obsoleted, "
		"please use integrated package `tramp-container'")))
```