### PR TITLE
fix(doom-ui): set `split-width-threshold` to `nil` to favor vertical window splits

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -268,9 +268,7 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 
 ;; UX: Favor vertical splits over horizontal ones. Monitors are trending toward
 ;;   wide, rather than tall.
-(setq split-width-threshold 160
-      split-height-threshold nil)
-
+(setq split-width-threshold nil)
 
 ;;
 ;;; Minibuffer


### PR DESCRIPTION
Fixes #7153 


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
