### PR TITLE
bump: :completion vertico (and some requirements)

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -108,6 +108,7 @@ orderless."
     [remap evil-show-registers]           #'consult-register
     [remap goto-line]                     #'consult-goto-line
     [remap imenu]                         #'consult-imenu
+    [remap Info-search]                   #'consult-info
     [remap locate]                        #'consult-locate
     [remap load-theme]                    #'consult-theme
     [remap man]                           #'consult-man

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -147,7 +147,7 @@ orderless."
    +default/search-notes-for-symbol-at-point
    +default/search-emacsd
    consult--source-recent-file consult--source-project-recent-file consult--source-bookmark
-   :preview-key (kbd "C-SPC"))
+   :preview-key "C-SPC")
   (consult-customize
    consult-theme
    :preview-key (list (kbd "C-SPC") :debounce 0.5 'any))
@@ -253,12 +253,13 @@ orderless."
         cons
         '+vertico-embark-target-package-fn
         (nthcdr pos embark-target-finders)))
-  (embark-define-keymap +vertico/embark-doom-package-map
-    "Keymap for Embark package actions for packages installed by Doom."
-    ("h" doom/help-packages)
-    ("b" doom/bump-package)
-    ("c" doom/help-package-config)
-    ("u" doom/help-package-homepage))
+  (defvar-keymap +vertico/embark-doom-package-map
+    :doc "Keymap for Embark package actions for packages installed by Doom."
+    :parent embark-general-map
+    "h" #'doom/help-packages
+    "b" #'doom/bump-package
+    "c" #'doom/help-package-config
+    "u" #'doom/help-package-homepage)
   (setf (alist-get 'package embark-keymap-alist) #'+vertico/embark-doom-package-map)
   (map! (:map embark-file-map
          :desc "Open target with sudo"        "s"   #'doom/sudo-find-file

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,22 +4,21 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "bedd146c3ffc236d746d088a94c3858eca0618d9")
+  :pin "f303790546edecc67aa3bd5e23c68f982f1345dd")
 
-(package! orderless :pin "847694e78c12d903d5e3f6cb365a5d3b984db537")
+(package! orderless :pin "ae849b3d9f8c8a777e05816321ed2b00e8304447")
 
-(package! consult :pin "16b2dc5e34c8a500adbee394b42c0e0d7fd24ad8")
-(package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6")
+(package! consult :pin "b22a7de62ee4adf766be2f867dee8b6980902bba")
+(package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9")
 (package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
-  (package! consult-flycheck :pin "7a10be316d728d3384fa25574a30857c53fb3655"))
+  (package! consult-flycheck :pin "51b1b48e8dad314f9c9d963376f2ea8de94b97f2"))
+(package! embark :pin "4882b395cef98a517d530ffe483aa0dc7201158c")
+(package! embark-consult :pin "4882b395cef98a517d530ffe483aa0dc7201158c")
 
-(package! embark :pin "629cce948c562361ddd6136d7cc49c5c981bb610")
-(package! embark-consult :pin "629cce948c562361ddd6136d7cc49c5c981bb610")
+(package! marginalia :pin "6d48ed54be87969e3ce53a24dbc63ec72ec6a91a")
 
-(package! marginalia :pin "c1365bf0c7b5d32e7531fa8f1a9a3b64a155cec0")
-
-(package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
+(package! wgrep :pin "edf768732a56840db6879706b64c5773c316d619")
 
 (when (modulep! +icons)
   (package! all-the-icons-completion :pin "4da28584a1b36b222e0e78d46fd8d46bbd9116c7"))
@@ -27,4 +26,4 @@
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "a3d0802d7b4a64be1c8c9344fe2de99f2c5ce7ff"))
+    :pin "790f74b49d5309dc2f0e6a438e2e89007d591d07"))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -9,7 +9,7 @@
 (package! orderless :pin "ae849b3d9f8c8a777e05816321ed2b00e8304447")
 
 (package! consult :pin "b22a7de62ee4adf766be2f867dee8b6980902bba")
