### PR TITLE
docs: fix link by removing newline

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -430,8 +430,7 @@ bin/doom command.
 #+end_quote
 
 **** With WSL + Ubuntu 18.04 LTS
-(Credit goes to @lunias and [[https://ethanaa.com/blog/switching-to-doom-emacs/#installing-on-windows-10
-][his fantastic tutorial]] for informing this guide)
+(Credit goes to @lunias and [[https://ethanaa.com/blog/switching-to-doom-emacs/#installing-on-windows-10][his fantastic tutorial]] for informing this guide)
 
 1. Install Powershell as admin (Windows key + x) with:
    #+BEGIN_SRC


### PR DESCRIPTION
Remove newline in `docs/getting_started.org` to fix link display on GitHub.

Before/After:
![image](https://user-images.githubusercontent.com/29655971/231827153-ff15d25c-5690-4950-8ffa-ffd7df13cbfb.png)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
