### PR TITLE
fix(lib): unquote base-directory in project-file-exists-p!

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -34,7 +34,7 @@
 The project's root is determined by `projectile', starting from BASE-DIRECTORY
 (defaults to `default-directory'). FILES are paths relative to the project root,
 unless they begin with a slash."
-  `(file-exists-p! ,files (doom-project-root base-directory)))
+  `(file-exists-p! ,files (doom-project-root ,base-directory)))
 
 
 ;;


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Unquotes `base-directory` argument added to `project-file-exists-p!` in b1cc719. It was triggering the error (void-variable base-directory).

Fixes #7356

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
