### PR TITLE
bump link-hint for compatability with mu 1.10.x

### DIFF
--- a/modules/config/default/packages.el
+++ b/modules/config/default/packages.el
@@ -3,7 +3,7 @@
 
 (package! avy :pin "955c8dedd68c74f3cf692c1249513f048518c4c9")
 (package! drag-stuff :pin "6d06d846cd37c052d79acd0f372c13006aa7e7c8")
-(package! link-hint :pin "1f9bb60289d87f31f92b86ed22d1f2c0a7af0222")
+(package! link-hint :pin "36ce929331f2838213bcaa1145ece4b73ce84afe")
 
 (unless (modulep! :editor evil)
   (package! expand-region :pin "b70feaa644310dc2d599dc277cd20a1f2b6446ac"))


### PR DESCRIPTION
Addresses #7196 by bumping `link-hint` to include the following commit:
https://github.com/noctuid/link-hint.el/commit/5f51b00546842fee4e37493fa4d81aa66aa54979

Without this change, `link-hint` will fail with `link-hint--apply: Wrong number of arguments` when trying to open links in `mu4e` message buffers on mu 1.10.x. 

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
