### PR TITLE
Update spell-fu to version 0.4

### DIFF
--- a/modules/checkers/spell/packages.el
+++ b/modules/checkers/spell/packages.el
@@ -2,7 +2,7 @@
 ;;; checkers/spell/packages.el
 
 (if (not (modulep! +flyspell))
-    (package! spell-fu :pin "8185467b24f05bceb428a0e9909651ec083cc54e")
+    (package! spell-fu :pin "3caf7047ea8373b5f26b99e8b73e5da55df46a70")
   (package! flyspell-correct :pin "e9fde6f93af991b0528d6ed47d44bed470dc70af")
   (cond ((modulep! :completion ivy)
          (package! flyspell-correct-ivy))


### PR DESCRIPTION
Update to new version of spell-fu (0.4, released on 01/07)

Amongst other changes, 0.4 fixes spell-fu on windows platforms (see issue linked below)

Full changelog is here: https://github.com/emacsmirror/spell-fu/blob/master/changelog.rst

<!-- ⚠️ Please do not ignore this template! -->

Fixes #4009
Replaces #4009

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
