### PR TITLE
:tools rework REPL selection UI

### DIFF
--- a/modules/lang/common-lisp/autoload/common-lisp.el
+++ b/modules/lang/common-lisp/autoload/common-lisp.el
@@ -3,3 +3,17 @@
 ;; HACK Fix #1772: void-variable sly-contribs errors due to sly packages (like
 ;; `sly-macrostep') trying to add to `sly-contribs' before it is defined.
 ;;;###autoload (defvar sly-contribs '(sly-fancy))
+
+;;;###autoload
+(defun +lisp/open-repl ()
+  "Open the Sly REPL."
+  (interactive)
+  (require 'sly)
+  (if (sly-connected-p) (sly-mrepl)
+    (sly nil nil t)
+    (cl-labels ((recurse (attempt)
+                  (sleep-for 1)
+                  (cond ((sly-connected-p) (sly-mrepl))
+                        ((> attempt 5) (error "Failed to start Slynk process."))
+                        (t (recurse (1+ attempt))))))
+      (recurse 1))))

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -24,7 +24,7 @@
     (remove-hook 'lisp-mode-hook #'sly-editing-mode))
 
   (after! lisp-mode
-    (set-repl-handler! 'lisp-mode #'sly-mrepl)
+    (set-repl-handler! 'lisp-mode #'+lisp/open-repl)
     (set-eval-handler! 'lisp-mode #'sly-eval-region)
     (set-lookup-handlers! 'lisp-mode
       :definition #'sly-edit-definition

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/common-lisp/packages.el
 
-(when (package! sly :pin "fa70fc8ab1bc1f1c21661d672834e41b1d0abd39")
+(when (package! sly :pin "f34c22289a2b3ab10e607f9f8822d62bb5c98cf5")
   (package! sly-macrostep :pin "5113e4e926cd752b1d0bcc1508b3ebad5def5fad")
   (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048"))

--- a/modules/lang/haskell/autoload.el
+++ b/modules/lang/haskell/autoload.el
@@ -4,6 +4,7 @@
 (defun +haskell/open-repl (&optional arg)
   "Opens a Haskell REPL."
   (interactive "P")
+  (require 'haskell-interactive-mode)
   (if-let (window
            (display-buffer
             (haskell-session-interactive-buffer (haskell-session))))

--- a/modules/lang/sh/autoload.el
+++ b/modules/lang/sh/autoload.el
@@ -30,6 +30,7 @@
 (defun +sh/open-repl ()
   "Open a shell REPL."
   (interactive)
+  (require 'sh-script)
   (let* ((dest-sh (symbol-name sh-shell))
          (sh-shell-file dest-sh))
     (sh-shell-process t)


### PR DESCRIPTION
This PR fixes a previously unreported bug, where not all available REPL-opening functions would be displayed via `SPC o r` in major modes that don't have an associated REPL (like the `*doom*` buffer). Further, this PR improves the UI a bit, displaying more human-readable names for the available modes.

Before:

![repl-modes-before](https://user-images.githubusercontent.com/229679/221062317-50e1bbc7-6076-458c-939f-081132e2a950.png)

After:

![repl-modes](https://user-images.githubusercontent.com/229679/221060683-15bcbb51-c607-44a3-b53c-09dcb7093dc7.png)

**NOTE:** There is still a strange bug here involving loading. In particular, from a __fresh__ restart of Doom, I'm able to open a Lua, Elisp, and Scheme repls, but not:

- Sh: `Symbol's value as variable is void: sh-shell`
- Lisp (`sly-mrepl`): `Couldn't find a valid REPL for +doom-dashboard-mode`
  - Indeed `sly-mrepl` (the symbol found in `+eval-repls`) is not a `commandp`, while `sly` is! __Is the `commandp` requirement too strict?__
- Haskell: `Symbol’s function definition is void: haskell-session-interactive-buffer`

The Lisp failure might be trivially fixable by a tweak to the `common-lisp` module, but I'm not sure about the other two. Thoughts?

Unrelated: Should we also attempt to put major mode icons next to the `completing-read` selections?

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.