### PR TITLE
fix(javascript): use top-level node_modules in monorepos

### DIFF
--- a/modules/lang/javascript/autoload.el
+++ b/modules/lang/javascript/autoload.el
@@ -34,7 +34,8 @@ ignore the cache."
 ;;;###autoload
 (defun +javascript-add-npm-path-h ()
   "Add node_modules/.bin to `exec-path'."
-  (when-let ((node-modules-parent (locate-dominating-file default-directory "node_modules/"))
+  (when-let ((search-directory (or (doom-project-root) default-directory))
+             (node-modules-parent (locate-dominating-file search-directory "node_modules/"))
              (node-modules-dir (expand-file-name "node_modules/.bin/" node-modules-parent)))
     (make-local-variable 'exec-path)
     (add-to-list 'exec-path node-modules-dir)


### PR DESCRIPTION
JavaScript monorepo packages can contain a child `node_modules`, hence we need to grab the one at the workspace root if possible.