### PR TITLE
fix(emacs-lisp): docstring url format which error popup

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -413,7 +413,7 @@ Intended as :around advice for `elisp-demos--search'."
 
 Intended as :override advice for `calculate-lisp-indent'.
 
-Adapted from 'https://www.reddit.com/r/emacs/comments/d7x7x8/finally_fixing_indentation_of_quoted_lists/'."
+Adapted from URL `https://www.reddit.com/r/emacs/comments/d7x7x8/finally_fixing_indentation_of_quoted_lists/'."
   ;; This line because `calculate-lisp-indent-last-sexp` was defined with
   ;; `defvar` with it's value ommited, marking it special and only defining it
   ;; locally. So if you don't have this, you'll get a void variable error.


### PR DESCRIPTION
In emacs 29 wrong quotes in docstrings throw up compilation errors,
which pop up randomly with no real context when using doom. I have found
a reference to url's being single quoted in the emacs wiki\[0], but the
emacs manual shows the standard format[1], not sure if it changed or was
a mistake. Also it should have a URL prefix apparently.

\[0]: https://www.emacswiki.org/emacs/DocString
[1]: info elisp 'Documentation tips'