### PR TITLE
docs: update install instructions for emacs-mac w/ homebrew

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -293,9 +293,11 @@ to least recommended for Doom (based on compatibility).
   with macOS, native emojis and better childframe support.
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
-  brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  brew install emacs-mac --with-modules --with-native-compilation
+  # Optional: Add launcher script to /Applications 
+  osacompile -o /Applications/Emacs.app -e "tell application \"Finder\" to open POSIX file \"$(brew --prefix)/opt/emacs-mac/Emacs.app\""
   #+END_SRC
+  There are other options for installing a helper launcher scripts for [[https://github.com/railwaycat/homebrew-emacsmacport/blob/master/docs/emacs-start-helpers.md][emacs starter helpers]] in the emacs-mac docs
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have
   experienced [flashing artifacts when scrolling](https://github.com/d12frosted/homebrew-emacs-plus/issues/314):


### PR DESCRIPTION
Updated installation to include the --with-native-compilation flag for compatibility with emacs@29.1, which is installed now by default. (The current instructions will create a broken config by default) Updated the command for adding an Emacs.app link to /Applications to a more Mac-ish solution. Added comment explaining that command is optional and linked to other options.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fixes #7054 
References #0000
Replaces #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
