### PR TITLE
docs: warn about disabling core packages

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -928,6 +928,12 @@ Once a package is disabled, ~use-package!~ and ~after!~ blocks for it will be
 ignored, and the package is removed the next time you run ~bin/doom sync~. Use
 this to disable Doom's packages that you don't want or need.
 
+#+begin_quote
+*IMPORTANT:* Core packages are required by doom; disabling these will break doom.
+Use ~doom/help-packages~ (=SPC h p= or =C-h p=) to see if a package is in ~core~.
+Disable their minor-modes or hooks instead.
+#+end_quote
+
 There is also the ~disable-packages!~ macro for conveniently disabling multiple
 packages:
 #+BEGIN_SRC elisp


### PR DESCRIPTION
add a warning against disabling core packages to `getting_started.org#disabling-packages`.

i understand the docs are under a rewrite and this is a "do not PR" area, but I am submitting anyway (without even discussing on discord first!) because:
- it is a tiny change.
- the existing wording is very misleading without this warning and could potentially sink a lot of time for fools like me.
- as far as I can tell is not documented anywhere (there [was a runtime warning](https://github.com/doomemacs/doomemacs/commit/969b047472b091e84b599f92e26b089386748cc5) but it seems to have been [lost in a rewrite](https://github.com/doomemacs/doomemacs/commit/0e851ace9ba48971f43af91b31af508381c38e13#diff-2d4f918cd919eb3c19d5fd737bc992f732d08b9ed87688a48cf4394f30d8b71aL165), by accident or purpose I can't tell).

if this PR is bothersome or conflicts with the rewrite in any way please do feel free to close without further comment, i completely understand! my goal in submitting this is partly to offer an easy stop-gap fix to a pitfall and partly as a personally satisfying end to a several hour journey (reading "use this to disable doom packages you do not want", lead me into thinking disabling any package included with doom was a supported feature, before eventually finding #2223).

i don't mean to create conflict or fuss so if this PR is not helpful please don't hesitate to close it. thank you for everything!

-----
- [✔️] I searched the issue tracker and this hasn't been PRed before.
- [❌] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [✔️] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [✔️] I am blindly checking these off.
- [✔️] Any relevant issues or PRs have been linked to.
