### PR TITLE
bump: :completion vertico compat

### DIFF
--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -48,4 +48,4 @@
 
 (package! compat
   :recipe (:host github :repo "emacs-compat/compat")
-  :pin "7775c3185764337b8a78c3005aab4a11aa80dfe8")
+  :pin "be1d94d5e0e2fc9f02d2cd240d255c3a43037ba3")

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,20 +4,20 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "b6b8420d2943e42b88e2a143da29edf76bc223b5")
+  :pin "926234ab3fbe2b89e8c7ddfccecff518d73ac6ba")
 
 (package! orderless :pin "e6784026717a8a6a7dcd0bf31fd3414f148c542e")
 
-(package! consult :pin "052399ed05372464b8ed6261b3196de143a8a834")
+(package! consult :pin "511d8c0b072a660009fcba1f461dba9e21bc0cf0")
 (package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
 (when (modulep! :checkers syntax)
-  (package! consult-flycheck :pin "c371996c571b7139ef4d9a8db142bf37a7ee826b"))
-(package! embark :pin "3ffb27a833d326ccf7e375bb9d94ebf4dc37fa77")
-(package! embark-consult :pin "3ffb27a833d326ccf7e375bb9d94ebf4dc37fa77")
+  (package! consult-flycheck :pin "fda630411ad9219f45136310f671b44eaefafcab"))
+(package! embark :pin "9b17d9a63b6960e026ad3c09a7871e0a3364e926")
+(package! embark-consult :pin "9b17d9a63b6960e026ad3c09a7871e0a3364e926")
 
-(package! marginalia :pin "2633b2dee22261531f960e49106771e679102a98")
+(package! marginalia :pin "b900ec5457068cd2b15b0e3600437f147c6bf636")
 
-(package! wgrep :pin "edf768732a56840db6879706b64c5773c316d619")
+(package! wgrep :pin "3132abd3750b8c87cbcf6942db952acfab5edccd")
 
 (when (modulep! +icons)
   (package! all-the-icons-completion :pin "b08f053cee444546ab44a05fd541f59e8bc8983b"))


### PR DESCRIPTION
emacs-compat/compat@7775c3185764 -> emacs-compat/compat@be1d94d5e0e2
mhayashi1120/Emacs-wgrep@edf768732a56 -> mhayashi1120/Emacs-wgrep@3132abd3750b
minad/consult-flycheck@c371996c571b -> minad/consult-flycheck@fda630411ad9
minad/consult@052399ed0537 -> minad/consult@511d8c0b072a
minad/marginalia@2633b2dee222 -> minad/marginalia@b900ec545706
minad/vertico@b6b8420d2943 -> minad/vertico@926234ab3fbe
oantolin/embark@3ffb27a833d3 -> oantolin/embark@9b17d9a63b69

---

- [ ] decide what to do regarding `embark-cycle` being on `SPC a` in `embark-general-map` conflicting with `embark-select`