### PR TITLE
snippets module command fixes and enhancements

### DIFF
--- a/modules/editor/snippets/autoload/snippets.el
+++ b/modules/editor/snippets/autoload/snippets.el
@@ -45,25 +45,20 @@ Finds correctly active snippets from parent modes (based on Yas' logic)."
            return it))
 
 (defun +snippet--completing-read-uuid (prompt all-snippets &rest args)
-  (plist-get
-   (text-properties-at
-    0 (apply #'completing-read prompt
-             (cl-loop for (_ . tpl) in (mapcan #'yas--table-templates (if all-snippets
-                                                                          (hash-table-values yas--tables)
-                                                                        (yas--get-snippet-tables)))
+  (let* ((completion-uuid-alist
+          (cl-loop for (_ . tpl) in (mapcan #'yas--table-templates
+                                            (if all-snippets
+                                                (hash-table-values yas--tables)
+                                              (yas--get-snippet-tables)))
 
-                      for txt = (format "%-25s%-30s%s"
-                                        (yas--template-key tpl)
-                                        (yas--template-name tpl)
-                                        (abbreviate-file-name (yas--template-load-file tpl)))
-                      collect
-                      (progn
-                        (set-text-properties 0 (length txt) `(uuid ,(yas--template-uuid tpl)
-                                                                   path ,(yas--template-load-file tpl))
-                                             txt)
-                        txt))
-             args))
-   'uuid))
+                   for txt = (format "%-25s%-30s%s"
+                                     (yas--template-key tpl)
+                                     (yas--template-name tpl)
+                                     (abbreviate-file-name (yas--template-load-file tpl)))
+                   collect
+                   (cons txt (yas--template-uuid tpl))))
+         (completion (apply #'completing-read prompt completion-uuid-alist args)))
+    (alist-get completion completion-uuid-alist nil nil #'string=)))
 
 (defun +snippet--abort ()
   (interactive)

--- a/modules/editor/snippets/autoload/snippets.el
+++ b/modules/editor/snippets/autoload/snippets.el
@@ -67,16 +67,14 @@ Finds correctly active snippets from parent modes (based on Yas' logic)."
     (alist-get completion completion-uuid-alist nil nil #'string=)))
 
 (defun +snippets--snippet-mode-name-completing-read (&optional all-modes)
-  (if all-modes
-      (completing-read
-       "Select snippet mode: "
-       obarray
-       (lambda (sym)
-         (string-match-p "-mode\\'" (symbol-name sym))))
-    (if (not (null yas--extra-modes))
-        (completing-read "Select snippet mode: "
-                         (cons major-mode yas--extra-modes))
-      (symbol-name major-mode))))
+  (cond (all-modes (completing-read
+                    "Select snippet mode: "
+                    obarray
+                    (lambda (sym)
+                      (string-match-p "-mode\\'" (symbol-name sym)))))
+        ((not (null yas--extra-modes)) (completing-read "Select snippet mode: "
+                                                        (cons major-mode yas--extra-modes)))
+        (t (symbol-name major-mode))))
 
 (defun +snippet--abort ()
   (interactive)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I've been playing with the snippets module lately and ran into a couple bugs and some small opportunities for enhancement.

Bugs:
- `+snippet--completing-read-uuid` always returns nil, breaking `+snippets/new-alias`, `+snippets/edit`.
  Rather than attempting to read the uuid from a text property on the selected completion -- which gets stripped by vertico (and possibly helm) -- grab it from a lookup alist of completion-candidat->uuid.

  Essentially the same as the proposed implementation by @jgrey4296 on #4127
- Couple issues related to `default-directory` binding in new and new-alias:
  1. `+snippets--ensure-dir` would error out when default-directory was bound to a non-existent dir. I modified it to return the dir if it already existed or was created and bound its result to `default-directory` afterward instead.
  2. `default-directory` alone wasn't enough for yasnippet to pick up the mode for which to load the new snippet/alias. I resolved this by prompting for a key and setting the new snippet buffer's file name to that in the proper snippet mode directory. Another pleasant side effect is that it makes it a bit more convenient to save to a file after finished writing the snippet.
- Snippets generated by `+snippets/new-alias` didn't work. `(%alias...)` didn't do anything, so I swapped it out for `(doom-snippet-expand ...)`

Enhancements:
- Prevent overwrite of an existing snippet file
- Prompt for mode selection when creating a new snippet. Use major-mode as the default like before, but if there are any yas extra modes in the current buffer, prompt the user for the major mode or one of the extra modes. If an argument is supplied, prompt the user for any mode.

Fixes #4127

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
