### PR TITLE
tree-sitter: bump versions

### DIFF
--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,11 +2,11 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter
-  :pin "c3fe96a103a766256ba62120eb638eef8e9a9802")
+  :pin "2a9d951cd6faf8367a402210c406f0f64818aa24")
 
 (package! tree-sitter-langs
-  :pin "deb2d8674be8f777ace50e15c7c041aeddb1d0b2")
+  :pin "ffe9ab0c8ec9e37e70e31d296df3b85bcfc73c5e")
 
 (when (modulep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "9dce8dab68c954ae32095328cf898eb856fc341a"))
+    :pin "71bf11072840fc85f728c1084896d892be4d3c56"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Bumping tree-sitter version -- this fixes the discrepencies between the grammar in evil-textobj-tree-sitter and tree-sitter-langs for java (line_comment/block_comment available in the former but not the latter)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
