### PR TITLE
module: add `:lang idris2`

### DIFF
--- a/modules/lang/idris2/README.org
+++ b/modules/lang/idris2/README.org
@@ -1,0 +1,52 @@
+#+title:    :lang idris
+#+subtitle: A language you can depend on
+#+created:  May 9, 2023
+#+since:    v2.0.9
+
+* Description :unfold:
+This module adds rudimentary [[idris2.readthedocs.io/][Idris 2]] support to Doom Emacs.
+
+** Maintainers
+- [[doom-user:][@ribosomerocker]]
+[[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+/This module has no flags./
+
+** Packages
+- [[doom-package:idris2-mode]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+# This section will be machine generated. Don't edit it by hand.
+/This module does not have a changelog yet./
+
+* TODO Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+#+begin_quote
+ 🔨 /No installation steps have been documented./ [[doom-contrib-module:][Document them?]]
+#+end_quote
+
+* TODO Usage
+#+begin_quote
+ 🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+#+end_quote
+
+* TODO Configuration
+#+begin_quote
+ 🔨 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
+#+end_quote
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+ 🔨 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/lang/idris2/config.el
+++ b/modules/lang/idris2/config.el
@@ -1,0 +1,16 @@
+;;; lang/idris2/config.el -*- lexical-binding: t; -*-
+
+(use-package! idris2-mode
+  :mode ("\\.l?idr\\'" . idris2-mode)
+  :config
+
+  (after! lsp-mode
+    (add-to-list 'lsp-language-id-configuration '(idris2-mode . "idris2"))
+
+    (lsp-register-client
+     (make-lsp-client
+      :new-connection (lsp-stdio-connection "idris2-lsp")
+      :major-modes '(idris2-mode)
+      :server-id 'idris2-lsp)))
+
+  (add-hook 'idris2-mode-hook #'lsp!))

--- a/modules/lang/idris2/packages.el
+++ b/modules/lang/idris2/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/idris2/packages.el
+
+(package! idris2-mode :recipe (:host github :repo "idris-community/idris2-mode"))


### PR DESCRIPTION
Added support for the Idris 2 programming language. This is a new, breaking version of Idris, that isn't supported by the pre-existing module. Idris 1 (the one the pre-existing module supports) is deprecated, but I haven't removed it because some people might still depend on it (no pun intended). I haven't really deprecated the module or anything, I'll be waiting for your input to tell me if you want to do so.

As the Idris 1 language is deprecated and pretty much not at all used at this point, and since the pre-existing module doesn't support Idris 2, this kind of makes the pre-existing module useless for Idris users.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
(technically not for this, but I have discussed this with the maintainer on Discord and I've been told that it's fine to PR this)
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
(there are no relevant issues or PRs)
- [x] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
