### PR TITLE
docs(cli): add ~/.emacs.d warning

### DIFF
--- a/lisp/cli/doctor.el
+++ b/lisp/cli/doctor.el
@@ -98,9 +98,24 @@ in."
   (print! (start "Checking for Emacs config conflicts..."))
   (when (file-exists-p "~/.emacs")
     (warn! "Detected an ~/.emacs file, which may prevent Doom from loading")
-    (explain! "If Emacs finds an ~/.emacs file, it will ignore ~/.emacs.d, where Doom is "
-              "typically installed. If you're seeing a vanilla Emacs splash screen, this "
+    (explain! "If Emacs finds an ~/.emacs file, it will ignore ~/.emacs.d or ~/.config/emacs, "
+              "where Doom is typically installed. If you're seeing a vanilla Emacs splash screen, this "
               "may explain why. If you use Chemacs, you may ignore this warning."))
+  (when (and (file-exists-p "~/.emacs.d")
+             (file-exists-p "~/.config/emacs"))
+    (if (file-equal-p doom-emacs-dir "~/.emacs.d")
+        (progn
+          (warn! "Detected an ~/.config/emacs directory, which may prevent Doom from loading")
+          (explain! "Emacs will prefer a ~/.emacs.d directory over a ~/.config/emacs when one "
+                    "exists. As Doom is usually cloned to ~/.config/emacs, it may prevent Doom "
+                    "from loading. If you are seeing a vanilla Emacs splash screen, this "
+                    "may be why. If you use Chemacs 2, you may ignore this warning."))
+      (warn! "Detected an ~/.emacs.d directory, which may prevent Doom from loading")
+      (explain! "If Emacs finds a ~/.emacs.d file when Doom is installed in ~/.config/emacs, "
+                "it will ignore Doom in favour of whatever is in ~/.emacs.d. "
+                "If you are seeing a vanilla Emacs splash screen, this may explain why. "
+                "If Doom is installed in ~/.emacs.d then you can ignore this warning. "
+                "If not you need to backup or remove ~/.emacs.d.")))
 
   (print! (start "Checking for great Emacs features..."))
   (unless (functionp 'json-serialize)


### PR DESCRIPTION
Fix: #7292

<!-- ⚠️ Please do not ignore this template! -->

Add in a warning to make sure ~/.emacs.d is not there when both ~/.emacs.d *and* ~/.config/emacs exists
Fixes #7292

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
