### PR TITLE
fix(multiple-cursors): check evil-local-mode instead of the global one (+multiple-cursors-compat-switch-to-emacs-state-h)

### DIFF
--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -175,12 +175,12 @@
   (when (modulep! :editor evil)
     (evil-define-key* '(normal emacs) mc/keymap [escape] #'mc/keyboard-quit)
 
-    (defvar +mc--compat-evil-prev-state nil)
-    (defvar +mc--compat-mark-was-active nil)
+    (defvar-local +mc--compat-evil-prev-state nil)
+    (defvar-local +mc--compat-mark-was-active nil)
 
     (add-hook! 'multiple-cursors-mode-enabled-hook
       (defun +multiple-cursors-compat-switch-to-emacs-state-h ()
-        (when (and (bound-and-true-p evil-mode)
+        (when (and (bound-and-true-p evil-local-mode)
                    (not (memq evil-state '(insert emacs))))
           (setq +mc--compat-evil-prev-state evil-state)
           (when (region-active-p)
@@ -210,7 +210,7 @@
     ;; how evil deals with regions
     (defadvice! +multiple--cursors-adjust-mark-for-evil-a (&rest _)
       :before #'mc/edit-lines
-      (when (and (bound-and-true-p evil-mode)
+      (when (and (bound-and-true-p evil-local-mode)
                  (not (memq evil-state '(insert emacs))))
         (if (> (point) (mark))
             (goto-char (1- (point)))


### PR DESCRIPTION
For evil compatibility (switching to emacs state during multiple cursors), when evil is enabled locally by evil-local-mode but not globally by evil-mode, using the former to check is more accurate.

Also make the state variables local since MC maybe used for multiple buffers: activate current buffer and while not deactivating here, go to another buffer and activate there.

<!-- ⚠️ Please do not ignore this template! -->

<!-- Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any. -->

<!-- Fixes #0000 -->
<!-- References #0000 -->
<!-- Replaces #0000 -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
