### PR TITLE
feat(fortran): `SPC m f o` opens project config

### DIFF
--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -63,7 +63,7 @@ or gfortran, depending on what feature flags are set."
     (_ "")))
 
 ;;;###autoload
-(defun +fortran-compilation-buffer-name-fn (mode)
+(defun +fortran-compilation-buffer-name-fn (_mode)
   "The name of the buffer produced by `compile'."
   "*fortran-compilation*")
 
@@ -115,3 +115,13 @@ or gfortran, depending on what feature flags are set."
   "Test the current project using fpm."
   (interactive)
   (compile "fpm test"))
+
+;;;###autoload
+(defun +fortran/fpm-open-project-toml (project-root)
+  "Open fpm.toml at PROJECT-ROOT (defaults to the open project)."
+  (interactive (list (doom-project-root)))
+  (let ((file (file-name-concat project-root "fpm.toml")))
+    (cond ((file-exists-p file) (find-file file))
+          ((null project-root) (user-error "Not in a project"))
+          (t (user-error "No fpm.toml found at project root (%s)"
+                         (abbreviate-file-name project-root))))))

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -27,7 +27,8 @@
         (:prefix ("f" . "fpm")
          :desc "fpm build" "b" #'+fortran/fpm-build
          :desc "fpm run"   "r" #'+fortran/fpm-run
-         :desc "fpm test"  "t" #'+fortran/fpm-test)
+         :desc "fpm test"  "t" #'+fortran/fpm-test
+         :desc "Open project config" "o" #'+fortran/fpm-open-project-toml)
         (:prefix ("g" . "gfortran")
          :desc "compile" "c" #'+fortran/gfortran-compile
          :desc "run"     "r" #'+fortran/gfortran-run)


### PR DESCRIPTION
This PR adds a new convenience function and binding to the `fortran` module.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
