### PR TITLE
fix(fortran): account for the `.F90` extension

### DIFF
--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -5,6 +5,7 @@
 
 (use-package! f90
   :defer t
+  :mode ("\\.F90" . f90-mode)
   :config
   ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)


### PR DESCRIPTION
In the Elder Days, it was common to give Fortran files the extensions of `.FOR` or later `.F90`. The major modes for Fortran don't automatically detect this conversion. The former was already accounted for in Doom's module, but not the latter. This commit rectifies this.

See also: https://fortran-lang.discourse.group/t/fully-featured-fortran-setup-for-linux-mac-in-emacs-intel-fortran-support-included/3532/14

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.

