### PR TITLE
tweak(everywhere): add icon to right of modeline

### DIFF
--- a/modules/app/everywhere/config.el
+++ b/modules/app/everywhere/config.el
@@ -30,8 +30,14 @@
                     45 nil nil "…")
                    'face 'doom-modeline-buffer-minor-mode)))
     (doom-modeline-def-modeline 'emacs-everywhere
-      '(bar modals emacs-everywhere buffer-position word-count parrot selection-info)
-      '(input-method major-mode checker))
+      '(bar modals emacs-everywhere buffer-position
+        word-count parrot selection-info)
+      '(input-method major-mode checker
+        #("  " 0 1 ; "Exit to app" icon + a little padding
+          (rear-nonsticky t
+           display (raise -0.25)
+           face (:inherit doom-modeline-emphasis :family "Material Icons" :height 1.1)
+           help-echo "This is an Emacs Everywhere window"))))
     (add-hook! 'emacs-everywhere-mode-hook
       (defun +everywhere-set-modeline ()
         (doom-modeline-set-modeline 'emacs-everywhere))))


### PR DESCRIPTION
This adds an icon to indicate that Emacs Everywhere is being used, to ease at-a-glance identification. The "exit_to_app" material icon was chosen as it seems like a good fit for a window that will return you to the application it was invoked from. The padding on the right stops the icon from being right up against the very edge of the window.

It's a minor thing, but I think it's visually nice.

#### Sample image

![image](https://user-images.githubusercontent.com/20903656/219620372-04944a28-816a-4af8-8920-06ccba0dec9e.png)
