### PR TITLE
tweak(evil): make window-move-* cyclic

### DIFF
--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -76,21 +76,25 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
 (defun +evil/window-move-left ()
   "Swap windows to the right"
   (interactive)
-  (if (window-at-side-p nil 'left)
+  (if (and (window-at-side-p nil 'left)
+           (not (or (window-in-direction 'above)
+                    (window-in-direction 'below))))
       (evil-window-move-far-right)
     (+evil--window-swap 'left)))
 ;;;###autoload
 (defun +evil/window-move-right ()
   "Swap windows to the right"
   (interactive)
-  (if (window-at-side-p nil 'right)
+  (if (and (window-at-side-p nil 'right)
+           (not (or (window-in-direction 'above)
+                    (window-in-direction 'below))))
       (evil-window-move-far-left)
     (+evil--window-swap 'right)))
 ;;;###autoload
 (defun +evil/window-move-up ()
   "Swap windows upward."
   (interactive)
-  (if (window-at-side-p nil 'top)
+  (if (and (window-at-side-p nil 'top))
       (evil-window-move-very-bottom)
     (+evil--window-swap 'up)))
 ;;;###autoload

--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -74,20 +74,32 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
 
 ;;;###autoload
 (defun +evil/window-move-left ()
-  "Swap windows to the left."
-  (interactive) (+evil--window-swap 'left))
+  "Swap windows to the right"
+  (interactive)
+  (if (window-at-side-p nil 'left)
+      (evil-window-move-far-right)
+    (+evil--window-swap 'left)))
 ;;;###autoload
 (defun +evil/window-move-right ()
   "Swap windows to the right"
-  (interactive) (+evil--window-swap 'right))
+  (interactive)
+  (if (window-at-side-p nil 'right)
+      (evil-window-move-far-left)
+    (+evil--window-swap 'right)))
 ;;;###autoload
 (defun +evil/window-move-up ()
   "Swap windows upward."
-  (interactive) (+evil--window-swap 'up))
+  (interactive)
+  (if (window-at-side-p nil 'top)
+      (evil-window-move-very-bottom)
+    (+evil--window-swap 'up)))
 ;;;###autoload
 (defun +evil/window-move-down ()
   "Swap windows downward."
-  (interactive) (+evil--window-swap 'down))
+  (interactive)
+  (if (window-at-side-p nil 'bottom)
+      (evil-window-move-very-top)
+    (+evil--window-swap 'down)))
 
 ;;;###autoload
 (defun +evil/window-split-and-follow ()


### PR DESCRIPTION
Attempting to move far-right window further to the right, makes it appear on the left side of the frame.
Works similarly for other directions.

*I understand that this might be the subject of preference - someone likes it this way, others may not. Feel free to reject it.*

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).





