### PR TITLE
docs(cli): add further checks for conflicting config paths

### DIFF
--- a/lisp/cli/doctor.el
+++ b/lisp/cli/doctor.el
@@ -96,10 +96,15 @@ in."
      (error! "Couldn't find the `rg' binary; this a hard dependecy for Doom, file searches may not work at all")))
 
   (print! (start "Checking for Emacs config conflicts..."))
-  (when (file-exists-p "~/.emacs")
-    (warn! "Detected an ~/.emacs file, which may prevent Doom from loading")
-    (explain! "If Emacs finds an ~/.emacs file, it will ignore ~/.emacs.d, where Doom is "
-              "typically installed. If you're seeing a vanilla Emacs splash screen, this "
+  (when-let* ((superseding-files (append (when (file-exists-p "~/.emacs.el") '("~/.emacs.el file"))
+                                         (when (file-exists-p "~/.emacs") '("~/.emacs file"))
+                                         (when (and (not (file-equal-p doom-emacs-dir "~/.emacs.d"))
+                                                    (file-directory-p "~/.emacs.d")) '("~/.emacs.d directory"))))
+              (files-with-and (mapconcat 'identity superseding-files " and "))
+              (files-with-or (mapconcat 'identity superseding-files " or ")))
+    (warn! (format "Detected an %s, which may prevent Doom from loading" files-with-and))
+    (explain! (format "If Emacs finds an %s, it will ignore %s, where Doom is " files-with-or doom-emacs-dir)
+              "installed. If you're seeing a vanilla Emacs splash screen, this "
               "may explain why. If you use Chemacs, you may ignore this warning."))
 
   (print! (start "Checking for great Emacs features..."))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Adds checks for a couple more paths from https://www.gnu.org/software/emacs/manual/html_node/emacs/Find-Init.html that can cause the correct init.el not to load. Just the existence of `~/.emacs.d`, created for `eln-cache`, seems enough to stop Emacs searching.

```
! Detected an ~/.emacs file and ~/.emacs.d directory, which may prevent Doom from loading
  If Emacs finds an ~/.emacs file or ~/.emacs.d directory, it will
  ignore ~~~~~~~~~~~~~~/.config/emacs2/, where Doom is installed. If
  you're seeing a vanilla Emacs splash screen, this may explain why. If
  you use Chemacs, you may ignore this warning.
```

Potentially related to https://github.com/doomemacs/doomemacs/issues/7292, https://github.com/doomemacs/doomemacs/issues/7285

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
