### PR TITLE
bump :lang org +org-noter

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -88,7 +88,7 @@
 (when (modulep! +journal)
   (package! org-journal :pin "2f220a06e3bf6bfa5cda00ebd44817a7b2fd7b76"))
 (when (modulep! +noter)
-  (package! org-noter :pin "9ead81d42dd4dd5074782d239b2efddf9b8b7b3d"))
+  (package! org-noter :pin "228a3c8f62d7c020770dfa5dbc4d7e4bfa84ea9d"))
 (when (modulep! +pomodoro)
   (package! org-pomodoro :pin "3f5bcfb80d61556d35fc29e5ddb09750df962cc6"))
 (when (modulep! +pretty)


### PR DESCRIPTION
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

Now org-noter have new maintainers [github](https://github.com/org-noter/org-noter), [melpa](https://melpa.org/#/org-noter). [Reddit post from authors](https://www.reddit.com/r/emacs/comments/11x237p/orgnoter_is_under_new_maintainership_with_the/).