### PR TITLE
Bump :completion ivy (ivy-rich)

### DIFF
--- a/modules/completion/ivy/packages.el
+++ b/modules/completion/ivy/packages.el
@@ -9,7 +9,7 @@
 
 (package! amx :pin "37f9c7ae55eb0331b27200fb745206fc58ceffc0")
 (package! counsel-projectile :pin "40d1e1d4bb70acb00fddd6f4df9778bf2c52734b")
-(package! ivy-rich :pin "600b8183ed0be8668dcc548cc2c8cb94b001363b")
+(package! ivy-rich :pin "4fdd4669d69c9e8248b361b6e069b27d10e809e4")
 (package! wgrep :pin "edf768732a56840db6879706b64c5773c316d619")
 
 (if (modulep! +prescient)


### PR DESCRIPTION
An error that occurs on switching buffers is fixed by the latest ivy-rich commit.:
```
Error in post-command-hook (ivy--queue-exhibit): (file-error "Opening directory" "Not a directory" "/home/me/foo.txt")
```

References: abo-abo/swiper#3006

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
