### PR TITLE
fix: add pyim-cregexp-utils dependency to modules/input/chinese/config.el

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -1,5 +1,7 @@
 ;;; input/chinese/config.el -*- lexical-binding: t; -*-
 
+(require 'pyim-cregexp-utils)
+
 (use-package! pyim
   :after-call after-find-file pre-command-hook
   :init


### PR DESCRIPTION
hi, I encountered this error after startup: `Symbol's function definition is void: pyim-cregexp-ivy`.

After some research, I found that `pyim-cregexp-ivy` was used in `modules/input/chinese/config.el`, but there is no `pyim-cregexp-utils` imported. So I add the following code at the beginning of `modules/input/chinese/config.el`:

    (require 'pyim-cregexp-utils)

And it fix the problem.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).