### PR TITLE
fix(syntax): add elisp flymake load path advice

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -101,6 +101,13 @@ See `+emacs-lisp-non-package-mode' for details.")
   ;;   original in the flycheck instance (see `+emacs-lisp-linter-warnings').
   (add-hook 'flycheck-mode-hook #'+emacs-lisp-non-package-mode)
 
+  (defadvice! +syntax--fix-elisp-flymake-load-path (orig-fn &rest args)
+    "Set load path for elisp byte compilation Flymake backend"
+    :around #'elisp-flymake-byte-compile
+    (let ((elisp-flymake-byte-compile-load-path
+           (append elisp-flymake-byte-compile-load-path load-path)))
+      (apply orig-fn args)))
+
   ;; Enhance elisp syntax highlighting, by highlighting Doom-specific
   ;; constructs, defined symbols, and truncating :pin's in `package!' calls.
   (font-lock-add-keywords


### PR DESCRIPTION
We set `flycheck-emacs-lisp-load-path` to 'inherit, which evaluates `load-path` when spawning the Emacs subprocess. flymake relies on a static variable, hence the advice.

Ref: https://github.com/flycheck/flycheck/blob/e56e30d8c66ffc9776d07740658d3b542c1a8e21/flycheck.el#L8725-L8727
Ref: https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/progmodes/elisp-mode.el?h=emacs-29.1#n2166
Ref: https://emacs.stackexchange.com/questions/48661/how-do-i-get-flymake-to-recognize-files-in-my-load-path

---

We need to set up [+emacs-lisp-non-package-mode](https://github.com/doomemacs/doomemacs/blob/56187fc35af21246b23b8020bc9ffa8cabee1157/modules/lang/emacs-lisp/autoload.el#L278) for flymake as well. A simple approach would be to remove/restore `elisp-flymake-byte-compile` from buffer-local `flymake-diagnostic-functions`; I just don’t know how to go about adding this cleanly. It seems like `modulep!` is avoided in `autoload.el` files.

Edit: I see https://github.com/doomemacs/doomemacs/pull/7341 now and gave that a review. This PR still applies for packaged elisp. If that PR is merged in its current form (with the full new diagnostic function), we can directly modify the load path argument in the new function for non-packaged elisp