### PR TITLE
revert: closql

### DIFF
--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -6,5 +6,9 @@
     (package! forge :pin "ba35ffc9bafc6457cc95633904e53e34e544543f")
     (package! code-review
       :recipe (:files ("graphql" "code-review*.el"))
-      :pin "26f426e99221a1f9356aabf874513e9105b68140"))
+      :pin "26f426e99221a1f9356aabf874513e9105b68140")
+    ; HACK closql c3b34a6ec438 breaks code-review wandersoncferreira/code-review#245,
+    ; and the current forge commit (but forge does have an upstream fix),
+    ; pinned as a temporary measure to prevent user breakages
+    (package! closql :pin "0a7226331ff1f96142199915c0ac7940bac4afdd"))
   (package! magit-todos :pin "c6f3fd03aa5b750636c2647253f21cc03329566c"))


### PR DESCRIPTION
magit/closql@c3b34a6ec438 -> magit/closql@0a7226331ff1

---

closql c3b34a6ec438 breaks code-review
wandersoncferreira/code-review#245, and the current forge commit (but
forge does have an upstream fix), pinned as a temporary measure to
prevent user breakages

Ref: wandersoncferreira/code-review#245
Ref: magit/closql#8
Fix: #7191
