### PR TITLE
fix(lib): doom/help-packages: handle missing homepage

### DIFF
--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -575,7 +575,10 @@ If prefix arg is present, refresh the cache."
                                         (pp-to-string recipe))))
 
            (package--print-help-section "Homepage")
-           (doom--help-insert-button (doom-package-homepage package)))
+           (let ((homepage (doom-package-homepage package)))
+             (if homepage
+                 (doom--help-insert-button homepage)
+               (insert "n/a"))))
 
           (`elpa (insert "[M]ELPA ")
                  (doom--help-insert-button (doom-package-homepage package))


### PR DESCRIPTION
When a package is added via straight local-repo recipe, no homepage can be determined. Prevent `doom--help-insert-button` throwing an error when `help-packages` is called for such a package. Instead insert "n/a" for this section, similar to other sections without data.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
    - while trivial, this fixes an error preventing display of help
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