-(package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9")
+(package! compat :pin "01fdf316a44eac9a7f6ab7e0983427a702ffd04d")
 (package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
   (package! consult-flycheck :pin "51b1b48e8dad314f9c9d963376f2ea8de94b97f2"))

--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -6,7 +6,7 @@
 (package! smerge-mode :built-in t)
 
 (package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
-(package! git-commit :pin "6d325d90ba1374d48c4c7088f96864b678155f48")
+(package! git-commit :pin "30b0debaaadadec6103a8d7eab92322fd9d30a15")
 (package! git-timemachine
   ;; The original lives on codeberg.org; which has uptime issues.
   :recipe (:host github :repo "emacsmirror/git-timemachine")

--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -6,7 +6,7 @@
 (package! smerge-mode :built-in t)
 
 (package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
-(package! git-commit :pin "8a0cc83eff98489d3685b8585afdcebbb47c1393")
+(package! git-commit :pin "6d325d90ba1374d48c4c7088f96864b678155f48")
 (package! git-timemachine
   ;; The original lives on codeberg.org; which has uptime issues.
   :recipe (:host github :repo "emacsmirror/git-timemachine")

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -13,4 +13,4 @@
   (when (modulep! :completion helm)
     (package! helm-lsp :pin "c2c6974dadfac459b1a69a1217441283874cea92"))
   (when (modulep! :completion vertico)
-    (package! consult-lsp :pin "58b541476203fa68e9e7682531f2a10e11780857")))
+    (package! consult-lsp :pin "f8db3252c0daa41225ba4ed1c0d178b281cd3e90")))

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,8 +1,8 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "6d325d90ba1374d48c4c7088f96864b678155f48")
-  (package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9")
+(when (package! magit :pin "30b0debaaadadec6103a8d7eab92322fd9d30a15")
+  (package! compat :pin "01fdf316a44eac9a7f6ab7e0983427a702ffd04d")
   (when (modulep! +forge)
     (package! forge :pin "ce212f8f95838889c51d0327eb8c3979bec6665c")
     (package! code-review

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,8 +1,8 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "0ef98ef51811807952a4c3c677cbf3dfb269de2e")
-  (package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6")
+(when (package! magit :pin "6d325d90ba1374d48c4c7088f96864b678155f48")
+  (package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9")
   (when (modulep! +forge)
     (package! forge :pin "ce212f8f95838889c51d0327eb8c3979bec6665c")
     (package! code-review

--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -3,7 +3,7 @@
 
 (unless (modulep! +light)
   (package! doom-modeline :pin "b66d5e5006df4cedb1119da3d83fd6c08965b830")
-  (package! compat :pin "7ca7d300d1d256f674f83932d2918d8e70cd28f6"))
+  (package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9"))
 (package! anzu :pin "5abb37455ea44fa401d5f4c1bdc58adb2448db67")
 (when (modulep! :editor evil)
   (package! evil-anzu :pin "d1e98ee6976437164627542909a25c6946497899"))

--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -3,7 +3,7 @@
 
 (unless (modulep! +light)
   (package! doom-modeline :pin "b66d5e5006df4cedb1119da3d83fd6c08965b830")
-  (package! compat :pin "2bedcb5ea91914e75d4905bc53e537b33f8f51e9"))
+  (package! compat :pin "01fdf316a44eac9a7f6ab7e0983427a702ffd04d"))
 (package! anzu :pin "5abb37455ea44fa401d5f4c1bdc58adb2448db67")
 (when (modulep! :editor evil)
   (package! evil-anzu :pin "d1e98ee6976437164627542909a25c6946497899"))


### PR DESCRIPTION
---
bump: :completion vertico compat consult-lsp magit git-commit

emacs-straight/compat@7ca7d300d1d2 -> emacs-straight/compat@2bedcb5ea919
mhayashi1120/Emacs-wgrep@f9687c28bbc2 -> mhayashi1120/Emacs-wgrep@edf768732a56
minad/consult-flycheck@7a10be316d72 -> minad/consult-flycheck@51b1b48e8dad
minad/consult@16b2dc5e34c8 -> oantolin/orderless@ae849b3d9f8c
minad/marginalia@c1365bf0c7b5 -> minad/marginalia@6d48ed54be87
minad/vertico@bedd146c3ffc -> minad/vertico@f303790546ed
oantolin/embark@629cce948c56 -> oantolin/embark@4882b395cef9
oantolin/orderless@847694e78c12 -> minad/vertico@f303790546ed
tumashu/vertico-posframe@a3d0802d7b4a -> tumashu/vertico-posframe@790f74b49d53
gagbo/consult-lsp@58b541476203 -> gagbo/consult-lsp@f8db3252c0da
magit/magit@0ef98ef51811 -> magit/magit@6d325d90ba13

consult-lsp needed to be bumped to work with some changed consult
internals, and due to compat shenanigans we have to bump magit to latest
as well.

Includes fixes to stay up to date with upstream api changes to.
consult-customize and the deprecation of embark-define-keymap

---

feat(vertico): remap Info-search to consult-info

---