### PR TITLE
Quickload safeguards

### DIFF
--- a/lisp/lib/sessions.el
+++ b/lisp/lib/sessions.el
@@ -67,12 +67,17 @@
 ;;; Commands
 
 ;;;###autoload
-(defun doom/quickload-session ()
-  "TODO"
-  (interactive)
-  (message "Restoring session...")
-  (doom-load-session)
-  (message "Session restored. Welcome back."))
+(defun doom/quickload-session (force)
+  "Load the last session saved.
+If the FORCE \\[universal-argument] is provided
+then no confirmation is asked."
+  (interactive "P")
+  (if (or force
+          (yes-or-no-p "This will wipe your current session, do you want to continue? "))
+      (progn (message "Restoring session...")
+             (doom-load-session)
+             (message "Session restored. Welcome back."))
+    (message "Session not restored.")))
 
 ;;;###autoload
 (defun doom/quicksave-session ()

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -46,21 +46,21 @@ Possible values:
   nil            `default-directory' will never change")
 
 (defvar +doom-dashboard-menu-sections
-  '(("Reload last session"
+  '(("Recently opened files"
+     :icon (all-the-icons-octicon "file-text" :face 'doom-dashboard-menu-title)
+     :face (:inherit (doom-dashboard-menu-title bold))
+     :action recentf-open-files)
+    ("Reload last session"
      :icon (all-the-icons-octicon "history" :face 'doom-dashboard-menu-title)
      :when (cond ((modulep! :ui workspaces)
                   (file-exists-p (expand-file-name persp-auto-save-fname persp-save-dir)))
                  ((require 'desktop nil t)
                   (file-exists-p (desktop-full-file-name))))
-     :face (:inherit (doom-dashboard-menu-title bold))
      :action doom/quickload-session)
     ("Open org-agenda"
      :icon (all-the-icons-octicon "calendar" :face 'doom-dashboard-menu-title)
      :when (fboundp 'org-agenda)
      :action org-agenda)
-    ("Recently opened files"
-     :icon (all-the-icons-octicon "file-text" :face 'doom-dashboard-menu-title)
-     :action recentf-open-files)
     ("Open project"
      :icon (all-the-icons-octicon "briefcase" :face 'doom-dashboard-menu-title)
      :action projectile-switch-project)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This PR adds in a few safeguards when loading sessions. As quickloading a session can be destructive to a current session it makes sense too 
1. remove reload session as the top menu item and replace it with something non destructive (in this case I replaced it with the "Recently used files" action) 
2. ask for confirmation when you do want to restore a session. For good measure I have also allowed for the universal argument to be supplied to bypass this confirmation.

Now this is somewhat opinionated. With the first point its easy to restore. 

```lisp
(setq +doom-dashboard-menu-sections
  '(("Reload last session"
     :icon (all-the-icons-octicon "history" :face 'doom-dashboard-menu-title)
     :when (cond ((modulep! :ui workspaces)
                  (file-exists-p (expand-file-name persp-auto-save-fname persp-save-dir)))
                 ((require 'desktop nil t)
                  (file-exists-p (desktop-full-file-name))))
     :face (:inherit (doom-dashboard-menu-title bold))
     :action doom/quickload-session)
    ("Open org-agenda"
     :icon (all-the-icons-octicon "calendar" :face 'doom-dashboard-menu-title)
     :when (fboundp 'org-agenda)
     :action org-agenda)
    ("Recently opened files"
     :icon (all-the-icons-octicon "file-text" :face 'doom-dashboard-menu-title)
     :action recentf-open-files)
    ("Open project"
     :icon (all-the-icons-octicon "briefcase" :face 'doom-dashboard-menu-title)
     :action projectile-switch-project)
    ("Jump to bookmark"
     :icon (all-the-icons-octicon "bookmark" :face 'doom-dashboard-menu-title)
     :action bookmark-jump)
    ("Open private configuration"
     :icon (all-the-icons-octicon "tools" :face 'doom-dashboard-menu-title)
     :when (file-directory-p doom-user-dir)
     :action doom/open-private-config)
    ("Open documentation"
     :icon (all-the-icons-octicon "book" :face 'doom-dashboard-menu-title)
     :action doom/help)))
```
The second one is harder to restore. If requested a variable can be added to always bypass the confirmation in the long term. In the short term an override advice to just straight up replace the function with its original can be used.

```lisp
(defadvice! restore-no-confirm-session-quickload-a ()
   "Restore the no confirm quickload of workspace sessions"
   :override #'doom/quickload-session
   (message "Restoring session...")
   (doom-load-session)
   (message "Session restored. Welcome back."))
```
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
