### PR TITLE
fix(lib): don't overwrite kill-ring on doom/backward-kill-word

### DIFF
--- a/lisp/lib/text.el
+++ b/lisp/lib/text.el
@@ -221,7 +221,7 @@ line to beginning of line. Same as `evil-delete-back-to-indentation'."
 (defun doom/delete-backward-word (arg)
   "Like `backward-kill-word', but doesn't affect the kill-ring."
   (interactive "p")
-  (let (kill-ring)
+  (let ((kill-ring nil) (kill-ring-yank-pointer nil))
     (ignore-errors (backward-kill-word arg))))
 
 ;;;###autoload


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

That's a bit tricky to explain, but here it is. I'm on macOs Ventura 13.1 (not that it matters), Emacs is
```
GNU Emacs     v27.2            nil
Doom core     v3.0.0-pre       HEAD -> master e96624926 2023-01-01 21:55:13 -0500
Doom modules  v22.10.0-pre     HEAD -> master e96624926 2023-01-01 21:55:13 -0500
```

When I copy something outside of Emacs (terminal / Safari / whatever) and then then call `doom/backward-delete-word` (usually via `c-w` hotkey or `m-backspace` in my case) before I paste (yank) right afterwards, instead of what I copied before I get some rubbish from the end of the current `kill-ring`. Not an expert in Emacs, but it does look to me that even though `kill-ring` is overridden in `let` block and not actually modified, the pointer is still modified which is causing this weirdness.

So my attempt to fix this is to not only override `kill-ring` variable, but also `kill-ring-yank-pointer`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
