### PR TITLE
bump: :completion vertico compat

### DIFF
--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -696,14 +696,7 @@ config blocks in your private config."
   (unless (executable-find "rg")
     (user-error "Can't find ripgrep on your system"))
   (cond ((fboundp 'consult--grep)
-         (consult--grep
-          prompt
-          (lambda (input)
-            ;; PERF: avoid converting dirs to string and back when adding them to ripgrep args.
-            (letf! (defun consult--command-split (&rest args)
-                     (append (apply consult--command-split args) dirs))
-              (funcall (consult--ripgrep-make-builder) input)))
-          data-directory query))
+         (consult--grep prompt #'consult--ripgrep-make-builder (cons data-directory dirs) query))
         ((fboundp 'counsel-rg)
          (let ((counsel-rg-base-command
                 (if (stringp counsel-rg-base-command)

--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -48,4 +48,4 @@
 
 (package! compat
   :recipe (:host github :repo "emacs-compat/compat")
-  :pin "38280a7b54a6220377835391ead8af6fa4839117")
+  :pin "7775c3185764337b8a78c3005aab4a11aa80dfe8")

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -26,10 +26,10 @@
                   (if all-files "-uu ")
                   (unless recursive "--maxdepth 1 ")
                   "--null --line-buffered --color=never --max-columns=1000 "
-                  "--path-separator /   --smart-case --no-heading --line-number "
+                  "--path-separator /   --smart-case --no-heading "
+                  "--with-filename --line-number --search-zip "
                   "--hidden -g !.git -g !.svn -g !.hg "
-                  (mapconcat #'shell-quote-argument args " ")
-                  " ."))
+                  (mapconcat #'shell-quote-argument args " ")))
          (prompt (if (stringp prompt) (string-trim prompt) "Search"))
          (query (or query
                     (when (doom-region-active-p)
@@ -54,7 +54,7 @@
                                    "%")
                      :type perl)
                    consult-async-split-style 'perlalt))))))
-    (consult--grep prompt (consult--ripgrep-make-builder) directory query)))
+    (consult--grep prompt #'consult--ripgrep-make-builder directory query)))
 
 ;;;###autoload
 (defun +vertico/project-search (&optional arg initial-query directory)
@@ -225,9 +225,10 @@ targets."
 (defun +vertico/consult-fd (&optional dir initial)
   (interactive "P")
   (if doom-projectile-fd-binary
-      (let* ((prompt-dir (consult--directory-prompt "Fd" dir))
-             (default-directory (cdr prompt-dir)))
-        (find-file (consult--find (car prompt-dir) (+vertico--consult--fd-make-builder) initial)))
+      (pcase-let* ((`(,prompt ,paths ,dir) (consult--directory-prompt "Fd" dir))
+                   (default-directory dir)
+                   (builder (consult--find-make-builder paths)))
+        (find-file (consult--find prompt builder initial)))
     (consult-find dir initial)))
 
 ;;;###autoload

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,25 +4,25 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "6f22ff129886a6b9292212f9897c65f919340aca")
+  :pin "b6b8420d2943e42b88e2a143da29edf76bc223b5")
 
-(package! orderless :pin "d09aab37951b25627b96660f429eaec969d16d8a")
+(package! orderless :pin "e6784026717a8a6a7dcd0bf31fd3414f148c542e")
 
-(package! consult :pin "ffaaf6da909dc9ff766e5a5f16eb265635aa6149")
+(package! consult :pin "052399ed05372464b8ed6261b3196de143a8a834")
 (package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
   (package! consult-flycheck :pin "c371996c571b7139ef4d9a8db142bf37a7ee826b"))
-(package! embark :pin "5497a19eef92e4b82e2dcbcd26eb671227240c45")
-(package! embark-consult :pin "5497a19eef92e4b82e2dcbcd26eb671227240c45")
+(package! embark :pin "3ffb27a833d326ccf7e375bb9d94ebf4dc37fa77")
+(package! embark-consult :pin "3ffb27a833d326ccf7e375bb9d94ebf4dc37fa77")
 
-(package! marginalia :pin "ccf573e2145d9deb9d734432351eefc87fc1bc16")
+(package! marginalia :pin "2633b2dee22261531f960e49106771e679102a98")
 
 (package! wgrep :pin "edf768732a56840db6879706b64c5773c316d619")
 
 (when (modulep! +icons)
-  (package! all-the-icons-completion :pin "4da28584a1b36b222e0e78d46fd8d46bbd9116c7"))
+  (package! all-the-icons-completion :pin "b08f053cee444546ab44a05fd541f59e8bc8983b"))
 
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "f57b170b435ecb73027de00783c58e7cb46019a5"))
+    :pin "7da6d648ff4202a48eb6647ee7dce8d65de48779"))


### PR DESCRIPTION
iyefrat/all-the-icons-completion@4da28584a1b3 -> iyefrat/all-the-icons-completion@b08f053cee44
minad/consult@ffaaf6da909d -> minad/consult@052399ed0537
minad/marginalia@ccf573e2145d -> minad/marginalia@2633b2dee222
minad/vertico@6f22ff129886 -> minad/vertico@b6b8420d2943
oantolin/embark@5497a19eef92 -> oantolin/embark@3ffb27a833d3
oantolin/orderless@d09aab37951b -> oantolin/orderless@e6784026717a
tumashu/vertico-posframe@f57b170b435e -> tumashu/vertico-posframe@7da6d648ff42
emacs-compat/compat@38280a7b54a6 -> emacs-compat/compat@7775c3185764

---

consult--grep added support for searching in multiple directories, so we
can drop the advice in `doom--help-search`. The other changes just adapt
to upstream API changes.