### PR TITLE
fix(lib): doom-system-distro-version: check nixos-version first

### DIFF
--- a/lisp/lib/system.el
+++ b/lisp/lib/system.el
@@ -31,10 +31,10 @@
         (format "Windows %s" "Unknown")) ; TODO
        ((eq distro 'macos)
         (format "MacOS %s" (sh "sw_vers" "-productVersion")))
-       ((executable-find "lsb_release")
-        (sh "lsb_release" "-s" "-d"))
        ((executable-find "nixos-version")
         (format "NixOS %s" (sh "nixos-version")))
+       ((executable-find "lsb_release")
+        (sh "lsb_release" "-s" "-d"))
        ((ignore-errors
           (with-file-contents! "/etc/os-release"
             (when (re-search-forward "^PRETTY_NAME=\"?\\([^\"\n]+\\)\"?" nil t)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

If a NixOS machine has `lsb_release` in its PATH, `lsb_release` will be used instead of `nixos-version` to determine the version.

Move the more general `lsb_release` check after the NixOS check.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] I am *not* blindly checking these off. ;-)

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
