### PR TITLE
fix(gdscript): Replace deprecated breakpoint fn

### DIFF
--- a/modules/lang/gdscript/config.el
+++ b/modules/lang/gdscript/config.el
@@ -26,9 +26,8 @@
          :desc "Run current scene" "s" #'gdscript-godot-run-current-scene)
 
         (:prefix ("d" . "debug")
-         :desc "Add breakpoint" "a"  #'gdscript-debug-add-breakpoint
+         :desc "Toggle breakpoint" "d" #'gdscript-debug-toggle-breakpoint
          :desc "Display breakpoint buffer" "b" #'gdscript-debug-display-breakpoint-buffer
-         :desc "Remove breakpoint" "d" #'gdscript-debug-remove-breakpoint
          :desc "Continue execution" "c" #'gdscript-debug-continue
          :desc "Next" "n" #'gdscript-debug-next
          :desc "Step" "s" #'gdscript-debug-step)


### PR DESCRIPTION
The function `gdscript-debug-add-breakpoint` no longer exists. The binding for it has been removed, and the binding for `gdscript-debug-remove-breakpoint` has been replaced with `gdscript-debug-toggle-breakpoint`, following the convention that a double tap (`<localleader> d d`) should do the most common action.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
