### PR TITLE
fix(cli): set set-language-environment to UTF-8

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -74,6 +74,8 @@
 ;; - The user may have a noexec flag set on /tmp, so pass the exit script to
 ;;   /bin/sh rather than executing them directly.
 
+(set-language-environment "UTF-8")
+
 ;; In CLI sessions, prefer correctness over performance.
 (setq load-prefer-newer t)
 


### PR DESCRIPTION

doom prompts `Select coding system (default utf-8):` on almost every command(similar to #3042).
Adding `(set-language-environment "UTF-8")` to `bin/doom` solves it for me.

<details>
<summary>doom cli</summary>

```
23:24:06 ω ~\AppData\Roaming\.emacs.d on  master
λ .\bin\doom.cmd env
> Regenerating envvars file
  â Generated ~/.emacs.d/.local/env
Select coding system (default utf-8):
C:\Program Files\Emacs\emacs-29.1\bin\emacs.exe: Write error to standard output: No error
23:24:24 ω ~\AppData\Roaming\.emacs.d on  master
λ .\bin\doom.cmd build -r -j 32
> (Re)building packages...
  - No packages need rebuilding
â Finished in 2.76559s
Select coding system (default utf-8):
C:\Program Files\Emacs\emacs-29.1\bin\emacs.exe: Write error to standard output: No error
23:24:33 ω ~\AppData\Roaming\.emacs.d on  master 3s
λ .\bin\doom.cmd sync
> Synchronizing "default" profile...
  > Regenerating envvars file
    â Generated ~/.emacs.d/.local/env
  > Installing packages...
    - No packages need to be installed
  > (Re)building packages...
    - No packages need rebuilding
  > Purging orphaned packages (for the emperor)...
    - Skipping builds
    - Skipping elpa packages
    - Skipping repos
    - Skipping regrafting
  > (Re)building profile in c:/Users/bennyyip/AppData/Roaming/.emacs.d/.local/etc/@/...
    > Deleting old init files...
    > Generating 4 init files...

Package autoload is deprecated
    > Byte-compiling init.29.el...
    â Built init.29.elc
  - Restart Emacs or use 'M-x doom/reload' for changes to take effect
â Finished in 19.84223s
Select coding system (default utf-8):
C:\Program Files\Emacs\emacs-29.1\bin\emacs.exe: Write error to standard output: No error
23:25:16 ω ~\AppData\Roaming\.emacs.d on  master 33s
λ .\bin\doom.cmd version
GNU Emacs     v29.1            nil
Doom core     v3.0.0-pre       HEAD -> master, fork/master cb0ebaf59 2023-08-02 23:05:01 +0800
Doom modules  v23.03.0-pre     HEAD -> master, fork/master cb0ebaf59 2023-08-02 23:05:01 +0800

Copyright (c) 2014-2022 Henrik Lissner.

Doom Emacs uses the MIT license and is provided without warranty of
any kind. You may redistribute and modify copies if given proper
attribution. See the LICENSE file for details.
```


</details>

<details>
<summary>`doom/info` output:</summary>

```
generated  Aug 02, 2023 23:27:25
system     Windows Unknown MSYS_NT-10.0-19045 3.4.6.x86_64 x86_64 w32
emacs      29.1 ~/.emacs.d/
doom       3.0.0-pre PROFILE=_@0 HEAD -> master, fork/master cb0ebaf59 2023-08-02
           23:05:01 +0800 ~/.doom.d/
shell      C:/Program
           Files/Emacs/emacs-29.1/libexec/emacs/29.1/x86_64-w64-mingw32/cmdproxy.exe
features   ACL GIF GMP GNUTLS HARFBUZZ JPEG JSON LCMS2 LIBXML2 MODULES NATIVE_COMP
           NOTIFY W32NOTIFY PDUMPER PNG RSVG SOUND SQLITE3 THREADS TIFF
           TOOLKIT_SCROLL_BARS TREE_SITTER WEBP XPM ZLIB
traits     gui server-running envvar-file
modules    :config use-package :input chinese :completion company vertico :ui doom
           doom-dashboard hl-todo modeline nav-flash ophints (popup +defaults)
           (vc-gutter +pretty) vi-tilde-fringe workspaces :editor (evil +everywhere)
           file-templates fold format lispy snippets :emacs dired electric ibuffer
           undo vc :checkers syntax :tools (eval +overlay) lookup lsp magit
           tree-sitter :os tty :lang emacs-lisp (json +tree-sitter) (markdown
           +tree-sitter) org (python +lsp +pyright +tree-sitter) (racket +tree-sitter)
           rest (scheme +tree-sitter +guile) (sh +tree-sitter) :config (default
           +bindings +smartparens) :benyip (&user keybindings) (&user chinese)
```

</details>



References #3042


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
