### PR TITLE
fix(vc): string type error caused by codeberg support

### DIFF
--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -135,7 +135,7 @@ otherwise in default state."
 
   ;; Add codeberg.org support
   ;; TODO: PR this upstream?
-  (add-to-list 'browse-at-remote-remote-type-regexps '("^codeberg\\.org$" . "codeberg"))
+  (add-to-list 'browse-at-remote-remote-type-regexps '(:host "^codeberg\\.org$" :type "github"))
 
   ;; HACK `browse-at-remote' produces urls with `nil' in them, when the repo is
   ;;      detached. This creates broken links. I think it is more sensible to


### PR DESCRIPTION
As reported on the Discord earlier today.

`browse-at-remote--get-remote-type` uses this list to match hostnames to remote types, and it assumes the entries are plists. The codeberg cons cell broke `+vc/browse-at-remote{,-kill}` because of this due to a `(wrong-type-argument stringp nil)` error.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
