### PR TITLE
tweak(irc): check circe-notification is bound

### DIFF
--- a/modules/app/irc/autoload/irc.el
+++ b/modules/app/irc/autoload/irc.el
@@ -55,7 +55,8 @@ workspace for it."
         circe-server-killed-confirmation)
     (when +irc--defer-timer
       (cancel-timer +irc--defer-timer))
-    (disable-circe-notifications)
+    (when (fboundp #'disable-circe-notifications)
+      (disable-circe-notifications))
     (mapc #'kill-buffer (doom-buffers-in-mode 'circe-mode (buffer-list) t))
     (when (modulep! :ui workspaces)
       (when (equal (+workspace-current-name) +irc--workspace-name)

--- a/modules/app/irc/doctor.el
+++ b/modules/app/irc/doctor.el
@@ -1,0 +1,5 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; app/irc/doctor.el
+
+(when (memq 'circe-notifications doom-disabled-packages)
+  (warn! "Circe Notifications has been disabled, You will not receive desktop notifications from IRC channels."))


### PR DESCRIPTION
This PR tweaks the IRC module to make disabling circe notifications not cause an
error. 

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.