### PR TITLE
fix(evil): more reliable window detection

### DIFF
--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -48,7 +48,7 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
     (user-error "Cannot swap a dedicated window"))
   (let* ((this-window (selected-window))
          (this-buffer (current-buffer))
-         (that-window (windmove-find-other-window direction nil this-window))
+         (that-window (window-in-direction direction nil this-window))
          (that-buffer (window-buffer that-window)))
     (when (or (minibufferp that-buffer)
               (window-dedicated-p this-window))


### PR DESCRIPTION
At some point `windmove-find-other-window` stopped loading reliably, such that `SPC w H` would complain of a missing symbol. Indeed navigating to the implementation of `windmove` within Emacs's Lisp we find warnings that `windmove-find-other-window` has mostly been superceded by newer window APIs since 2013, and is implemented in terms of `window-in-direction`.

By using `window-in-direction` directly, the loading problem disappears.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
