### PR TITLE
fix(lookup): correctly scrape identifier in pdf-view-mode

### DIFF
--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -408,10 +408,10 @@ Otherwise, falls back on `find-file-at-point'."
   "Look up the definition of the word at point (or selection)."
   (interactive
    (list (or (doom-thing-at-point-or-region 'word)
+             (if (equal major-mode 'pdf-view-mode)
+                 (car (pdf-view-active-region-text)))
              (read-string "Look up in dictionary: "))
          current-prefix-arg))
-  (if (equal major-mode 'pdf-view-mode)
-      (setq identifier (car (pdf-view-active-region-text))))
   (message "Looking up dictionary definition for %S" identifier)
   (cond ((and IS-MAC (require 'osx-dictionary nil t))
          (osx-dictionary--view-result identifier))

--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -410,6 +410,8 @@ Otherwise, falls back on `find-file-at-point'."
    (list (or (doom-thing-at-point-or-region 'word)
              (read-string "Look up in dictionary: "))
          current-prefix-arg))
+  (if (equal major-mode 'pdf-view-mode)
+      (setq identifier (car (pdf-view-active-region-text))))
   (message "Looking up dictionary definition for %S" identifier)
   (cond ((and IS-MAC (require 'osx-dictionary nil t))
          (osx-dictionary--view-result identifier))


### PR DESCRIPTION
Set the selected `identifier` to `pdf-view-active-region-text` in the case of being selected in pdf-view-mode.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
