### PR TITLE
docs: use `pacman -Syu` in Arch Linux install instructions

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -158,9 +158,9 @@ dnf install fd-find    # is 'fd' in Fedora <28
 **** Arch Linux
 #+BEGIN_SRC bash
 # required dependencies
-pacman -S git emacs ripgrep
+pacman -Syu git emacs ripgrep
 # optional dependencies
-pacman -S fd
+pacman -Syu fd
 #+END_SRC
 
 The above installs Emacs 27 (at the time of writing).


### PR DESCRIPTION
Use safest pacman incantation, '-Syu'. The outcome in package list state could be okay for a majority, but it's 100% safe to upgrade when installing.

From the Arch wiki:

* https://wiki.archlinux.org/title/Pacman#Installing_packages
* https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported (could happen...)

Trivial docs, no issue.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [ x] I searched the issue tracker and this hasn't been PRed before.


