### PR TITLE
fix(treemacs): ignore default popup rules

### DIFF
--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -29,6 +29,7 @@ This must be set before `treemacs' has loaded.")
   ;; Don't follow the cursor
   (treemacs-follow-mode -1)
 
+  (set-popup-rule! "^ ?\\*Treemacs" :ignore t)
   (when +treemacs-git-mode
     ;; If they aren't supported, fall back to simpler methods
     (when (and (memq +treemacs-git-mode '(deferred extended))


### PR DESCRIPTION
As of https://github.com/Alexander-Miller/treemacs/commit/79927691bb2aba5b50161deb30b1a892489f31fa Treemacs switched to using `display-buffer` as opposed to its own window management system. As such it is now subject to doom's popup system. This pr just makes treemacs exempt from them just like it is for neotree. 

Fixes #7216

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

