### PR TITLE
docs: fix macOS doom doctor warning

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -293,7 +293,7 @@ to least recommended for Doom (based on compatibility).
   with macOS, native emojis and better childframe support.
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
-  brew install emacs-mac --with-modules
+  brew install emacs-mac --with-modules --with-native-compilation
   ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
Checking for great Emacs features...
! Emacs was not built with native compilation support
  Users will see a substantial performance gain by building Emacs with
  native compilation support, availible in emacs 28+.You must install a
  prebuilt Emacs binary with this included, or compile Emacs with the
  --with-native-compilation option.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
References #0000
Replaces #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
