### PR TITLE
bump: tree-sitter-langs.

### DIFF
--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -7,4 +7,4 @@
 
 (when (modulep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "02f8253034042d8f171bc0ef93e3538b71a29153"))
+    :pin "e8bb9d63deeb2953ff9600e1633de667b3d7673e"))

--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,7 +2,7 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter :pin "3cfab8a0e945db9b3df84437f27945746a43cc71")
-(package! tree-sitter-langs :pin "d8f8ac4faeb4564fbb61e94a631b4672523d84a9")
+(package! tree-sitter-langs :pin "ac6084b62c15803ea42d996815795afa32f6cd9f")
 (package! tree-sitter-indent :pin "4ef246db3e4ff99f672fe5e4b416c890f885c09e")
 
 (when (modulep! :editor evil +everywhere)


### PR DESCRIPTION
This bumps the commit of `tree-sitter-langs` to the latest to include the `MATLAB` parser that just got accepted.
To make the highlight work I had to `(setq! matlab-file-font-lock-keywords '())` in my configuration (inside `matlab-mode-hook`).