### PR TITLE
refactor(org): move org-crypt and related hooks behind a `+crypt` flag

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -48,6 +48,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 - +dragndrop ::
   Enable drag-and-drop support for images and files; inserts inline previews
   for images and an icon+link for other media types.
+- +crypt ::
+  Enable [[https://orgmode.org/manual/Org-Crypt.html][org-crypt]] integraiton for encryption and decryption on org files.
 - +gnuplot ::
   Install gnuplot & gnuplot-mode, which enables rendering images from gnuplot
   src blocks or plotting tables with fn:org-plot/gnuplot (bound to =SPC m b p=,

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -1143,8 +1143,8 @@ between the two."
         (set-marker p nil)))))
 
 
-;; TODO Move to +encrypt flag
 (use-package! org-crypt ; built-in
+  :when (modulep! +crypt)
   :commands org-encrypt-entries org-encrypt-entry org-decrypt-entries org-decrypt-entry
   :hook (org-reveal-start . org-decrypt-entry)
   :preface


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Move org-crypt and related hooks behind a '+crypt' flag

Doom marks this as a TODO and it's easy to implement. What's more, doom add `org-encrypt-entries` hook to `before-save-hook`, which makes saving buffer not work due to a recent bug from GnuPG: https://stackoverflow.com/questions/76388376/emacs-org-encrypt-entry-hangs-when-file-is-modified. This PR fixed this problem for those who don't enable encryption on org file.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
