### PR TITLE
fix: make leader key descriptions in the keymap itself

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -145,11 +145,8 @@ all hooks after it are ignored.")
                     forms))
             (when-let (desc (cadr (memq :which-key udef)))
               (prependq!
-               wkforms `((which-key-add-key-based-replacements
-                           (general--concat t doom-leader-alt-key ,key)
-                           ,desc)
-                         (which-key-add-key-based-replacements
-                           (general--concat t doom-leader-key ,key)
+               wkforms `((which-key-add-keymap-based-replacements doom-leader-map
+                           ,key
                            ,desc))))))))
     (macroexp-progn
      (append (and wkforms `((after! which-key ,@(nreverse wkforms))))
@@ -195,7 +192,7 @@ localleader prefix."
 ;;   :prefix/:non-normal-prefix properties because general is incredibly slow
 ;;   binding keys en mass with them in conjunction with :states -- an effective
 ;;   doubling of Doom's startup time!
-(define-prefix-command 'doom/leader 'doom-leader-map)
+(define-prefix-command 'doom-leader-map)
 (define-key doom-leader-map [override-state] 'all)
 
 ;; Bind `doom-leader-key' and `doom-leader-alt-key' as late as possible to give
@@ -210,9 +207,9 @@ localleader prefix."
                    (set-keymap-parent doom-leader-map mode-specific-map))
                   ((equal doom-leader-alt-key "C-x")
                    (set-keymap-parent doom-leader-map ctl-x-map)))
-            (define-key map (kbd doom-leader-alt-key) 'doom/leader))
-        (evil-define-key* '(normal visual motion) map (kbd doom-leader-key) 'doom/leader)
-        (evil-define-key* '(emacs insert) map (kbd doom-leader-alt-key) 'doom/leader))
+            (define-key map (kbd doom-leader-alt-key) #'doom-leader-map))
+        (evil-define-key* '(normal visual motion) map (kbd doom-leader-key) #'doom-leader-map)
+        (evil-define-key* '(emacs insert) map (kbd doom-leader-alt-key) #'doom-leader-map))
       (general-override-mode +1))))
 
 
@@ -317,6 +314,8 @@ For example, :nvi will map to (list 'normal 'visual 'insert). See
                                           :prefix prefix)
                                     rest))
                       (push `(defvar ,keymap (make-sparse-keymap))
+                            doom--map-forms)
+                      (push `(define-prefix-command ',keymap)
                             doom--map-forms))))
                  (:prefix
                   (cl-destructuring-bind (prefix . desc)

--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -242,7 +242,8 @@ localleader prefix."
 (defun doom-update-localleader-key-h ()
   "Set the localleader keys for the current major-mode."
   (set-keymap-parent doom-localleader-map
-                     (cdr (assq major-mode doom-localleader-map-alist))))
+                     (cdr (assq (buffer-local-value 'major-mode (window-buffer))
+                                doom-localleader-map-alist))))
 
 (add-hook 'post-command-hook #'doom-update-localleader-key-h)
 

--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -250,7 +250,8 @@ localleader prefix."
     (unless (or (derived-mode-p 'special-mode)
                 (derived-mode-p 'minibuffer-inactive-mode)
                 (derived-mode-p 'minibuffer-mode)
-                (derived-mode-p 'compilation-mode))
+                (derived-mode-p 'compilation-mode)
+                (eq major-mode 'fundamental-mode))
       (setq doom-localleader-current-major-mode major-mode)
       (set-keymap-parent doom-localleader-map
                          (cdr (assq major-mode doom-localleader-map-alist))))))

--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -247,11 +247,8 @@ localleader prefix."
              doom-switch-frame-hook)
   (defun doom-init-localleader-key-h ()
     "Set the localleader keys for the current major-mode."
-    (unless (or (derived-mode-p 'special-mode)
-                (derived-mode-p 'minibuffer-inactive-mode)
-                (derived-mode-p 'minibuffer-mode)
-                (derived-mode-p 'compilation-mode)
-                (eq major-mode 'fundamental-mode))
+    (unless (and (doom-unreal-buffer-p (current-buffer))
+                 (not (derived-mode-p 'text-mode 'prog-mode 'conf-mode)))
       (setq doom-localleader-current-major-mode major-mode)
       (set-keymap-parent doom-localleader-map
                          (cdr (assq major-mode doom-localleader-map-alist))))))

--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -240,6 +240,7 @@ localleader prefix."
 (define-key doom-leader-map [override-state] 'all)
 (define-prefix-command 'doom-leader-map)
 (define-prefix-command 'doom-localleader-map)
+(fset 'doom/leader doom-leader-map)     ; For backwards compatibility.
 
 (add-hook! '(after-change-major-mode-hook
              doom-switch-buffer-hook

--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -31,9 +31,6 @@ and Emacs states, and for non-evil users.")
 (defvar doom-localleader-map (make-sparse-keymap)
   "The current major mode's localleader keymap.")
 
-(defvar doom-localleader-current-major-mode nil
-  "The major mode of the current localleader keymap.")
-
 ;;
 ;;; Global keybind settings
 
@@ -242,17 +239,12 @@ localleader prefix."
 (define-prefix-command 'doom-localleader-map)
 (fset 'doom/leader doom-leader-map)     ; For backwards compatibility.
 
-(add-hook! '(after-change-major-mode-hook
-             doom-switch-buffer-hook
-             doom-switch-window-hook
-             doom-switch-frame-hook)
-  (defun doom-init-localleader-key-h ()
-    "Set the localleader keys for the current major-mode."
-    (unless (and (doom-unreal-buffer-p (current-buffer))
-                 (not (derived-mode-p 'text-mode 'prog-mode 'conf-mode)))
-      (setq doom-localleader-current-major-mode major-mode)
-      (set-keymap-parent doom-localleader-map
-                         (cdr (assq major-mode doom-localleader-map-alist))))))
+(defun doom-update-localleader-key-h ()
+  "Set the localleader keys for the current major-mode."
+  (set-keymap-parent doom-localleader-map
+                     (cdr (assq major-mode doom-localleader-map-alist))))
+
+(add-hook 'post-command-hook #'doom-update-localleader-key-h)
 
 ;; Bind `doom-leader-key' and `doom-leader-alt-key' as late as possible to give
 ;; the user a chance to modify them.


### PR DESCRIPTION
This commit moves leader key descriptions from `which-key-replacement-alist` to the keymap itself. This helps with performance because that way, which-key does not have to calculate every single leader key description for each keypress. Furthermore, this fixes issues like #1413 where relocating leader keymaps resulted in which-key not showing the correct leader key descriptions.
 
I also made the leader prefix maps have their own prefix commands by populating the function slot of the keymap variables. This is an Emacs convention. I made `doom-leader-map` follow this convention as well, though I kept the `doom/leader` so as to not break existing configs.