### PR TITLE
fix(workspaces): save current tab-bar tabs to file for workspaces

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -581,10 +581,24 @@ This be hooked to `projectile-after-switch-project-hook'."
     (set-persp-parameter 'tab-bar-closed-tabs tab-bar-closed-tabs)))
 
 ;;;###autoload
+(defun +workspaces-save-tab-bar-data-to-file-h (&rest _)
+  "Save the current workspace's tab bar data to file."
+  (when (get-current-persp)
+    ;; HACK: Remove fields (for window-configuration) that cannot be serialized.
+    (set-persp-parameter 'tab-bar-tabs
+                         (frameset-filter-tabs (tab-bar-tabs) nil nil t))))
+
+;;;###autoload
 (defun +workspaces-load-tab-bar-data-h (_)
   "Restores the tab bar data of the workspace we have just switched to."
   (tab-bar-tabs-set (persp-parameter 'tab-bar-tabs))
   (setq tab-bar-closed-tabs (persp-parameter 'tab-bar-closed-tabs))
+  (tab-bar--update-tab-bar-lines t))
+
+;;;###autoload
+(defun +workspaces-load-tab-bar-data-from-file-h (&rest _)
+  "Restores the tab bar data from file."
+  (tab-bar-tabs-set (persp-parameter 'tab-bar-tabs))
   (tab-bar--update-tab-bar-lines t))
 
 ;;

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -282,4 +282,7 @@ stored in `persp-save-dir'.")
   (add-hook! 'tab-bar-mode-hook
     (defun +workspaces-set-up-tab-bar-integration-h ()
       (add-hook 'persp-before-deactivate-functions #'+workspaces-save-tab-bar-data-h)
-      (add-hook 'persp-activated-functions #'+workspaces-load-tab-bar-data-h))))
+      (add-hook 'persp-activated-functions #'+workspaces-load-tab-bar-data-h)
+      ;; Load and save configurations for tab-bar.
+      (add-hook 'persp-before-save-state-to-file-functions #'+workspaces-save-tab-bar-data-to-file-h)
+      (+workspaces-load-tab-bar-data-from-file-h))))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This PR introduces functions for persisting the `tab-bar` data for the `workspace` module.

The `workspace` module has supported integration with `tab-bar` currently, but the `tab-bar` data cannot persist after reopening the workspace. This PR adds functions for saving and loading the `tab-bar` data from the file.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
