### PR TITLE
tweak(ledger): map `ledger-report` in `ledger-report-mode-map`

### DIFF
--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -61,6 +61,10 @@
          :m "[[" #'ledger-navigate-prev-xact-or-directive)
 
         (:localleader
+         :map ledger-report-mode-map
+         "r" #'ledger-report)
+
+        (:localleader
          :map ledger-mode-map
          "a" #'ledger-add-transaction
          "e" #'ledger-post-edit-amount


### PR DESCRIPTION
This PR maps `<localleader> r` in `ledger-report-mode-map` to `ledger-report` function. 

`ledger-report` function is very often used and the keybinding `<localleader> r` is already mapped to `ledger-report` in `ledger-mode-map` (notice not a "report" mode map).

The issue is after a report is generated you can't type the same key sequence to choose another report to generate.
It's because the active buffer is changed to the report one and `ledger-report-mode-map` doesn't have the very same keybinding defined. 
It means you have to switch the buffer back to your ledger file and type the sequence again. 

In the ledger-mode.el the keybinding to generate a report works in both buffers. 

Hope it makes sense.
 
That's my first time here, please let m know if I missed anything important. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
