### PR TITLE
fix(company): hook company-abort when +childframe enabled

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -46,17 +46,14 @@
   :config
   (when (modulep! :editor evil)
     (add-hook 'company-mode-hook #'evil-normalize-keymaps)
-    (unless (modulep! +childframe)
-      ;; Don't persist company popups when switching back to normal mode.
-      ;; `company-box' aborts on mode switch so it doesn't need this.
-      (add-hook! 'evil-normal-state-entry-hook
-        (defun +company-abort-h ()
-          ;; HACK `company-abort' doesn't no-op if company isn't active; causing
-          ;;      unwanted side-effects, like the suppression of messages in the
-          ;;      echo-area.
-          ;; REVIEW Revisit this to refactor; shouldn't be necessary!
-          (when company-candidates
-            (company-abort)))))
+    (add-hook! 'evil-normal-state-entry-hook
+      (defun +company-abort-h ()
+        ;; HACK `company-abort' doesn't no-op if company isn't active; causing
+        ;;      unwanted side-effects, like the suppression of messages in the
+        ;;      echo-area.
+        ;; REVIEW Revisit this to refactor; shouldn't be necessary!
+        (when company-candidates
+          (company-abort))))
     ;; Allow users to switch between backends on the fly. E.g. C-x C-s followed
     ;; by C-x C-n, will switch from `company-yasnippet' to
     ;; `company-dabbrev-code'.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Add hook for `company-abort` when `+childframe` option is enabled.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
