### PR TITLE
bump: :editor evil

### DIFF
--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/evil/packages.el
 
-(package! evil :pin "9eb69b7f5b3c72cfc66f69b3242e935015780654")
+(package! evil :pin "5fc16776c5eb00c956ec7e9d83facb6a38dd868d")
 (package! evil-args :pin "2671071a4a57eaee7cc8c27b9e4b6fc60fd2ccd3")
 (package! evil-easymotion :pin "f96c2ed38ddc07908db7c3c11bcd6285a3e8c2e9")
 (package! evil-embrace :pin "3081d37811b6a3dfaaf01d578c7ab7a746c6064d")


### PR DESCRIPTION
emacs-evil/evil@9eb69b7f5b3c -> emacs-evil/evil@5fc16776c5eb

Fixes breaking change due to https://github.com/emacs-mirror/emacs/commit/802a54ad620

Ref: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=62248

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
