### PR TITLE
fix(popup): get all popup windows in all frames

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -224,8 +224,12 @@ with ARGS to get its return value."
 
 ;;;###autoload
 (defun +popup-windows ()
-  "Returns a list of all popup windows."
-  (cl-remove-if-not #'+popup-window-p (window-list)))
+  "Returns a list of all popup windows in all frames."
+  (apply #'append (mapcar
+                   (lambda (frame)
+                     (when frame
+                       (cl-remove-if-not #'+popup-window-p (window-list frame))))
+                   (frame-list))))
 
 ;;;###autoload
 (defun +popup-shrink-to-fit (&optional window)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Hi,

I'm running Doom Emacs in daemon mode with multiple frames opened.
If a popup window is opened in one frame, pressing `C-g` in another frame will not close that popup window.

I fixed this issue by enabling the function `+popup-windows` to get all popup windows in all frames.

Can you review and merge this PR if it is useful?

Thanks!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
