### PR TITLE
tweak(config): feature-gate company keybindings

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -506,8 +506,9 @@
       "C-x K"       #'doom/kill-this-buffer-in-all-windows
 
       ;;; company-mode
-      "C-;" #'+company/complete
-      (:after company
+      (:when (modulep! :completion company)
+       "C-;" #'+company/complete
+       (:after company
         :map company-active-map
         "C-o"        #'company-search-kill-others
         "C-n"        #'company-select-next
@@ -528,7 +529,7 @@
         :map company-search-map
         "C-n"        #'company-search-repeat-forward
         "C-p"        #'company-search-repeat-backward
-        "C-s"        (cmd! (company-search-abort) (company-filter-candidates)))
+        "C-s"        (cmd! (company-search-abort) (company-filter-candidates))))
 
       ;;; ein notebooks
       (:after ein:notebook-multilang


### PR DESCRIPTION
In anticipation of the Corfu module, this PR feature-gates the company-mode keybindings for non-Evil users. This is already done for Evil users. 

While feature-gating keybindings is on the do-not-PR list, I am hoping that an exception will be made on the basis that the company keybindings are currently feature-gated for Evil users but not for non-Evil users.