### PR TITLE
bump: :tools magit

### DIFF
--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -6,7 +6,7 @@
 (package! smerge-mode :built-in t)
 
 (package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
-(package! git-commit :pin "8a0cc83eff98489d3685b8585afdcebbb47c1393")
+(package! git-commit :pin "678a41eb8b162d6f86d8dc6773d4ac271a1afbfc")
 (package! git-timemachine
   ;; The original lives on codeberg.org; which has uptime issues.
   :recipe (:host github :repo "emacsmirror/git-timemachine")

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,8 +1,8 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "0ef98ef51811807952a4c3c677cbf3dfb269de2e")
-  (package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6")
+(when (package! magit :pin "678a41eb8b162d6f86d8dc6773d4ac271a1afbfc")
+  (package! compat :pin "62da199f0a9c2f8917bfe74b3ec1882f9d6a9d02")
   (when (modulep! +forge)
     (package! forge :pin "ce212f8f95838889c51d0327eb8c3979bec6665c")
     (package! code-review


### PR DESCRIPTION
https://github.com/magit/magit/commit/0ef98ef51811 -> https://github.com/magit/magit/commit/678a41eb8b16
magit/git-commit@8a0cc83eff98 -> magit/git-commit@678a41eb8b16
https://github.com/emacs-compat/compat/commit/7ca7d300d1d2 https://github.com/emacs-compat/compat/commit/62da199f0a9c

Update magit to the nevest version.

I want to pick up
https://github.com/magit/magit/commit/2653432bb513 for the --update-refs support, but since I'm
already bumping, let's go to the newest one. Also, updating compat to
the version in magit's default.mk.

FYI, magit seems to rename master branch to main, which impacts the
`doom sync -u`:

```
        [...]
    > In repository "magit", HEAD on "master" is behind default branch "main"

         1) Abort
         2) Checkout "main"
         3) Magit log "master..main" and open recursive edit

      How to proceed? (1, 2, 3) 2
```