### PR TITLE
fix(org): org-flag -> org-fold, add spec argument

### DIFF
--- a/modules/lang/org/autoload/contrib-present.el
+++ b/modules/lang/org/autoload/contrib-present.el
@@ -22,10 +22,10 @@
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward "^[[:space:]]*\\(#\\+\\)\\(\\(?:BEGIN\\|END\\|ATTR\\)[^[:space:]]+\\).*" nil t)
-      (org-flag-region (match-beginning 1)
+      (org-fold-region (match-beginning 1)
                        (match-end 0)
                        org-tree-slide-mode
-                       t))))
+                       'block))))
 
 ;;;###autoload
 (defun +org-present-hide-leading-stars-h ()
@@ -33,10 +33,10 @@
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward "^\\(\\*+\\)" nil t)
-      (org-flag-region (match-beginning 1)
+      (org-fold-region (match-beginning 1)
                        (match-end 1)
                        org-tree-slide-mode
-                       t))))
+                       'headline))))
 
 ;;;###autoload
 (defun +org-present-detect-slide-h ()


### PR DESCRIPTION
This implements the fixes described on takaxp/org-tree-slide#54

`org-flag-region` was deprecated on org 9.6, superseded by `org-fold-region`, which takes different `spec` argument.

Fixes takaxp/org-tree-slide#54
Fixes doomemacs/doomemacs#7058
References https://github.com/emacs-straight/org-mode/blob/5f817f21fcbbe7c122fcbbc0fb5f43f26fef6259/lisp/org-compat.el#L463

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.