### PR TITLE
mu4e: Use mu4e-highlight-face for main view actions

### DIFF
--- a/modules/email/mu4e/autoload/advice.el
+++ b/modules/email/mu4e/autoload/advice.el
@@ -12,7 +12,7 @@ clicked."
           "\\[\\(..?\\)\\]"
           (lambda(m)
             (format "%s"
-                    (propertize (match-string 1 m) 'face '(mode-line-emphasis bold))))
+                    (propertize (match-string 1 m) 'face 'mu4e-highlight-face)))
           (replace-regexp-in-string "\t\\*" (format "\t%s" +mu4e-main-bullet) str)))
         (map (make-sparse-keymap))
         (func (if (functionp func-or-shortcut)


### PR DESCRIPTION
Note: I see that PRs for modules are not being accepted at the moment – is it ok if I leave the PR open (possibly as a draft)? Since it’s a minor change to a module, I think it should be straightforward to adapt after the changes to the modules. Happy to close and reopen later if you’d prefer!

In the leuven theme (and possibly others), the use of `(mode-line-emphasis bold)` results in white text on a white background, making the shortcut keys invisible.

The original function mu4e--main-action-string uses mu4e-highlight-face, and changing back to this fixes the problem.

I can’t tell from the git history what the reasoning for the face change specifically was: the new function seems to have been made mainly for changing the bullets to unicode versions.

Fixes #7010

Before screenshot:

<img width="979" alt="mu4e-before" src="https://user-images.githubusercontent.com/23191049/209441690-79e5ca35-7a27-4311-a3a1-15b26a32f40c.png">

After screenshot:

<img width="1015" alt="mu4e-after" src="https://user-images.githubusercontent.com/23191049/209441688-9fa67b07-d9af-42bd-95f1-3850a072e834.png">


-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.