### PR TITLE
docs(getting_started.org): installing Nerd Fonts

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -552,7 +552,8 @@ doom env
 
 # Lastly, install the icon fonts Doom uses:
 emacs --batch -f all-the-icons-install-fonts
-# On Windows, `all-the-icons-install-fonts` will only download the fonts, you'll
+emacs --batch -f nerd-icons-install-fonts
+# On Windows, `all-the-icons-install-fonts` and `nerd-icons-install-fonts` will only download the fonts, you'll
 # have to install them by hand afterwards!
 #+END_SRC
 


### PR DESCRIPTION
This PR only updates the Getting Started guide, several modules are still using `all-the-icons`.

### Background
doom-modeline switched from `all-the-icons` to `nerd-icons` (see https://github.com/seagle0128/doom-modeline/pull/622), so new users need to install a default Nerd Fonts. 
### For existing users

If you come to this PR for **missing icons in the mode line**, just call the function in Emacs: `nerd-icons-install-fonts`, it will install the default icon "Symbols Nerd Font Mono" in your system.

If you are using [Nix](https://nixos.org), you can add Nerd Fonts in Nix configuration like following:
```nix
{ pkgs, ... }:

{
  fonts.fontconfig.enable = true;
  home.packages = [
    fontconfig

    # Patched fonts
    (pkgs.nerdfonts.override { fonts = [ "NerdFontsSymbolsOnly" ]; })
  ];
}
```

See https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/data/fonts/nerdfonts/shas.nix for names of Nerd Fonts to add in `fonts`.