### PR TITLE
bump: :editor format

### DIFF
--- a/modules/editor/format/packages.el
+++ b/modules/editor/format/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/format/packages.el
 
-(package! format-all :pin "47d862d40a088ca089c92cd393c6dca4628f87d3")
+(package! format-all :pin "91ea3c16f594294b8064e61c4b14c5264d88e24d")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

swiftformat doesn't use `.swiftformat` as config, it had been fixed by https://github.com/lassik/emacs-format-all-the-code/commit/827c3e38eb5e6da7ab21ae2c03814e61d6b0ed05

There are no breakchanges for latest `emacs-format-all-the-code`

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
