### PR TITLE
Lua Love project root function fix

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -28,12 +28,12 @@
 ;;; Macros
 
 ;;;###autoload
-(defmacro project-file-exists-p! (files)
+(defmacro project-file-exists-p! (files &optional directory)
   "Checks if the project has the specified FILES.
 Paths are relative to the project root, unless they start with ./ or ../ (in
 which case they're relative to `default-directory'). If they start with a slash,
 they are absolute."
-  `(file-exists-p! ,files (doom-project-root)))
+  `(file-exists-p! ,files (or ,directory (doom-project-root))))
 
 
 ;;

--- a/modules/lang/lua/autoload/lua.el
+++ b/modules/lang/lua/autoload/lua.el
@@ -9,26 +9,28 @@
             (shell-quote-argument root))))
 
 ;;;###autoload
-(defun +lua-love-project-root ()
-  "Returns the directory where a main.lua or main.moon exists.
+(defun +lua-love-project-root (&optional dir)
+  "Search up from DIR for the directory where a main.lua or main.moon exists.
 
 Returns nil if 'love' executable can't be found."
   (when (executable-find "love")
-    (if (doom-project-p)
+    (if (doom-project-p dir)
         (file-name-directory
-         (or (project-file-exists-p! (or "main.lua" "src/main.lua"))
+         (or (project-file-exists-p! (or "main.lua" "src/main.lua")
+                                     dir)
              (and (modulep! +moonscript)
-                  (project-file-exists-p! (or "main.moon" "src/main.moon")))
+                  (project-file-exists-p! (or "main.moon" "src/main.moon")
+                                          dir))
              ""))
       ;; Since Love2D games are likely to be prototypes, they may not be in a
       ;; well-formed project as far as projecitle is concerned, so we search for
       ;; main.lua/main.moon up the file tree as a backup.
-      (or (projectile-locate-dominating-file default-directory "main.lua")
-          (when-let (root (projectile-locate-dominating-file default-directory "src/main.lua"))
+      (or (projectile-locate-dominating-file dir "main.lua")
+          (when-let (root (projectile-locate-dominating-file dir "src/main.lua"))
             (expand-file-name "src" root))
           (and (modulep! +moonscript)
-               (or (projectile-locate-dominating-file default-directory "main.moon")
-                   (when-let (root (projectile-locate-dominating-file default-directory "src/main.moon"))
+               (or (projectile-locate-dominating-file dir "main.moon")
+                   (when-let (root (projectile-locate-dominating-file dir "src/main.moon"))
                      (expand-file-name "src" root))))))))
 
 


### PR DESCRIPTION
This PR addresses an error I get every time I open a Love2D project with Doom Emacs. It occurs whenever `projectile-update-mode-line` is called.

Currently, the project root function for Love2D projects is broken
because it does not take an optional `dir` argument. This commit fixes
that.