### PR TITLE
tweak(workspaces): prefill current name on rename

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -221,7 +221,7 @@ workspace."
 ;;;###autoload
 (defun +workspace/rename (new-name)
   "Rename the current workspace."
-  (interactive (list (read-from-minibuffer "New workspace name: ")))
+  (interactive (list (completing-read "New workspace name: " (list (+workspace-current-name)))))
   (condition-case-unless-debug ex
       (let* ((current-name (+workspace-current-name))
              (old-name (+workspace-rename current-name new-name)))


### PR DESCRIPTION
This change uses completing-read to get the new name from the user when renaming workspaces, to allow them to more easily make a small change to the existing name of a workspace.

Note: I haven’t included screenshots because I don’t think this is a big enough visual change to need them. Let me know if this is the wrong conclusion!

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).