### PR TITLE
tweak(vterm): vterm-send-next-key mapped to C-q

### DIFF
--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -17,6 +17,8 @@
   :config
   (set-popup-rule! "^\\*vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
 
+  (map! :map vterm-mode-map "C-q" #'vterm-send-next-key)
+
   ;; Once vterm is dead, the vterm buffer is useless. Why keep it around? We can
   ;; spawn another if want one.
   (setq vterm-kill-buffer-on-exit t)


### PR DESCRIPTION
when using vterm and accidently opening nano (wrong $EDITOR set and using git via cli) closing nano is not possible because sending C-x is not possible.
not even in `<insert-state>`

With `C-q` mapped to `vterm-send-next-key` it's possible to send it via `C-q C-x`