### PR TITLE
docs(upload): append "/" to the directory

### DIFF
--- a/modules/tools/upload/README.org
+++ b/modules/tools/upload/README.org
@@ -45,7 +45,7 @@ Uses ~ssh-deploy~ to map a local folder to a remote one. Set
 ~ssh-deploy-root-remote~ and ~ssh-deploy-root-local~ in a =.dir-locals.el= file
 to establish this mapping. E.g.
 #+begin_src emacs-lisp
-((nil . ((ssh-deploy-root-local . "/local/path/to/project")
+((nil . ((ssh-deploy-root-local . "/local/path/to/project/")
          (ssh-deploy-root-remote . "/ssh:user@server:/remote/project/")
          (ssh-deploy-on-explicit-save . t))))
 #+end_src
@@ -66,7 +66,7 @@ Check out [[https://github.com/cjohansson/emacs-ssh-deploy#deployment-configurat
 ** ~root-local~ and ~root-remote~ must match
 The final directory names much match:
 #+begin_src emacs-lisp
-((nil . ((ssh-deploy-root-local . "/local/path/to/example-project")
+((nil . ((ssh-deploy-root-local . "/local/path/to/example-project/")
          (ssh-deploy-root-remote . "/ssh:user@server:/remote/example-project/")
 #+end_src
 


### PR DESCRIPTION
Because of the nature of relative path handling, appending / to the directory works more reliable. Sometimes relative path can become a root directory "/" without the suffix in the local root. This updated example prevents such cases.

Examples on the upstream ssh-deploy repo also have / in the end.

Closes #7271

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
References #0000
Replaces #0000

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
