### PR TITLE
feat(lua): recognize `.fenneldoc` files

### DIFF
--- a/modules/lang/lua/config.el
+++ b/modules/lang/lua/config.el
@@ -63,6 +63,7 @@ lua-language-server.")
 (use-package! fennel-mode
   :when (modulep! +fennel)
   :defer t
+  :mode ("\\.fenneldoc" . fennel-mode)
   :config
   (set-lookup-handlers! 'fennel-mode
     :definition #'fennel-find-definition


### PR DESCRIPTION
This turns on Fennel syntax highlighting for `.fenneldoc` files.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.