### PR TITLE
fix(fold): set ts-fold-replacement-face fg to unspecified

### DIFF
--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -92,7 +92,7 @@
   :config
   ;; we want to use our own face so we nullify this one to have no effect and
   ;; make it more similar to hideshows
-  (custom-set-faces! '(ts-fold-replacement-face :foreground nil
+  (custom-set-faces! '(ts-fold-replacement-face :foreground unspecified
                                                 :box nil
                                                 :inherit font-lock-comment-face
                                                 :weight light))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Hi,

Currently, when I enable the `tree-sitter-hl-mode`, Doom Emacs will throw a lot of the warning `Warning: setting attribute ‘:foreground’ of face ‘ts-fold-replacement-face’: nil value is invalid, use ‘unspecified’ instead.`

Here is a screenshot of the `*Message*` buffer:

<img width="848" alt="Screenshot 2023-02-12 at 5 14 20 PM" src="https://user-images.githubusercontent.com/193967/218302657-f23e9d86-a358-4066-91f6-ccbe3e49f816.png">

This PR will fix the issue by configure `foreground` of `ts-fold-replacement-face` to `unspecified` instead.

-----
- [v] I searched the issue tracker and this hasn't been PRed before.
- [v] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [v] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [v] My changes are visual; I've included before and after screenshots.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
