### PR TITLE
feat(vertico): search pattern after consult-line

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -175,7 +175,13 @@ orderless."
                          (lambda (x)
                            (eq (buffer-local-value 'major-mode x) 'org-mode))
                          (buffer-list)))))))
-    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append)))
+    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append))
+
+  (defadvice! evil-ex-store-pattern-a (_ _)
+    "Remember the search pattern after consult-line."
+    :after #'consult-line
+    (setq evil-ex-search-pattern
+          (list (car consult--line-history) t t))))
 
 
 (use-package! consult-dir


### PR DESCRIPTION
Reuse search pattern for Evil's `<n>` or `<N>` after consult-line

Very often, after searching for something with `consult-line`, I want to jump to the next/previous occurrences with `<n>|<N>`

<!-- ⚠️ Please do not ignore this template! -->


- [x] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).



