### PR TITLE
bump: :editor dirvish

### DIFF
--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -7,7 +7,7 @@
 (when (modulep! +ranger)
   (package! ranger :pin "2498519cb21dcd5791d240607a72a204d1761668"))
 (when (modulep! +dirvish)
-  (package! dirvish :pin "73dcaa404da9ab84d25f2919e6e3af4b1f8e7f37"))
+  (package! dirvish :pin "4fe9c00894304e99aca22ae4b6b656fe94b8f927"))
 (when (and (modulep! +icons)
            (not (modulep! +dirvish)))
   (package! all-the-icons-dired :pin "5e9b097f9950cc9f86de922b07903a4e5fefc733"))


### PR DESCRIPTION
alexluigit/dirvish@73dcaa404da9 -> alexluigit/dirvish@4fe9c0089430

This "lateral" bump buys us more time until doomemacs/doomemacs#6760 lands.

`dirvish`'s repository apparently rebased the commit we have pinned.
Visiting it gives us:
```
This commit does not belong to any branch on this repository, and may
belong to a fork outside of the repository.
```

Te new pinned version references the same commit contents, but on a new
position. They're correctly identified as identical by git. The new
commit also contains an explicitly reference to the old one:

```
Former-commit-id: 73dcaa4
```

Ref: https://github.com/alexluigit/dirvish/compare/73dcaa404da9..4fe9c0089430