### PR TITLE
fix(org): check org-fold-outline in invisible property

### DIFF
--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -168,7 +168,8 @@ selection of all minor-modes, active or not."
                   (location
                    (goto-char location)))
             (ignore-errors
-              (when (outline-invisible-p)
+              (when (memq (get-char-property (point) 'invisible)
+                          '(outline org-fold-outline))
                 (save-excursion
                   (outline-previous-visible-heading 1)
                   (org-show-subtree))))))

--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -371,7 +371,9 @@ see how ARG affects this command."
         (goto-char (point-min))
         (while (not (eobp))
           (org-next-visible-heading 1)
-          (when (outline-invisible-p (line-end-position))
+          (when (memq (get-char-property (line-end-position)
+                                         'invisible)
+                      '(outline org-fold-outline))
             (let ((level (org-outline-level)))
               (when (> level max)
                 (setq max level))))))
@@ -489,7 +491,10 @@ All my (performant) foldings needs are met between this and `org-show-subtree'
                    (or org-cycle-open-archived-trees
                        (not (member org-archive-tag (org-get-tags))))
                    (or (not arg)
-                       (setq invisible-p (outline-invisible-p (line-end-position)))))
+                       (setq invisible-p
+                             (memq (get-char-property (line-end-position)
+                                                      'invisible)
+                                   '(outline org-fold-outline)))))
           (unless invisible-p
             (setq org-cycle-subtree-status 'subtree))
           (org-cycle-internal-local)


### PR DESCRIPTION
This PR addresses https://github.com/doomemacs/doomemacs/issues/7206. Currently, `+org/open-fold` is not working because `(outline-visible-p)` does not check for the `org-fold-outline` property. So I replaced all calls of `(outline-visible-p)` with the redefinition by jesseylin, which checks for `org-fold-outline`.