### PR TITLE
tweak(default): Allow disabling OS-specific key bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -238,7 +238,7 @@
        :g "M-8"   #'+workspace/switch-to-7
        :g "M-9"   #'+workspace/switch-to-8
        :g "M-0"   #'+workspace/switch-to-final
-       (:when IS-MAC
+       (:when (and IS-MAC (not (modulep! +no-OS-specific-bindings)))
         :g "s-t"   #'+workspace/new
         :g "s-T"   #'+workspace/display
         :n "s-1"   #'+workspace/switch-to-0

--- a/modules/config/default/README.org
+++ b/modules/config/default/README.org
@@ -21,6 +21,7 @@ This module provides a set of reasonable defaults, including:
 ** Module flags
 - +bindings :: ...
 - +smartparens :: ...
+- +no-OS-specific-bindings :: Disable introduction of any OS-specific keybindings that this module would otherwise introduce.
 
 ** Packages
 - [[doom-package:avy]]

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -295,7 +295,7 @@ Continues comments if executed from a commented line. Consults
   (define-key tabulated-list-mode-map "q" #'quit-window))
 
 ;; OS specific fixes
-(when IS-MAC
+(when (and IS-MAC (not (modulep! +no-OS-specific-bindings)))
   ;; Fix MacOS shift+tab
   (define-key key-translation-map [S-iso-lefttab] [backtab])
   ;; Fix conventional OS keys in Emacs
@@ -482,7 +482,7 @@ Continues comments if executed from a commented line. Consults
         :gi "C-S-RET"       #'+default/newline-above
         :gn [C-S-return]    #'+default/newline-above
 
-        (:when IS-MAC
+        (:when (and IS-MAC (not (modulep! +no-OS-specific-bindings)))
          :gn "s-RET"        #'+default/newline-below
          :gn [s-return]     #'+default/newline-below
          :gn "S-s-RET"      #'+default/newline-above


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Adds a module flag `+no-OS-specific-bindings` to `default` that allows disabling the automatically assigned keybindings on MacOS. I did not notice any Windows-specific keybindings, so this currently only disables the MacOS specific bindings, but I have named the flag to try to maintain forward compatibility _if_ Windows stuff is needed too.

The intention with having it be a _negative_ flag (i.e., `+no-....`) is so that it stays backwards compatible with people's setups, and folks should remain unimpacted by this change, _unless_ they explicitly want to disable the automatically assigned OS-specific keybindings.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
