### PR TITLE
fix(lua): remove trailing ! in modulep!

### DIFF
--- a/modules/lang/lua/config.el
+++ b/modules/lang/lua/config.el
@@ -43,7 +43,7 @@ lua-language-server.")
 
       (set-eglot-client! 'lua-mode (+lua-generate-lsp-server-command)))
 
-    (when (modulep! +tree-sitter!)
+    (when (modulep! +tree-sitter)
       (add-hook 'lua-mode-local-vars-hook #'tree-sitter! 'append))))
 
 


### PR DESCRIPTION
A small typo in the lua tree sitter implementation, This removed the trailing ! which got in. 

I have checked all the other languages and it seems lua is the only one. Sorry for that. 

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
