### PR TITLE
bump: :rss

### DIFF
--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; app/rss/packages.el
 
-(package! elfeed :pin "162d7d545ed41c27967d108c04aa31f5a61c8e16")
+(package! elfeed :pin "55fb162fa27e71b88effa59a83c57842e262b00f")
 (package! elfeed-goodies :pin "544ef42ead011d960a0ad1c1d34df5d222461a6b")
 (when (modulep! +org)
   (package! elfeed-org :pin "3242ec0519800a58f20480c8a6e3b3337d137084"))


### PR DESCRIPTION
This fixes a warning raised by Emacs 29 regarding the setting of `point` via `setf` in CL-style, which is now deprecated.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.



