### PR TITLE
fix(lib): letf! in doom--help-search

### DIFF
--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -700,7 +700,7 @@ config blocks in your private config."
           prompt
           (lambda (input)
             ;; PERF: avoid converting dirs to string and back when adding them to ripgrep args.
-            (letf! (defun consult--command-split (fn &rest args)
+            (letf! (defun consult--command-split (&rest args)
                      (append (apply consult--command-split args) dirs))
               (funcall (consult--ripgrep-make-builder) input)))
           data-directory query))


### PR DESCRIPTION
Slipped by manual testing due to consult not being loaded at the time
and doom--help-search going to default grep-find usage instead of
hitting the failiure.

Amend: 54c4340740ec