### PR TITLE
docs: don't set user-* variables by default

### DIFF
--- a/templates/config.example.el
+++ b/templates/config.example.el
@@ -6,8 +6,8 @@
 
 ;; Some functionality uses this to identify you, e.g. GPG configuration, email
 ;; clients, file templates and snippets. It is optional.
-(setq user-full-name "John Doe"
-      user-mail-address "john@doe.com")
+;; (setq user-full-name "John Doe"
+;;       user-mail-address "john@doe.com")
 
 ;; Doom exposes five (optional) variables for controlling fonts in Doom:
 ;;


### PR DESCRIPTION
Do not default to setting the user's name to John Doe or their email to john@doe.com. It is better to leave these variables unset than to set them incorrectly.

Currently, if the user edits the Doom config and ignores those two lines, their name and email get set to "John Doe" <john@doe.com>, which is probably not what they want.

I could not find any explanation for why the lines are uncommented when you added them in 18d8ea22f6c81e6b46c87448476d62c9be6685f2

Thank you!

-----

Related #4553

- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
