### PR TITLE
fix(scala): remove -emacs suffix from metals executable

### DIFF
--- a/modules/lang/scala/README.org
+++ b/modules/lang/scala/README.org
@@ -87,7 +87,7 @@ coursier bootstrap \
   org.scalameta:metals_2.12:0.9.4 \
   -r bintray:scalacenter/releases \
   -r sonatype:snapshots \
-  -o /usr/local/bin/metals-emacs -f
+  -o /usr/local/bin/metals -f
 #+end_src
 
 **** Arch Linux

--- a/modules/lang/scala/doctor.el
+++ b/modules/lang/scala/doctor.el
@@ -9,5 +9,5 @@
          "This module requires (:tools tree-sitter)")
 
 (if (and (modulep! +lsp)
-         (not (executable-find "metals-emacs")))
-    (warn! "metals-emacs isn't installed"))
+         (not (executable-find "metals")))
+    (warn! "metals isn't installed"))


### PR DESCRIPTION
warn about metals binary instead of metals-emacs.
there's no need for a custom binary for each editor

- https://github.com/NixOS/nixpkgs/pull/182087#issuecomment-1296195328
- https://github.com/scalameta/metals/blob/45df705da236edfddcea7e358592fd3202bb9460/docs/editors/vim.md?plain=1#L81
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.