### PR TITLE
feat(cli): added mid-upgrade hook

### DIFF
--- a/lisp/cli/upgrade.el
+++ b/lisp/cli/upgrade.el
@@ -15,6 +15,8 @@
 (defvar doom-upgrade-remote "_upgrade"
   "The name to use as our staging remote.")
 
+(defvar doom-upgrade-before-sync-hook ()
+  "Hooks run between upgrading Doom itself and performing an upgrading sync.")
 
 ;;
 ;;; Commands
@@ -57,6 +59,8 @@ following shell commands:
       (exit! "doom" "upgrade" "-p"
              (if force? "--force")
              (if jobs (format "--jobs=%d" jobs))))
+
+     (run-hooks 'doom-upgrade-before-sync-hook)
 
      ((print! "Doom is up-to-date!")
       (call! sync-cmd)))))


### PR DESCRIPTION
Add a hook to run after upgrading doom, but before sync.

This is to enable me to have a hook to upgrade my private doom modules,
which I only want to do when upgrading doom itself, to keep the two in
sync.