### PR TITLE
fix(csharp): csharp-tree-sitter-mode: void-function error in Emacs 29+

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -49,7 +49,7 @@ or terminating simple string."
   :defer t
   :init
   (add-hook 'csharp-mode-local-vars-hook #'tree-sitter! 'append)
-  (if (version<= emacs-version "28")
+  (if (fboundp #'csharp-tree-sitter-mode)
       (add-to-list 'auto-mode-alist '("\\.cs\\'" . csharp-tree-sitter-mode))))
 
 

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -48,8 +48,7 @@ or terminating simple string."
   :when (modulep! +tree-sitter)
   :defer t
   :init
-  (add-hook 'csharp-mode-local-vars-hook #'tree-sitter! 'append)
-  (add-to-list 'auto-mode-alist '("\\.cs\\'" . csharp-tree-sitter-mode)))
+  (add-hook 'csharp-mode-local-vars-hook #'tree-sitter! 'append))
 
 
 ;; Unity shaders

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -48,7 +48,9 @@ or terminating simple string."
   :when (modulep! +tree-sitter)
   :defer t
   :init
-  (add-hook 'csharp-mode-local-vars-hook #'tree-sitter! 'append))
+  (add-hook 'csharp-mode-local-vars-hook #'tree-sitter! 'append)
+  (if (version<= emacs-version "28")
+      (add-to-list 'auto-mode-alist '("\\.cs\\'" . csharp-tree-sitter-mode))))
 
 
 ;; Unity shaders


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

in Emacs 29.0.60 the function (csharp-tree-sitter-mode) is void and deprecated, and seems that tree-sitter works just fine without it. So i have Removed it

Fixes #0000
References #0000
Replaces #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
