### PR TITLE
fix(tabs) fix #6647

### DIFF
--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -23,11 +23,11 @@
 
   ;; When started in daemon mode, centaur tabs does not work at all, so here is a fix
   (if (not (daemonp))
-	    (centaur-tabs-mode)
+      (centaur-tabs-mode)
 
     (defun centaur-tabs--daemon-mode (frame)
-	    (unless (and (featurep 'centaur-tabs) (centaur-tabs-mode-on-p))
-		    (run-at-time nil nil (lambda () (centaur-tabs-mode)))))
+      (unless (and (featurep 'centaur-tabs) (centaur-tabs-mode-on-p))
+        (run-at-time nil nil (lambda () (centaur-tabs-mode)))))
     (add-hook 'after-make-frame-functions #'centaur-tabs--daemon-mode))
 
 

--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -1,7 +1,7 @@
 ;;; ui/tabs/config.el -*- lexical-binding: t; -*-
 
 (use-package! centaur-tabs
-  :hook (doom-first-file . centaur-tabs-mode)
+  :hook (server-after-make-frame . centaur-tabs-mode)
   :init
   (setq centaur-tabs-set-icons t
         centaur-tabs-gray-out-icons 'buffer
@@ -20,6 +20,15 @@
       "Disable `centaur-tabs-mode' in current buffer."
       (when (centaur-tabs-mode-on-p)
         (centaur-tabs-local-mode)))))
+
+  ;; When started in daemon mode, centaur tabs does not work at all, so here is a fix
+  (if (not (daemonp))
+	    (centaur-tabs-mode)
+
+    (defun centaur-tabs--daemon-mode (frame)
+	    (unless (and (featurep 'centaur-tabs) (centaur-tabs-mode-on-p))
+		    (run-at-time nil nil (lambda () (centaur-tabs-mode)))))
+    (add-hook 'after-make-frame-functions #'centaur-tabs-daemon-mode))
 
 
 ;; TODO tab-bar-mode (emacs 27)

--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -28,7 +28,7 @@
     (defun centaur-tabs--daemon-mode (frame)
 	    (unless (and (featurep 'centaur-tabs) (centaur-tabs-mode-on-p))
 		    (run-at-time nil nil (lambda () (centaur-tabs-mode)))))
-    (add-hook 'after-make-frame-functions #'centaur-tabs-daemon-mode))
+    (add-hook 'after-make-frame-functions #'centaur-tabs--daemon-mode))
 
 
 ;; TODO tab-bar-mode (emacs 27)


### PR DESCRIPTION
fix(tabs): fix centaur tabs not appearing in server mode

When started from the emacs daemon, centaur tabs
looks like this:
![Before fix](https://user-images.githubusercontent.com/62480697/183426012-a09a3dd0-921f-4f54-9e44-dcd3b571f8cd.png)

My fix makes it work properly:
![After fix](https://user-images.githubusercontent.com/62480697/183426376-a1d3fc34-b6c2-4097-9844-f4f495d8b5aa.png)

- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [X] Any relevant issues or PRs have been linked to.

Fix: #6647
Ref: ema2159/centaur-tabs#127
Ref: #6647 