### PR TITLE
fix(chinese): update pyim-cregexp-build func

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -22,7 +22,7 @@
                      :filter-return
                      (if (modulep! :editor evil +everywhere)
                          #'evil-pinyin--build-regexp-string
-                       #'pyim-cregexp-build-regexp-string)))
+                       #'pyim-cregexp-build)))
         ((modulep! :completion ivy)
          (setq ivy-re-builders-alist '((t . pyim-cregexp-ivy))))))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Pyim has replaced the `pyim-cregexp-build-regexp-string` with `pyim-cregexp-build`.

Fixes: `Error in pre-command-hook (vertico--prepare): (void-function pyim-cregexp-build-regexp-string)`
References https://github.com/tumashu/pyim/issues/468

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
