### PR TITLE
bump: :lang nix

### DIFF
--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/nix/packages.el
 
 (package! nix-mode :pin "20ee8d88900b169831d6b0783bd82d2625e940c7")
-(package! nix-update :pin "fc6c39c2da3fcfa62f4796816c084a6389c8b6e7")
+(package! nix-update :pin "aab70a38165575a9cb41726f1cc67df60fbf2832")
 
 (when (modulep! :completion company)
   (package! company-nixos-options :pin "053a2d5110ce05b7f99bcc2ac4804b70cbe87916"))


### PR DESCRIPTION
The current version of `nix-update` in the `nix` module is old (fc6c39c2da3fcfa62f4796816c084a6389c8b6e7). This PR bumps it to the latest (aab70a38165575a9cb41726f1cc67df60fbf2832) which has improvements and fixes.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
  - There's an item from October 2022 that matches this, but the note said that would happen within 2-3 weeks?
- [X ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
