### PR TITLE
fix(common-lisp): sly completion when there is no matching

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -40,9 +40,16 @@
         sly-kill-without-query-p t
         sly-net-coding-system 'utf-8-unix
         ;; Doom defaults to non-fuzzy search, because it is faster and more
-        ;; precise (but requires more keystrokes). Change this to
-        ;; `sly-flex-completions' for fuzzy completion
-        sly-complete-symbol-function 'sly-simple-completions)
+        ;; precise (but requires more keystrokes), since it causes showing all
+        ;; symbols in the cases of using vertico/helm (without +fuzzy) (see
+        ;; https://github.com/joaotavora/sly/issues/535) for :completion, it
+        ;; changes it to `sly-flex-completions', which is a fuzzy completion.
+        sly-complete-symbol-function (if (or (modulep! :completion vertico)
+                                             (and (modulep! :completion helm)
+                                                  (not (modulep! :completion helm +fuzzy))))
+                                         'sly-flex-completions
+                                       'sly-simple-completions))
+
 
   (set-popup-rules!
     '(("^\\*sly-mrepl"       :vslot 2 :size 0.3 :quit nil :ttl nil)


### PR DESCRIPTION
Using `sly-simple-completion` when using vertico or helm (without`+fuzzy`) causes sly to suggest all the system's symbols whenever there is no matches. See https://github.com/joaotavora/sly/issues/535. As also reported [here](https://www.reddit.com/r/DoomEmacs/comments/uox6b2/commonlisp_completion_not_machting_input/) and [here](https://www.reddit.com/r/emacs/comments/t8bguf/how_do_i_prevent_companymode_from_giving_a/) 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

