### PR TITLE
feat(rss): allow disable auto elfeed-db-compact

### DIFF
--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -86,9 +86,10 @@
   "Clean up after an elfeed session. Kills all elfeed and elfeed-org files."
   (interactive)
   ;; `delete-file-projectile-remove-from-cache' slows down `elfeed-db-compact'
-  ;; tremendously, so we disable the projectile cache:
-  (let (projectile-enable-caching)
-    (elfeed-db-compact))
+  (when +rss-auto-db-compact
+    ;; tremendously, so we disable the projectile cache:
+    (let (projectile-enable-caching)
+      (elfeed-db-compact)))
   (let ((buf (previous-buffer)))
     (when (or (null buf) (not (doom-real-buffer-p buf)))
       (switch-to-buffer (doom-fallback-buffer))))

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -14,6 +14,9 @@ easier to scroll through.")
 (defvar +rss-workspace-name "*rss*"
   "Name of the workspace that contains the elfeed buffer.")
 
+(defvar +rss-auto-db-compact t
+  "Automatically run `elfeed-db-compact' when killing the *elfeed-search* buffer.")
+
 ;;
 ;; Packages
 


### PR DESCRIPTION
running elfeed-db-compact automatically when killing the *elfeed-search* buffer is a convenient way to keep the elfeed db files clean, but it can also take a lot of time to do so, which blocks emacs from doing anything, adding a variable to disable it.

on my setup, it would take almost 10s to kill the buffer, which is annoying, the default value of `+rss-auto-db-compact` is true, so the default behavior is unchanged.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
