### PR TITLE
fix(lsp): check npm when eglot is enabled

### DIFF
--- a/modules/tools/lsp/doctor.el
+++ b/modules/tools/lsp/doctor.el
@@ -4,7 +4,7 @@
                    (modulep! +peek)))
          "+eglot and +peek flags are not compatible. Peek uses lsp-mode, while Eglot is another package altogether for LSP.")
 
-(unless (and (not (modulep! +eglot))
-             (executable-find "npm"))
-  (warn! "Couldn't find npm, most server installers won't work and will have to be installed manually.
-For more information, see https://emacs-lsp.github.io/lsp-mode/page/languages/."))
+(when (modulep! +eglot)
+  (unless (executable-find "npm")
+    (warn! "Couldn't find npm, most server installers won't work and will have to be installed manually.
+For more information, see https://emacs-lsp.github.io/lsp-mode/page/languages/.")))


### PR DESCRIPTION
The logic to check npm existence when `+eglot` flag is enabled is wrong.

### My configuration:
```
(lsp +eglot)
```

### Confirm npm is installed and can be found
- In shell
```shell
❱ which npm
/etc/profiles/per-user/james/bin/npm
```

- In Emacs
```emacs-lisp
(executable-find "npm")
> "/etc/profiles/per-user/james/bin/npm"
```

### Doom doctor 
- Before the fix

```shell
❱ doom doctor
The doctor will see you now...

> Checking your Emacs version...
  ! Detected a development version of Emacs (29.1)
    This is the bleeding edge of Emacs. Doom does not support it because
    Emacs HEAD is in an especially unstable period of its development. If
    you've found a stable commit, great! But be cautious about updating
    too eagerly!
    
    Because development builds are prone to random breakage, there will be
    a greater burden on you to investigate and deal with issues. Please
    make extra sure that your issue is reproducible in 28.1 before
    reporting them to Doom's issue tracker!
    
    If this doesn't phase you, read the "Why does Doom not support Emacs
    HEAD" QnA in Doom's FAQ. It offers some advice for debugging and
    surviving issues on the bleeding edge. Failing that, 28.1 is highly
    recommended and will always be Doom's best supported version of Emacs.
> Checking for Doom's prerequisites...
> Checking for Emacs config conflicts...
> Checking for great Emacs features...
! Emacs was not built with native compilation support
  Users will see a substantial performance gain by building Emacs with
  native compilation support, availible in emacs 28+.You must install a
  prebuilt Emacs binary with this included, or compile Emacs with the
  --with-native-compilation option.
> Checking for private config conflicts...
> Checking for stale elc files...
> Checking for problematic git global settings...
> Checking Doom Emacs...
  ✓ Initialized Doom Emacs 3.0.0-pre
  ✓ Detected 54 modules
  ✓ Detected 210 packages
  > Checking Doom core for irregularities...
    Found font material-design-icons.ttf
    Found font weathericons.ttf
    Found font octicons.ttf
    Found font fontawesome.ttf
    Found font file-icons.ttf
    Found font all-the-icons.ttf
  > Checking for stale elc files in your DOOMDIR...
  > Checking your enabled modules...
    > :tools lsp
      ! Couldn't find npm, most server installers won't work and will have to be installed manually.
        For more information, see https://emacs-lsp.github.io/lsp-mode/page/languages/.

There are 3 warnings!
```

- After the fix
```shell
❱ doom doctor
The doctor will see you now...

> Checking your Emacs version...
  ! Detected a development version of Emacs (29.1)
    This is the bleeding edge of Emacs. Doom does not support it because
    Emacs HEAD is in an especially unstable period of its development. If
    you've found a stable commit, great! But be cautious about updating
    too eagerly!
    
    Because development builds are prone to random breakage, there will be
    a greater burden on you to investigate and deal with issues. Please
    make extra sure that your issue is reproducible in 28.1 before
    reporting them to Doom's issue tracker!
    
    If this doesn't phase you, read the "Why does Doom not support Emacs
    HEAD" QnA in Doom's FAQ. It offers some advice for debugging and
    surviving issues on the bleeding edge. Failing that, 28.1 is highly
    recommended and will always be Doom's best supported version of Emacs.
> Checking for Doom's prerequisites...
> Checking for Emacs config conflicts...
> Checking for great Emacs features...
! Emacs was not built with native compilation support
  Users will see a substantial performance gain by building Emacs with
  native compilation support, availible in emacs 28+.You must install a
  prebuilt Emacs binary with this included, or compile Emacs with the
  --with-native-compilation option.
> Checking for private config conflicts...
> Checking for stale elc files...
> Checking for problematic git global settings...
> Checking Doom Emacs...
  ✓ Initialized Doom Emacs 3.0.0-pre
  ✓ Detected 54 modules
  ✓ Detected 210 packages
  > Checking Doom core for irregularities...
    Found font material-design-icons.ttf
    Found font weathericons.ttf
    Found font octicons.ttf
    Found font fontawesome.ttf
    Found font file-icons.ttf
    Found font all-the-icons.ttf
  > Checking for stale elc files in your DOOMDIR...
  > Checking your enabled modules...

There are 2 warnings!
```