### PR TITLE
fic(bin): set LC_ALL to force english output

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+:; # To prevent non-English output from Doom leading to garbled text, set LC_ALL=C.UTF-8.
+:; export LC_ALL=C.UTF-8
 :; # -*- mode: emacs-lisp; lexical-binding: t -*-
 :; case "$EMACS" in *term*) EMACS=emacs ;; *) EMACS="${EMACS:-emacs}" ;; esac
 :; emacs="$EMACS ${DEBUG:+--debug-init} -q --no-site-file --batch"


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #0000
Fix doom command output, it will show like `������������ https://github.com/emacs-straight/emacsmirror-mirror` when host env is chinese or others.

If there need more commit info, please tell me
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
