### PR TITLE
fix(unicode): don't unset `doom-unicode-font`

### DIFF
--- a/modules/ui/unicode/autoload.el
+++ b/modules/ui/unicode/autoload.el
@@ -5,8 +5,7 @@
   (defun +unicode-init-fonts-h ()
     "Set up `unicode-fonts' to eventually run; accommodating the daemon, if
 necessary."
-    (setq-default bidi-display-reordering t
-                  doom-unicode-font nil)
+    (setq-default bidi-display-reordering t)
     (if (display-graphic-p)
         (+unicode-setup-fonts-h (selected-frame))
       (add-hook 'after-make-frame-functions #'+unicode-setup-fonts-h))))


### PR DESCRIPTION
unicode mode would unset `doom-unicode-font` prior to adding the hook for `+unicode-setup-fonts-h`, thus bypassing #3334.
This also addresses #3298 without disabling unicode module, as required for
@teu5us's issue: https://github.com/doomemacs/doomemacs/issues/3298#issuecomment-731711911