### PR TITLE
fix: enable rainbow delimiters by default

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -472,8 +472,9 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 ;; languages like Lisp. I reduce it from it's default of 9 to reduce the
 ;; complexity of the font-lock keyword and hopefully buy us a few ms of
 ;; performance.
-(setq rainbow-delimiters-max-face-count 4)
-
+(use-package! rainbow-delimiters
+  :hook (prog-mode . rainbow-delimiters-mode)
+  :config (setq rainbow-delimiters-max-face-count 4))
 
 ;;
 ;;; Line numbers


### PR DESCRIPTION
I had this snippet in my config, doom installs rainbow delimites but it doesn't enable them by default - just enable it on `prog-mode`

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
References #0000
Replaces #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
other prs enabled rainbow-delimiters for specific modes, so uhhh
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
