### PR TITLE
fix(lib): doom-region-*: only use evil visual range in visual mode

### DIFF
--- a/lisp/lib/text.el
+++ b/lisp/lib/text.el
@@ -78,6 +78,7 @@ Detects evil visual mode as well."
 Uses `evil-visual-beginning' if available."
   (declare (side-effect-free t))
   (or (and (bound-and-true-p evil-local-mode)
+           (evil-visual-state-p)
            (markerp evil-visual-beginning)
            (marker-position evil-visual-beginning))
       (region-beginning)))
@@ -87,7 +88,8 @@ Uses `evil-visual-beginning' if available."
   "Return end position of selection.
 Uses `evil-visual-end' if available."
   (declare (side-effect-free t))
-  (if (bound-and-true-p evil-local-mode)
+  (if (and (bound-and-true-p evil-local-mode)
+           (evil-visual-state-p))
       evil-visual-end
     (region-end)))
 


### PR DESCRIPTION
Hi,

I found out that Doom Emacs get regions incorrectly for `evil-emacs-state-mode`, because `evil-visual-beginning` and `evil-visual-end` are used to get regions in emacs state mode.

I added additional conditions check to fix this issue.

Can you review and merge this PR?

Thanks!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
