### PR TITLE
fix(god): remove hard coding of cursor color

### DIFF
--- a/modules/editor/god/autoload.el
+++ b/modules/editor/god/autoload.el
@@ -1,8 +1,5 @@
 ;;; editor/god/autoload.el -*- lexical-binding: t; -*-
 
-(defvar +god-default-color (face-background 'cursor)
-  "Default cursor and bar color.")
-
 (defvar +god-read-only-mode-color "Gray"
   "Cursor and bar color when `read-only-mode' is enabled.")
 
@@ -29,7 +26,7 @@
           (cond (buffer-read-only +god-read-only-mode-color)
                 (is-fill-overflow +god-fill-overflow-color)
                 (overwrite-mode +god-overwrite-mode-color)
-                (t +god-default-color))))
+                (t previous-cursor-color))))
     (setq cursor-type next-cursor-type)
     (unless (eq previous-cursor-color next-cursor-and-modeline-color)
       (set-cursor-color next-cursor-and-modeline-color))


### PR DESCRIPTION
When switching themes (light to dark or vice versa) with god-mode enabled sometimes the cursor becomes invisible.
This change removes the hard coded value and keeps the cursor color in sync with the current theme.
