### PR TITLE
docs(lispy): add "Working with Brackets"

### DIFF
--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -77,7 +77,7 @@ by typing ={=. If you prefer to use the bracket keys for input, you can rebind
 them like below:
 
 #+begin_src emacs-lisp
-;; config.el
+;; in $DOOMDIR/config.el
 
 ;; unbind individual bracket keys
 (map! :after (lispy lispyville)

--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -79,23 +79,14 @@ them like below:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
 
-;; unbind individual bracket keys
 (map! :after (lispy lispyville)
       :map lispy-mode-map-lispy
-      "[" nil)
-
-(map! :after (lispy lispyville)
-      :map lispy-mode-map-lispy
-      "]" nil)
-
-;; re-bind commands bound to bracket keys by default
-(map! :after (lispy lispyville)
-      :map lispy-mode-map-lispy
-      "M-[" #'lispyville-previous-opening)
-
-(map! :after (lispy lispyville)
-      :map lispy-mode-map-lispy
-      "M-]" #'lispyville-next-closing)
+      ;; unbind individual bracket keys
+      "[" nil
+      "]" nil
+      ;; re-bind commands bound to bracket keys by default
+      "M-[" #'lispyville-previous-opening
+      "M-]" #'lispyville.next-opening)
 #+end_src
 
 * Troubleshooting

--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -68,6 +68,32 @@ To change the key themes set ~lispyville-key-theme~. Think of
 lispyville's [[https://github.com/noctuid/lispyville/blob/master/README.org][README]] for more info on the specific keybindings of each key theme
 (starting [[https://github.com/noctuid/lispyville#operators-key-theme][here]]).
 
+** Working with Brackets
+
+By default, =[= and =]= are [[https://github.com/noctuid/lispyville/tree/master#additional-movement-key-theme][bound]] to =lispyville-previous-opening= and =lispyville-next-closing= respectively. If you use a language which makes frequent use of brackets (e.g. Clojure, Racket, Scheme), you can insert a bracket pair =[]= by typing ={=. If you prefer to use the bracket keys for input, you can rebind them like below:
+
+#+begin_src emacs-lisp
+;; config.el
+
+;; unbind individual bracket keys
+(map! :after (lispy lispyville)
+      :map lispy-mode-map-lispy
+      "[" nil)
+
+(map! :after (lispy lispyville)
+      :map lispy-mode-map-lispy
+      "]" nil)
+
+;; re-bind commands bound to bracket keys by default
+(map! :after (lispy lispyville)
+      :map lispy-mode-map-lispy
+      "M-[" #'lispyville-previous-opening)
+
+(map! :after (lispy lispyville)
+      :map lispy-mode-map-lispy
+      "M-]" #'lispyville-next-closing)
+#+end_src
+
 * Troubleshooting
 [[doom-report:][Report an issue?]]
 

--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -70,7 +70,11 @@ lispyville's [[https://github.com/noctuid/lispyville/blob/master/README.org][REA
 
 ** Working with Brackets
 
-By default, =[= and =]= are [[https://github.com/noctuid/lispyville/tree/master#additional-movement-key-theme][bound]] to =lispyville-previous-opening= and =lispyville-next-closing= respectively. If you use a language which makes frequent use of brackets (e.g. Clojure, Racket, Scheme), you can insert a bracket pair =[]= by typing ={=. If you prefer to use the bracket keys for input, you can rebind them like below:
+By default, =[= and =]= are [[https://github.com/noctuid/lispyville/tree/master#additional-movement-key-theme][bound]] to =lispyville-previous-opening= and
+=lispyville-next-closing= respectively. If you use a language which makes frequent
+use of brackets (e.g. Clojure, Racket, Scheme), you can insert a bracket pair =[]=
+by typing ={=. If you prefer to use the bracket keys for input, you can rebind
+them like below:
 
 #+begin_src emacs-lisp
 ;; config.el


### PR DESCRIPTION
Add documentation on how insert brackets `[]` with `lispy` enabled. 

By default `lispy` binds commands to `[` and `]` even in insert state, which caused myself (and a [few](https://github.com/noctuid/lispyville/issues/36) [others](https://github.com/abo-abo/lispy/issues/83)) confusion when first using the module.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
