### PR TITLE
feat(default): add use consult-man if available

### DIFF
--- a/modules/config/default/autoload/default.el
+++ b/modules/config/default/autoload/default.el
@@ -25,7 +25,8 @@ generate `completing-read' candidates."
   (interactive)
   (call-interactively
    (if (and (not IS-MAC) (executable-find "man"))
-       #'man
+       (or (command-remapping #'man)
+           #'man)
      #'woman)))
 
 ;;;###autoload


### PR DESCRIPTION
`consult-man` is a better version of `man` that computes its candidates asynchronously and allows the user to pass arguments directly to the man command. It's basically like `consult-grep` but for `man`. Before merging this, please double-check that `consult-man` is defined in our pinned version of `consult`.