### PR TITLE
fix(popup): add wdired hacks

### DIFF
--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -375,6 +375,12 @@ Ugh, such an ugly hack."
     (letf! ((#'switch-to-buffer-other-window #'pop-to-buffer))
       (apply fn args))))
 
+;;;###package wdired
+(progn
+  ;; close the popup after you're done with a wdired buffer
+  (advice-add #'wdired-abort-changes :after #'+popup-close-a)
+  (advice-add #'wdired-finish-edit :after #'+popup-close-a))
+
 ;;;###package wgrep
 (progn
   ;; close the popup after you're done with a wgrep buffer


### PR DESCRIPTION
Previously, wdired actions will not close popup windows, which is cumbersome to use. We've already added similar hacks to dired. Now it's time to add similar hacks to wdired.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
