### PR TITLE
bump: :completion vertico

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -54,7 +54,7 @@
                                    "%")
                      :type perl)
                    consult-async-split-style 'perlalt))))))
-    (consult--grep prompt #'consult--ripgrep-builder directory query)))
+    (consult--grep prompt (consult--ripgrep-make-builder) directory query)))
 
 ;;;###autoload
 (defun +vertico/project-search (&optional arg initial-query directory)

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -117,7 +117,6 @@ orderless."
     [remap switch-to-buffer-other-frame]  #'consult-buffer-other-frame
     [remap yank-pop]                      #'consult-yank-pop
     [remap persp-switch-to-buffer]        #'+vertico/switch-workspace-buffer)
-  (advice-add #'multi-occur :override #'consult-multi-occur)
   :config
   (defadvice! +vertico--consult-recent-file-a (&rest _args)
     "`consult-recent-file' needs to have `recentf-mode' on to work correctly"

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,20 +4,20 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "801ad3143d26653384f4c25bad44f7c098dd704c")
+  :pin "bedd146c3ffc236d746d088a94c3858eca0618d9")
 
-(package! orderless :pin "004cee6b8e01f8eb0cb1c683d0a637b14890600f")
+(package! orderless :pin "847694e78c12d903d5e3f6cb365a5d3b984db537")
 
-(package! consult :pin "e4e2af1a2d06d40461d975b74ea3cc863cd18085")
-(package! compat :pin "056e3ccffc716990dcb7b33273453d5fce0402de")
+(package! consult :pin "16b2dc5e34c8a500adbee394b42c0e0d7fd24ad8")
+(package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6")
 (package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
   (package! consult-flycheck :pin "7a10be316d728d3384fa25574a30857c53fb3655"))
 
-(package! embark :pin "09da327d43793f0b30114ee80d82ef587124462a")
-(package! embark-consult :pin "09da327d43793f0b30114ee80d82ef587124462a")
+(package! embark :pin "629cce948c562361ddd6136d7cc49c5c981bb610")
+(package! embark-consult :pin "629cce948c562361ddd6136d7cc49c5c981bb610")
 
-(package! marginalia :pin "c68164c56485e1ef855c2d12e4393f5f55ca2b12")
+(package! marginalia :pin "c1365bf0c7b5d32e7531fa8f1a9a3b64a155cec0")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
@@ -27,4 +27,4 @@
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "61a88aec07669d0399bbc6699740975d0d5ff721"))
+    :pin "a3d0802d7b4a64be1c8c9344fe2de99f2c5ce7ff"))

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -2,7 +2,7 @@
 ;;; tools/magit/packages.el
 
 (when (package! magit :pin "0ef98ef51811807952a4c3c677cbf3dfb269de2e")
-  (package! compat :pin "cc1924fd8b3f9b75b26bf93f084ea938c06f9615")
+  (package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6")
   (when (modulep! +forge)
     (package! forge :pin "ce212f8f95838889c51d0327eb8c3979bec6665c")
     (package! code-review

--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -3,7 +3,7 @@
 
 (unless (modulep! +light)
   (package! doom-modeline :pin "b66d5e5006df4cedb1119da3d83fd6c08965b830")
-  (package! compat :pin "cc1924fd8b3f9b75b26bf93f084ea938c06f9615"))
+  (package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6"))
 (package! anzu :pin "5abb37455ea44fa401d5f4c1bdc58adb2448db67")
 (when (modulep! :editor evil)
   (package! evil-anzu :pin "d1e98ee6976437164627542909a25c6946497899"))


### PR DESCRIPTION
bump: :completion vertico compat

emacs-straight/compat@cc1924fd8b3f -> emacs-straight/compat@7ca7d300d1d2
minad/consult@e4e2af1a2d06 -> minad/consult@16b2dc5e34c8
minad/marginalia@c68164c56485 -> minad/marginalia@c1365bf0c7b5
minad/vertico@801ad3143d26 -> minad/vertico@bedd146c3ffc
oantolin/embark@09da327d4379 -> oantolin/embark@629cce948c56
oantolin/orderless@004cee6b8e01 -> oantolin/orderless@847694e78c12
tumashu/vertico-posframe@61a88aec0766 -> tumashu/vertico-posframe@a3d0802d7b4a

---

convert consult--ripgrep-builder instance to  consult--ripgrep-make-builder

refactor!(vertico): remove multi-occur override

BREAKING CHANGE: remove override of multi-occur with consult-multi-occur

`consult-mulit-occur` is deprecated, and although it does have the
replacement `consult-line-multi`, I don't think that this override makes
much sense, as doom doesn't really touch `multi-occur` anywhere and this
would mostly be suprising to users that do use it.