### PR TITLE
fix(cli) deprecated use of native-comp-deferred-compilation-deny-list [EMACS-29]

### DIFF
--- a/lisp/cli/packages.el
+++ b/lisp/cli/packages.el
@@ -266,7 +266,10 @@ list remains lean."
              if (and (file-exists-p (byte-compile-dest-file file))
                      (not (doom-packages--find-eln-file (doom-packages--eln-file-name file)))
                      (not (cl-some (fn! (string-match-p % file))
-                                   native-comp-deferred-compilation-deny-list))) do
+                                  (if (> emacs-major-version 28)
+                                    native-comp-jit-compilation-deny-list
+                                    native-comp-deferred-compilation-deny-list
+                                  )))) do
              (doom-log "Compiling %s" file)
              (native-compile-async file))))
 

--- a/lisp/doom-packages.el
+++ b/lisp/doom-packages.el
@@ -139,7 +139,11 @@ uses a straight or package.el command directly).")
 (when (featurep 'native-compile)
   (after! comp
     ;; HACK Disable native-compilation for some troublesome packages
-    (mapc (doom-partial #'add-to-list 'native-comp-deferred-compilation-deny-list)
+    (mapc (doom-partial #'add-to-list 
+                        (if (> emacs-major-version 28)
+                          'native-comp-jit-compilation-deny-list
+                          'native-comp-deferred-compilation-deny-list
+                        ))
           (list "/emacs-jupyter.*\\.el\\'"
                 "/evil-collection-vterm\\.el\\'"
                 "/vterm\\.el\\'"


### PR DESCRIPTION
Hello, I've encountered an issue with doom cli on the latest emacs 29 commits due to a deprecated use of one function.
I've fixed it and wanted to contribute to Doom :D 

I'm absolutely not an expert of Elisp so I hope to get some feedback ( if necessary ) to improve this little contribution.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

