### PR TITLE
fix: correct name of doom-after-modules-init-hook

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -121,7 +121,7 @@ all hooks after it are ignored.")
 (defalias 'define-key! #'general-def)
 (defalias 'undefine-key! #'general-unbind)
 ;; Prevent "X starts with non-prefix key Y" errors except at startup.
-(add-hook 'doom-after-init-modules-hook #'general-auto-unbind-keys)
+(add-hook 'doom-after-modules-init-hook #'general-auto-unbind-keys)
 
 ;; HACK: `map!' uses this instead of `define-leader-key!' because it consumes
 ;;   20-30% more startup time, so we reimplement it ourselves.


### PR DESCRIPTION
The old name is doom-after-init-modules-hook, should be changed to `doom-after-modules-init-hook`.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
