### PR TITLE
feat(default): add C-h/C-l evil keybinds for vertico

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -116,6 +116,23 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
       (let ((embark-quit-after-action nil))
         (embark-dwim)))))
 
+;;;###autoload
+(defun +vertico/directory-enter ()
+  "Enter directory or embark preview on current candidate."
+  (interactive)
+  (if (>= vertico--index 0)
+      (if (and (let ((cand (vertico--candidate)))
+                 (or (string-suffix-p "/" cand)
+                     (and (vertico--remote-p cand)
+                          (string-suffix-p ":" cand))))
+               (not (equal vertico--base ""))
+               (eq 'file (vertico--metadata-get 'category)))
+          (vertico-insert)
+        (unless (bound-and-true-p consult--preview-function)
+          (save-selected-window
+            (let ((embark-quit-after-action nil))
+              (embark-dwim)))))))
+
 (defvar +vertico/find-file-in--history nil)
 ;;;###autoload
 (defun +vertico/find-file-in (&optional dir initial)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -216,7 +216,10 @@
          "C-j"   #'vertico-next
          "C-M-j" #'vertico-next-group
          "C-k"   #'vertico-previous
-         "C-M-k" #'vertico-previous-group)))
+         "C-M-k" #'vertico-previous-group
+         (:when (modulep! :editor evil +everywhere)
+          "C-h"  #'vertico-directory-up
+          "C-l"  #'+vertico/directory-enter))))
 
 
 ;;; :ui


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Add C-h/C-l keybinding for directory up/directory enter or embark preview to vertico-map. The keybindings are currently not used. I try to replicate the C-h/C-l behavior from helm that i added in these pull requests: [pr](https://github.com/doomemacs/doomemacs/pull/6853) and was merged [here](https://github.com/doomemacs/doomemacs/commit/6887998c23d31430bde619e52d86de7b0ddf5c96)
 
Fixes 0
References 0
Replaces 0

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
