### PR TITLE
fix(vertico): things that slipped by the previous bump PR

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -101,7 +101,6 @@ orderless."
   :defer t
   :preface
   (define-key!
-    [remap apropos]                       #'consult-apropos
     [remap bookmark-jump]                 #'consult-bookmark
     [remap evil-show-marks]               #'consult-mark
     [remap evil-show-jumps]               #'+vertico/jump-list


### PR DESCRIPTION
refactor!(vertico): remove consult-apropos remap

BREAKING CHANGE: This command is obsolete since 0.20; consult-apropos
has been deprecated in favor of Embark actions: M-x describe-symbol
<regexp> M-x embark-export M-x describe-symbol <regexp> M-x embark-act a

---

fix: consult case of doom--help-search

advise consult--ripgrep-make-builder instead of reimplementing