### PR TITLE
refactor!: replace all-the-icons with nerd-icons

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -551,9 +551,7 @@ doom sync
 doom env
 
 # Lastly, install the icon fonts Doom uses:
-emacs --batch -f all-the-icons-install-fonts
-# On Windows, `all-the-icons-install-fonts` will only download the fonts, you'll
-# have to install them by hand afterwards!
+emacs --batch -f nerd-icons-install-fonts
 #+END_SRC
 
 To understand the purpose of the =~/.doom.d= directory and =~/.doom.d/init.el=

--- a/lisp/cli/doctor.el
+++ b/lisp/cli/doctor.el
@@ -205,13 +205,13 @@ in."
           ;; Check for fonts
           (if (not (executable-find "fc-list"))
               (warn! "Warning: unable to detect fonts because fontconfig isn't installed")
-            ;; all-the-icons fonts
+            ;; nerd-icons fonts
             (when (and (pcase system-type
                          (`gnu/linux (concat (or (getenv "XDG_DATA_HOME")
                                                  "~/.local/share")
                                              "/fonts/"))
                          (`darwin "~/Library/Fonts/"))
-                       (require 'all-the-icons nil t))
+                       (require 'nerd-icons nil t))
               (with-temp-buffer
                 (let ((errors 0))
                   (cl-destructuring-bind (status . output)
@@ -219,13 +219,13 @@ in."
                     (if (not (zerop status))
                         (print! (error "There was an error running `fc-list'. Is fontconfig installed correctly?"))
                       (insert (cdr (doom-call-process "fc-list" "" "file")))
-                      (dolist (font all-the-icons-font-names)
+                      (dolist (font nerd-icons-font-names)
                         (if (save-excursion (re-search-backward font nil t))
                             (success! "Found font %s" font)
                           (print! (warn "Warning: couldn't find %S font") font)))
                       (when (> errors 0)
-                        (explain! "Some all-the-icons fonts were missing.\n\n"
-                                  "You can install them by running `M-x all-the-icons-install-fonts' within Emacs.\n"
+                        (explain! "Some nerd-icons fonts were missing.\n\n"
+                                  "You can install them by running `M-x nerd-icons-install-fonts' within Emacs.\n"
                                   "This could also mean you've installed them in non-standard locations, in which "
                                   "case feel free to ignore this warning.")))))))))
 

--- a/lisp/cli/install.el
+++ b/lisp/cli/install.el
@@ -19,7 +19,7 @@
      (config?  ("--config" :yes)  "Create `$DOOMDIR' or dummy files therein?")
      (envfile? ("--env" :yes)     "(Re)generate an envvars file? (see `$ doom help env`)")
      (install? ("--install" :yes) "Auto-install packages?")
-     (fonts?   ("--fonts" :yes)   "Install (or prompt to install) all-the-icons fonts?")
+     (fonts?   ("--fonts" :yes)   "Install (or prompt to install) nerd-icons fonts?")
      (hooks?   ("--hooks" :yes)   "Deploy Doom's git hooks to itself?")
      &context context)
   "Installs and sets up Doom Emacs for the first time.
@@ -32,7 +32,7 @@ This command does the following:
   3. Creates dummy files for `$DOOMDIR'/{config,packages}.el,
   4. Prompts you to generate an envvar file (same as `$ doom env`),
   5. Installs any dependencies of enabled modules (specified by `$DOOMDIR'/init.el),
-  6. And prompts to install all-the-icons' fonts
+  6. And prompts to install nerd-icons' fonts
 
 This command is idempotent and safe to reuse.
 
@@ -109,22 +109,6 @@ Change `$DOOMDIR' with the `--doomdir' option, e.g.
            (call! `(ci deploy-hooks ,@(if yes? '("--force"))))
          ('user-error
           (print! (warn "%s") (error-message-string e))))))
-
-    (cond ((eq fonts? :no))
-          (IS-WINDOWS
-           (print! (warn "Doom cannot install all-the-icons' fonts on Windows!\n"))
-           (print-group!
-            (print!
-             (concat "You'll have to do so manually:\n\n"
-                     "  1. Launch Doom Emacs\n"
-                     "  2. Execute 'M-x all-the-icons-install-fonts' to download the fonts\n"
-                     "  3. Open the download location in windows explorer\n"
-                     "  4. Open each font file to install them"))))
-          ((or yes? (y-or-n-p "Download and install all-the-icon's fonts?"))
-           (require 'all-the-icons)
-           (let ((window-system (cond (IS-MAC 'ns)
-                                      (IS-LINUX 'x))))
-             (all-the-icons-install-fonts 'yes))))
 
     (when (file-exists-p "~/.emacs")
       (print! (warn "A ~/.emacs file was detected. This conflicts with Doom and should be deleted!")))

--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -419,41 +419,17 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 ;;
 ;;; Third party packages
 
-(use-package! all-the-icons
-  :commands (all-the-icons-octicon
-             all-the-icons-faicon
-             all-the-icons-fileicon
-             all-the-icons-wicon
-             all-the-icons-material
-             all-the-icons-alltheicon)
-  :preface
-  (add-hook! 'after-setting-font-hook
-    (defun doom-init-all-the-icons-fonts-h ()
-      (when (fboundp 'set-fontset-font)
-        (dolist (font (list "Weather Icons"
-                            "github-octicons"
-                            "FontAwesome"
-                            "all-the-icons"
-                            "file-icons"
-                            "Material Icons"))
-          (set-fontset-font t 'unicode font nil 'append)))))
-  :config
-  (cond ((daemonp)
-         (defadvice! doom--disable-all-the-icons-in-tty-a (fn &rest args)
-           "Return a blank string in tty Emacs, which doesn't support multiple fonts."
-           :around '(all-the-icons-octicon all-the-icons-material
-                     all-the-icons-faicon all-the-icons-fileicon
-                     all-the-icons-wicon all-the-icons-alltheicon)
-           (if (or (not after-init-time) (display-multi-font-p))
-               (apply fn args)
-             "")))
-        ((not (display-graphic-p))
-         (defadvice! doom--disable-all-the-icons-in-tty-a (&rest _)
-           "Return a blank string for tty users."
-           :override '(all-the-icons-octicon all-the-icons-material
-                       all-the-icons-faicon all-the-icons-fileicon
-                       all-the-icons-wicon all-the-icons-alltheicon)
-           ""))))
+(use-package! nerd-icons
+  :commands (nerd-icons-octicon
+             nerd-icons-faicon
+             nerd-icons-flicon
+             nerd-icons-wicon
+             nerd-icons-mdicon
+             nerd-icons-codicon
+             nerd-icons-devicon
+             nerd-icons-ipsicon
+             nerd-icons-pomicon
+             nerd-icons-powerline))
 
 ;; Hide the mode line in completion popups and MAN pages because they serve
 ;; little purpose there, and is better hidden.

--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -36,7 +36,7 @@ Must be a `font-spec', a font object, an XFT font string, or an XLFD string. See
 
 An omitted font size means to inherit `doom-font''s size.")
 
-(defvar doom-unicode-font nil
+(defvar doom-unicode-font (font-spec :family "Symbols Nerd Font Mono")
   "Fallback font for Unicode glyphs.
 Must be a `font-spec', a font object, an XFT font string, or an XLFD string. See
 `doom-font' for examples.

--- a/lisp/lib/docs.el
+++ b/lisp/lib/docs.el
@@ -102,7 +102,7 @@
   "Create a header link according to SPEC."
   (let ((icon (and (plist-get spec :icon)
                    (funcall (or (plist-get spec :icon-function)
-                                #'all-the-icons-material)
+                                #'nerd-icons-material)
                             (plist-get spec :icon))))
         (label (pcase (plist-get spec :label)
                  ((and (pred functionp) lab)

--- a/lisp/lib/system.el
+++ b/lisp/lib/system.el
@@ -52,8 +52,8 @@
   (with-memoization (get 'doom-system-distro-icon 'cached-value)
     (propertize
      (pcase (doom-system-distro)
-       (`windows (all-the-icons-faicon "windows"))
-       (`macos (all-the-icons-faicon "apple"))
+       (`windows (nerd-icons-faicon "nf-fa-windows"))
+       (`macos (nerd-icons-faicon "nf-fa-apple"))
        (`arch "\uF303")
        (`debian "\uF306")
        (`raspbian "\uF315")
@@ -74,7 +74,7 @@
        (`devuan "\uF307")
        (`manjaro "\uF312")
        ((or `void `artix) "\uF17c")
-       (_ (all-the-icons-faicon "linux")))
+       (_ (nerd-icons-faicon "nf-fa-linux")))
      'face '(:height 1)
      'display '(raise 0))))
 

--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -21,6 +21,7 @@
 
 ;; doom-ui.el
 (package! all-the-icons :pin "be9d5dcda9c892e8ca1535e288620eec075eb0be")
+(package! nerd-icons :pin "619a0382d2e159f3142c4200fe4cfc2e89247ef1")
 (package! hide-mode-line :pin "bc5d293576c5e08c29e694078b96a5ed85631942")
 (package! highlight-numbers :pin "8b4744c7f46c72b1d3d599d4fb75ef8183dee307")
 (package! rainbow-delimiters :pin "f40ece58df8b2f0fb6c8576b527755a552a5e763")

--- a/modules/README.org
+++ b/modules/README.org
@@ -330,7 +330,7 @@ Modules that turn Emacs in an email client.
 
 This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]].
 
-- Tidied mu4e headers view, with flags from [[doom-package:all-the-icons]].
+- Tidied mu4e headers view, with flags from [[doom-package:nerd-icons]].
 - Consistent coloring of reply depths (across compose and gnus modes).
 - Prettified =mu4e:main= view.
 - Cooperative locking of the =mu= process. Another Emacs instance may request
@@ -1152,8 +1152,8 @@ you'd expect from IDEs, like code completion, realtime linting, language-aware
 
 As of this writing, this is the state of LSP support in Doom Emacs:
 
-| Module           | Major modes                                             | Default language server                                       |
-|------------------+---------------------------------------------------------+---------------------------------------------------------------|
+| Module                           | Major modes                                             | Default language server                                       |
+|----------------------------------+---------------------------------------------------------+---------------------------------------------------------------|
 | [[doom-module::lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls, clangd                                                  |
 | [[doom-module::lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
 | [[doom-module::lang csharp]]     | csharp-mode                                             | omnisharp                                                     |

--- a/modules/app/everywhere/config.el
+++ b/modules/app/everywhere/config.el
@@ -20,7 +20,7 @@
        (doom-modeline-spc)
        (when (emacs-everywhere-markdown-p)
          (concat
-          (all-the-icons-octicon "markdown" :face 'all-the-icons-green :v-adjust 0.02)
+          (nerd-icons-octicon "nf-oct-markdown" :face 'nerd-icons-green :v-adjust 0.02)
           (doom-modeline-spc)))
        (propertize (emacs-everywhere-app-class emacs-everywhere-current-app)
                    'face 'doom-modeline-project-dir)

--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -97,47 +97,46 @@
   :config
   (setq company-box-show-single-candidate t
         company-box-backends-colors nil
-        company-box-max-candidates 50
-        company-box-icons-alist 'company-box-icons-all-the-icons
+        company-box-tooltip-limit 50
+        company-box-icons-alist 'company-box-icons-nerd-icons
         ;; Move company-box-icons--elisp to the end, because it has a catch-all
         ;; clause that ruins icons from other backends in elisp buffers.
         company-box-icons-functions
         (cons #'+company-box-icons--elisp-fn
               (delq 'company-box-icons--elisp
                     company-box-icons-functions))
-        company-box-icons-all-the-icons
-        (let ((all-the-icons-scale-factor 0.8))
-          `((Unknown       . ,(all-the-icons-material "find_in_page"             :face 'all-the-icons-purple))
-            (Text          . ,(all-the-icons-material "text_fields"              :face 'all-the-icons-green))
-            (Method        . ,(all-the-icons-material "functions"                :face 'all-the-icons-red))
-            (Function      . ,(all-the-icons-material "functions"                :face 'all-the-icons-red))
-            (Constructor   . ,(all-the-icons-material "functions"                :face 'all-the-icons-red))
-            (Field         . ,(all-the-icons-material "functions"                :face 'all-the-icons-red))
-            (Variable      . ,(all-the-icons-material "adjust"                   :face 'all-the-icons-blue))
-            (Class         . ,(all-the-icons-material "class"                    :face 'all-the-icons-red))
-            (Interface     . ,(all-the-icons-material "settings_input_component" :face 'all-the-icons-red))
-            (Module        . ,(all-the-icons-material "view_module"              :face 'all-the-icons-red))
-            (Property      . ,(all-the-icons-material "settings"                 :face 'all-the-icons-red))
-            (Unit          . ,(all-the-icons-material "straighten"               :face 'all-the-icons-red))
-            (Value         . ,(all-the-icons-material "filter_1"                 :face 'all-the-icons-red))
-            (Enum          . ,(all-the-icons-material "plus_one"                 :face 'all-the-icons-red))
-            (Keyword       . ,(all-the-icons-material "filter_center_focus"      :face 'all-the-icons-red))
-            (Snippet       . ,(all-the-icons-material "short_text"               :face 'all-the-icons-red))
-            (Color         . ,(all-the-icons-material "color_lens"               :face 'all-the-icons-red))
-            (File          . ,(all-the-icons-material "insert_drive_file"        :face 'all-the-icons-red))
-            (Reference     . ,(all-the-icons-material "collections_bookmark"     :face 'all-the-icons-red))
-            (Folder        . ,(all-the-icons-material "folder"                   :face 'all-the-icons-red))
-            (EnumMember    . ,(all-the-icons-material "people"                   :face 'all-the-icons-red))
-            (Constant      . ,(all-the-icons-material "pause_circle_filled"      :face 'all-the-icons-red))
-            (Struct        . ,(all-the-icons-material "streetview"               :face 'all-the-icons-red))
-            (Event         . ,(all-the-icons-material "event"                    :face 'all-the-icons-red))
-            (Operator      . ,(all-the-icons-material "control_point"            :face 'all-the-icons-red))
-            (TypeParameter . ,(all-the-icons-material "class"                    :face 'all-the-icons-red))
-            (Template      . ,(all-the-icons-material "short_text"               :face 'all-the-icons-green))
-            (ElispFunction . ,(all-the-icons-material "functions"                :face 'all-the-icons-red))
-            (ElispVariable . ,(all-the-icons-material "check_circle"             :face 'all-the-icons-blue))
-            (ElispFeature  . ,(all-the-icons-material "stars"                    :face 'all-the-icons-orange))
-            (ElispFace     . ,(all-the-icons-material "format_paint"             :face 'all-the-icons-pink)))))
+        company-box-icons-nerd-icons
+        `((Unknown        . ,(nerd-icons-codicon  "nf-cod-code"                :face  'font-lock-warning-face))
+          (Text           . ,(nerd-icons-codicon  "nf-cod-text_size"           :face  'font-lock-doc-face))
+          (Method         . ,(nerd-icons-codicon  "nf-cod-symbol_method"       :face  'font-lock-function-name-face))
+          (Function       . ,(nerd-icons-codicon  "nf-cod-symbol_method"       :face  'font-lock-function-name-face))
+          (Constructor    . ,(nerd-icons-codicon  "nf-cod-triangle_right"      :face  'font-lock-function-name-face))
+          (Field          . ,(nerd-icons-codicon  "nf-cod-symbol_field"        :face  'font-lock-variable-name-face))
+          (Variable       . ,(nerd-icons-codicon  "nf-cod-symbol_variable"     :face  'font-lock-variable-name-face))
+          (Class          . ,(nerd-icons-codicon  "nf-cod-symbol_class"        :face  'font-lock-type-face))
+          (Interface      . ,(nerd-icons-codicon  "nf-cod-symbol_interface"    :face  'font-lock-type-face))
+          (Module         . ,(nerd-icons-codicon  "nf-cod-file_submodule"      :face  'font-lock-preprocessor-face))
+          (Property       . ,(nerd-icons-codicon  "nf-cod-symbol_property"     :face  'font-lock-variable-name-face))
+          (Unit           . ,(nerd-icons-codicon  "nf-cod-symbol_ruler"        :face  'font-lock-constant-face))
+          (Value          . ,(nerd-icons-codicon  "nf-cod-symbol_field"        :face  'font-lock-builtin-face))
+          (Enum           . ,(nerd-icons-codicon  "nf-cod-symbol_enum"         :face  'font-lock-builtin-face))
+          (Keyword        . ,(nerd-icons-codicon  "nf-cod-symbol_keyword"      :face  'font-lock-keyword-face))
+          (Snippet        . ,(nerd-icons-codicon  "nf-cod-symbol_snippet"      :face  'font-lock-string-face))
+          (Color          . ,(nerd-icons-codicon  "nf-cod-symbol_color"        :face  'success))
+          (File           . ,(nerd-icons-codicon  "nf-cod-symbol_file"         :face  'font-lock-string-face))
+          (Reference      . ,(nerd-icons-codicon  "nf-cod-references"          :face  'font-lock-variable-name-face))
+          (Folder         . ,(nerd-icons-codicon  "nf-cod-folder"              :face  'font-lock-variable-name-face))
+          (EnumMember     . ,(nerd-icons-codicon  "nf-cod-symbol_enum_member"  :face  'font-lock-builtin-face))
+          (Constant       . ,(nerd-icons-codicon  "nf-cod-symbol_constant"     :face  'font-lock-constant-face))
+          (Struct         . ,(nerd-icons-codicon  "nf-cod-symbol_structure"    :face  'font-lock-variable-name-face))
+          (Event          . ,(nerd-icons-codicon  "nf-cod-symbol_event"        :face  'font-lock-warning-face))
+          (Operator       . ,(nerd-icons-codicon  "nf-cod-symbol_operator"     :face  'font-lock-comment-delimiter-face))
+          (TypeParameter  . ,(nerd-icons-codicon  "nf-cod-list_unordered"      :face  'font-lock-type-face))
+          (Template       . ,(nerd-icons-codicon  "nf-cod-symbol_snippet"      :face  'font-lock-string-face))
+          (ElispFunction  . ,(nerd-icons-codicon  "nf-cod-symbol_method"       :face  'font-lock-function-name-face))
+          (ElispVariable  . ,(nerd-icons-codicon  "nf-cod-symbol_variable"     :face  'font-lock-variable-name-face))
+          (ElispFeature   . ,(nerd-icons-codicon  "nf-cod-globe"               :face  'font-lock-builtin-face))
+          (ElispFace      . ,(nerd-icons-codicon  "nf-cod-symbol_color"        :face  'success))))
 
   ;; HACK Fix oversized scrollbar in some odd cases
   ;; REVIEW `resize-mode' is deprecated and may stop working in the future.

--- a/modules/completion/helm/README.org
+++ b/modules/completion/helm/README.org
@@ -22,7 +22,7 @@ For official documentation about Helm, see:
   Enable fuzzy completion for Helm searches.
 - +icons ::
   Display icons on completion results (where possible) using either
-  [[doom-package:all-the-icons]] or [[doom-package:treemacs]] iconsets.
+  [[doom-package:nerd-icons]] or [[doom-package:treemacs]] iconsets.
 
 ** Packages
 - [[doom-package:helm]]
@@ -74,18 +74,18 @@ its highlights will be covered here.
 ** Jump-to navigation
 Similar to Ivy, this module provides an interface to navigate within a project
 using [[doom-package:projectile]]:
-| Keybind          | Description                                             |
-|------------------+---------------------------------------------------------|
+| Keybind                              | Description                                           |
+|--------------------------------------+-------------------------------------------------------|
 | [[kbd:][SPC p f]], [[kbd:][SPC SPC]] | Jump to file in project (~+helm/projectile-find-file~)  |
 | [[kbd:][SPC f f]], [[kbd:][SPC .]]   | Jump to file from current directory (~helm-find-files~) |
-| [[kbd:][SPC s i]]          | Jump to symbol in file (~helm-semantic-or-imenu~)       |
+| [[kbd:][SPC s i]]                    | Jump to symbol in file (~helm-semantic-or-imenu~)       |
 
 ** Project search & replace
 This module also provides interactive text search and replace using [[https://github.com/BurntSushi/ripgrep][Ripgrep]].
 
 *** Search
-| Keybind | Description                                               |
-|---------+-----------------------------------------------------------|
+| Keybind           | Description                                             |
+|-------------------+---------------------------------------------------------|
 | [[kbd:][SPC s p]] | Search project (~+default/search-project~)                |
 | [[kbd:][SPC s P]] | Search another project  (~+default/search-other-project~) |
 | [[kbd:][SPC s d]] | Search this directory (~+default/search-cwd~)             |
@@ -96,8 +96,8 @@ otherwise) changes the behavior of these commands, instructing the underlying
 search engine to include ignored files.
 
 This module also provides Ex Commands for evil users:
-| Ex command             | Description                                                      |
-|------------------------+------------------------------------------------------------------|
+| Ex command           | Description                                                    |
+|----------------------+----------------------------------------------------------------|
 | ~:pg[rep][!] [QUERY]~  | Search project (if ~!~, include hidden files)                    |
 | ~:pg[rep]d[!] [QUERY]~ | Search from current directory (if ~!~, don't search recursively) |
 
@@ -106,8 +106,8 @@ commands.
 
 *** Replace
 These keybindings are available while a search is active:
-| Keybind | Description                                   |
-|---------+-----------------------------------------------|
+| Keybind           | Description                                   |
+|-------------------+-----------------------------------------------|
 | [[kbd:][C-c C-o]] | Open a buffer with your search results        |
 | [[kbd:][C-c C-e]] | Open a writable buffer of your search results |
 | [[kbd:][C-SPC]]   | Preview the current candidate                 |
@@ -131,31 +131,31 @@ A [[doom-package:wgrep]] buffer can be opened from swiper with [[kbd:][C-c C-e]]
 Helm also has a number of overrides for built-in functionality:
 
 *** General
-| Keybind    | Description               |
-|------------+---------------------------|
+| Keybind                        | Description               |
+|--------------------------------+---------------------------|
 | [[kbd:][M-x]], [[kbd:][SPC :]] | Smarter, smex-powered M-x |
-| [[kbd:][SPC ']]      | Resume last ivy session   |
+| [[kbd:][SPC ']]                | Resume last ivy session   |
 
 *** Jump to files, buffers or projects
-| Keybind | Description                                                          |
-|---------+----------------------------------------------------------------------|
-| [[kbd:][SPC p t]] | List all TODO/FIXMEs in project                                      |
+| Keybind           | Description                                                        |
+|-------------------+--------------------------------------------------------------------|
+| [[kbd:][SPC p t]] | List all TODO/FIXMEs in project                                    |
 | [[kbd:][SPC s b]] | Search the current buffer (~+default/search-buffer~)                 |
 | [[kbd:][SPC s d]] | Search this directory (~+default/search-cwd~)                        |
 | [[kbd:][SPC s D]] | Search another directory (~+default/search-other-cwd~)               |
-| [[kbd:][SPC s i]] | Search for symbol in current buffer                                  |
+| [[kbd:][SPC s i]] | Search for symbol in current buffer                                |
 | [[kbd:][SPC s p]] | Search project (~+default/search-project~)                           |
 | [[kbd:][SPC s P]] | Search another project (~+default/search-other-project~)             |
 | [[kbd:][SPC s s]] | Search the current buffer (incrementally) (~+default/search-buffer~) |
 
 *** Search
-| Keybind | Description                                                          |
-|---------+----------------------------------------------------------------------|
-| [[kbd:][SPC p t]] | List all TODO/FIXMEs in project                                      |
+| Keybind           | Description                                                        |
+|-------------------+--------------------------------------------------------------------|
+| [[kbd:][SPC p t]] | List all TODO/FIXMEs in project                                    |
 | [[kbd:][SPC s b]] | Search the current buffer (~+default/search-buffer~)                 |
 | [[kbd:][SPC s d]] | Search this directory (~+default/search-cwd~)                        |
 | [[kbd:][SPC s D]] | Search another directory (~+default/search-other-cwd~)               |
-| [[kbd:][SPC s i]] | Search for symbol in current buffer                                  |
+| [[kbd:][SPC s i]] | Search for symbol in current buffer                                |
 | [[kbd:][SPC s p]] | Search project (~+default/search-project~)                           |
 | [[kbd:][SPC s P]] | Search another project (~+default/search-other-project~)             |
 | [[kbd:][SPC s s]] | Search the current buffer (incrementally) (~+default/search-buffer~) |
@@ -182,9 +182,9 @@ makes sense to exempt ~foo~ with the following:
 
 ** Icons
 There are two icon "themes" available for this module:
-[[doom-package:all-the-icons]] and [[doom-package:treemacs]]. By default, and to
+[[doom-package:nerd-icons]] and [[doom-package:treemacs]]. By default, and to
 maintain consistency with other icons across Doom's modules,
-[[doom-package:all-the-icons]] is used. To change this:
+[[doom-package:nerd-icons]] is used. To change this:
 #+begin_src emacs-lisp
 ;; add to $DOOMDIR/config.el
 (after! helm

--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -195,7 +195,4 @@ Can be negative.")
   :when (modulep! +icons)
   :hook (helm-mode . helm-icons-enable)
   :init
-  (setq helm-icons-provider 'all-the-icons)
-  :config
-  (when (eq helm-icons-provider 'all-the-icons)
-    (setq helm-icons-mode->icon nil)))
+  (setq helm-icons-provider 'nerd-icons))

--- a/modules/completion/helm/packages.el
+++ b/modules/completion/helm/packages.el
@@ -15,6 +15,6 @@
 (when (modulep! +fuzzy)
   (package! helm-flx :pin "5220099e695a3586dba2d59640217fe378e66310"))
 (when (modulep! +icons)
-  (package! helm-icons :pin "8d2f5e705c8b78a390677cf242024739c932fc95"))
+  (package! helm-icons :pin "53349000b114b2dfc874252de6605e3bafa435e2"))
 (when (modulep! :lang org)
   (package! helm-org :pin "d67186d3a64e610c03a5f3d583488f018fb032e4"))

--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -27,7 +27,7 @@ lighter, simpler and faster in many cases.
   Enable prescient filtering and sorting for Ivy searches.
 
 ** Packages
-- [[doom-package:all-the-icons-ivy]]* if [[doom-module:+icons]]
+- [[doom-package:nerd-icons-ivy]]* if [[doom-module:+icons]]
 - [[doom-package:amx]]
 - [[doom-package:counsel]]
 - [[doom-package:counsel-projectile]]

--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -35,22 +35,6 @@ Buffers that are considered unreal (see `doom-real-buffer-p') are dimmed with
           (candidate))))
 
 ;;;###autoload
-(defun +ivy-rich-buffer-icon (candidate)
-  "Display the icon for CANDIDATE buffer."
-  ;; NOTE This is inspired by `all-the-icons-ivy-buffer-transformer', minus the
-  ;; buffer name and extra padding as those are handled by `ivy-rich'.
-  (propertize "\t" 'display
-              (if-let* ((buffer (get-buffer candidate))
-                        (mode (buffer-local-value 'major-mode buffer)))
-                  (or
-                   (all-the-icons-ivy--icon-for-mode mode)
-                   (all-the-icons-ivy--icon-for-mode (get mode 'derived-mode-parent))
-                   (funcall
-                    all-the-icons-ivy-family-fallback-for-buffer
-                    all-the-icons-ivy-name-fallback-for-buffer))
-                (all-the-icons-icon-for-file candidate))))
-
-;;;###autoload
 (defun +ivy-rich-describe-variable-transformer (cand)
   "Previews the value of the variable in the minibuffer"
   (let* ((sym (intern cand))

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -116,12 +116,6 @@ results buffer.")
   :config
   (setq ivy-rich-parse-remote-buffer nil)
 
-  (when (modulep! +icons)
-    (cl-pushnew '(+ivy-rich-buffer-icon)
-                (cadr (plist-get ivy-rich-display-transformers-list
-                                 'ivy-switch-buffer))
-                :test #'equal))
-
   (defun ivy-rich-bookmark-filename-or-empty (candidate)
     (let ((filename (ivy-rich-bookmark-filename candidate)))
       (if (not filename) "" filename)))
@@ -155,25 +149,15 @@ results buffer.")
               (switch-buffer-alist (assq 'ivy-rich-candidate (plist-get plist :columns))))
     (setcar switch-buffer-alist '+ivy-rich-buffer-name))
 
+  (nerd-icons-ivy-rich-mode +1)
   (ivy-rich-mode +1)
   (ivy-rich-project-root-cache-mode +1))
 
 
-(use-package! all-the-icons-ivy
+(use-package! nerd-icons-ivy-rich
   :when (modulep! +icons)
-  :after ivy
-  :config
-  ;; `all-the-icons-ivy' is incompatible with ivy-rich's switch-buffer
-  ;; modifications, so we disable them and merge them ourselves
-  (setq all-the-icons-ivy-buffer-commands nil)
-
-  (all-the-icons-ivy-setup)
-  (after! counsel-projectile
-    (let ((all-the-icons-ivy-file-commands
-           '(counsel-projectile
-             counsel-projectile-find-file
-             counsel-projectile-find-dir)))
-      (all-the-icons-ivy-setup))))
+  :commands (nerd-icons-ivy-rich-mode)
+  :after counsel-projectile)
 
 
 (use-package! counsel
@@ -314,7 +298,7 @@ results buffer.")
 
 
 (use-package! counsel-projectile
-  :defer t
+  :after ivy-rich
   :init
   (define-key!
     [remap projectile-find-file]        #'+ivy/projectile-find-file

--- a/modules/completion/ivy/packages.el
+++ b/modules/completion/ivy/packages.el
@@ -21,4 +21,4 @@
   (package! ivy-posframe :pin "533a8e368fcabfd534761a5c685ce713376fa594"))
 
 (when (modulep! +icons)
-  (package! all-the-icons-ivy :pin "a70cbfa1effe36efc946a823a580cec686d5e88d"))
+  (package! nerd-icons-ivy-rich :pin "7197614b27fd562e64b11c91d41bed4443aded90"))

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -31,7 +31,7 @@ like [[doom-package:ivy]] and [[doom-package:helm]] do. The primary packages are
   Add icons to =file= and =buffer= category completion selections.
 
 ** Packages
-- [[doom-package:all-the-icons-completion]] if [[doom-module:+icons]]
+- [[doom-package:nerd-icons-completion]] if [[doom-module:+icons]]
 - [[doom-package:consult]]
 - [[doom-package:consult-flycheck]] if [[doom-module::checkers syntax]]
 - [[doom-package:embark]]
@@ -76,16 +76,16 @@ Doom-specific additions:
 When in an active Vertico completion session, the following doom added
 keybindings are available:
 
-| Keybind           | Description                                                    |
-|-------------------+----------------------------------------------------------------|
-| [[kbd:][C-k]]               | (evil) Go to previous candidate                                |
-| [[kbd:][C-j]]               | (evil) Go to next candidate                                    |
-| [[kbd:][C-M-k]]             | (evil) Go to previous group                                    |
-| [[kbd:][C-M-j]]             | (evil) Go to next group                                        |
+| Keybind                               | Description                                                  |
+|---------------------------------------+--------------------------------------------------------------|
+| [[kbd:][C-k]]                         | (evil) Go to previous candidate                              |
+| [[kbd:][C-j]]                         | (evil) Go to next candidate                                  |
+| [[kbd:][C-M-k]]                       | (evil) Go to previous group                                  |
+| [[kbd:][C-M-j]]                       | (evil) Go to next group                                      |
 | [[kbd:][C-;]] or [[kbd:][<leader> a]] | Open an ~embark-act~ menu to chose a useful action             |
-| [[kbd:][C-c C-;]]           | export the current candidate list to a buffer                  |
-| [[kbd:][C-c C-l]]           | ~embark-collect~ the current candidate list (collect verbatim) |
-| [[kbd:][C-SPC]]             | Preview the current candidate                                  |
+| [[kbd:][C-c C-;]]                     | export the current candidate list to a buffer                |
+| [[kbd:][C-c C-l]]                     | ~embark-collect~ the current candidate list (collect verbatim) |
+| [[kbd:][C-SPC]]                       | Preview the current candidate                                |
 
 ~embark-act~ will prompt you with a =which-key= menu with useful commands on the
 selected candidate or candidate list, depending on the completion category. Note
@@ -99,17 +99,17 @@ This module provides an interface to navigate within a project using
 
 https://assets.doomemacs.org/completion/vertico/projectile.png
 
-| Keybind          | Description                         |
-|------------------+-------------------------------------|
+| Keybind                              | Description                         |
+|--------------------------------------+-------------------------------------|
 | [[kbd:][SPC p f]], [[kbd:][SPC SPC]] | Jump to file in project             |
 | [[kbd:][SPC f f]], [[kbd:][SPC .]]   | Jump to file from current directory |
-| [[kbd:][SPC s i]]          | Jump to symbol in file              |
+| [[kbd:][SPC s i]]                    | Jump to symbol in file              |
 
 ** Project search & replace
 This module provides interactive text search and replace using ripgrep.
 
-| Keybind | Description              |
-|---------+--------------------------|
+| Keybind                | Description              |
+|------------------------+--------------------------|
 | [[kbd:][<leader> s p]] | Search project           |
 | [[kbd:][<leader> s P]] | Search another project   |
 | [[kbd:][<leader> s d]] | Search this directory    |
@@ -153,19 +153,19 @@ An ~occur-edit~ buffer can be opened from ~consult-line~ with [[kbd:][C-c C-e]].
 
 ** Vertico integration for various completing commands
 *** General
-| Keybind    | Description                 |
-|------------+-----------------------------|
+| Keybind                        | Description                 |
+|--------------------------------+-----------------------------|
 | [[kbd:][M-x]], [[kbd:][SPC :]] | Enhanced M-x                |
-| [[kbd:][SPC ']]      | Resume last Vertico session |
+| [[kbd:][SPC ']]                | Resume last Vertico session |
 
 *** Jump to files, buffers or projects
-| Keybind          | Description                           |
-|------------------+---------------------------------------|
-| [[kbd:][SPC RET]]          | Find bookmark                         |
+| Keybind                              | Description                           |
+|--------------------------------------+---------------------------------------|
+| [[kbd:][SPC RET]]                    | Find bookmark                         |
 | [[kbd:][SPC f f]], [[kbd:][SPC .]]   | Browse from current directory         |
 | [[kbd:][SPC p f]], [[kbd:][SPC SPC]] | Find file in project                  |
-| [[kbd:][SPC f r]]          | Find recently opened file             |
-| [[kbd:][SPC p p]]          | Open another project                  |
+| [[kbd:][SPC f r]]                    | Find recently opened file             |
+| [[kbd:][SPC p p]]                    | Open another project                  |
 | [[kbd:][SPC b b]], [[kbd:][SPC ,]]   | Switch to buffer in current workspace |
 | [[kbd:][SPC b B]], [[kbd:][SPC <]]   | Switch to buffer                      |
 
@@ -177,8 +177,8 @@ the last workspace by typing [[kbd:][0 SPC]].
 [[kbd:][SPC f f]] and [[kbd:][SPC .]] support exporting to a [[kbd:][wdired]] buffer using [[kbd:][C-c C-e]].
 
 *** Search
-| Keybind | Description                               |
-|---------+-------------------------------------------|
+| Keybind           | Description                               |
+|-------------------+-------------------------------------------|
 | [[kbd:][SPC p t]] | List all TODO/FIXMEs in project           |
 | [[kbd:][SPC s b]] | Search the current buffer                 |
 | [[kbd:][SPC s d]] | Search this directory                     |
@@ -200,10 +200,10 @@ to =~/=.
 *** Multiple candidate search
 This module modifies the default keybindings used in
 ~consult-completing-read-multiple~:
-| Keybind | Description                                                 |
-|---------+-------------------------------------------------------------|
-| [[kbd:][TAB]]     | Select or deselect current candidate                        |
-| [[kbd:][RET]]     | Enters selected candidates (also toggles current candidate) |
+| Keybind       | Description                                                 |
+|---------------+-------------------------------------------------------------|
+| [[kbd:][TAB]] | Select or deselect current candidate                        |
+| [[kbd:][RET]] | Enters selected candidates (also toggles current candidate) |
 
 *** Async search commands
 :PROPERTIES:
@@ -226,9 +226,9 @@ filtering should be done after a second =#=.
 For more information [[https://github.com/minad/consult#asynchronous-search][see here]].
 
 ** Marginalia
-| Keybind | Description                     |
-|---------+---------------------------------|
-| [[kbd:][M-A]]     | Cycle between annotation levels |
+| Keybind       | Description                     |
+|---------------+---------------------------------|
+| [[kbd:][M-A]] | Cycle between annotation levels |
 
 Marginalia annotations for symbols (e.g. [[kbd:][SPC h f]] and [[kbd:][SPC h v]]) come with extra
 information the nature of the symbol. For the meaning of the annotations see

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -316,7 +316,7 @@ orderless."
         :desc "Cycle marginalia views" "M-A" #'marginalia-cycle)
   :config
   (when (modulep! +icons)
-    (add-hook 'marginalia-mode-hook #'all-the-icons-completion-marginalia-setup))
+    (add-hook 'marginalia-mode-hook #'nerd-icons-completion-marginalia-setup))
   (advice-add #'marginalia--project-root :override #'doom-project-root)
   (pushnew! marginalia-command-categories
             '(+default/find-file-under-here . file)

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -21,7 +21,7 @@
 (package! wgrep :pin "3132abd3750b8c87cbcf6942db952acfab5edccd")
 
 (when (modulep! +icons)
-  (package! all-the-icons-completion :pin "8eb3e410d63f5d0657b41829e7898793e81f31c0"))
+  (package! nerd-icons-completion :pin "c2db8557a3c1a9588d111f8c8e91cae96ee85010"))
 
 (when (modulep! +childframe)
   (package! vertico-posframe

--- a/modules/emacs/dired/README.org
+++ b/modules/emacs/dired/README.org
@@ -16,7 +16,7 @@ This module provides reasonable defaults and augmentations for dired.
   Enables dired to be more like [[https://github.com/ranger/ranger][ranger]].
 
 ** Packages
-- [[doom-package:all-the-icons-dired]] if [[doom-module:+icons]]
+- [[doom-package:nerd-icons-dired]] if [[doom-module:+icons]]
 - [[doom-package:diff-hl]]
 - [[doom-package:diredfl]]
 - [[doom-package:dired-rsync]]
@@ -43,10 +43,10 @@ This module has no requirements *except on BSDs* like MacOS or FreeBSD, where
  🔨 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
 #+end_quote
 
-| Keybind | Description                |
-|---------+----------------------------|
-| [[kbd:][SPC f d]] | Find directory with dired  |
-| [[kbd:][q]]       | Exit dired buffer          |
+| Keybind           | Description                                 |
+|-------------------+---------------------------------------------|
+| [[kbd:][SPC f d]] | Find directory with dired                   |
+| [[kbd:][q]]       | Exit dired buffer                           |
 | [[kbd:][C-c C-r]] | Run [[doom-package:dired-rsync]]            |
 | [[kbd:][C-c C-e]] | Rename entries with [[doom-package:wdired]] |
 

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -1,5 +1,8 @@
 ;;; tools/dired/config.el -*- lexical-binding: t; -*-
 
+(defvar +dired-dirvish-icon-provider 'nerd-icons
+  "Icon provider to use for dirvish when the module is enabled.")
+
 (use-package! dired
   :commands dired-jump
   :init
@@ -139,7 +142,7 @@ we have to clean it up ourselves."
         dirvish-attributes '(git-msg)
         dired-omit-files (concat dired-omit-files "\\|^\\..*$"))
   (when (modulep! +icons)
-    (push 'all-the-icons dirvish-attributes))
+    (push +dired-dirvish-icon-provider dirvish-attributes))
   (map! :map dirvish-mode-map
         :n "b" #'dirvish-goto-bookmark
         :n "z" #'dirvish-show-history
@@ -151,28 +154,20 @@ we have to clean it up ourselves."
         "h" #'dired-omit-mode))
 
 
-(use-package! all-the-icons-dired
+(use-package! nerd-icons-dired
   :when (modulep! +icons)
   :unless (modulep! +dirvish)
-  :hook (dired-mode . all-the-icons-dired-mode)
+  :hook (dired-mode . nerd-icons-dired-mode)
   :config
-  ;; HACK Fixes #1929: icons break file renaming in Emacs 27+, because the icon
-  ;;      is considered part of the filename, so we disable icons while we're in
-  ;;      wdired-mode.
-  (defvar +wdired-icons-enabled -1)
-
-  ;; display icons with colors
-  (setq all-the-icons-dired-monochrome nil)
-
   (defadvice! +dired-disable-icons-in-wdired-mode-a (&rest _)
     :before #'wdired-change-to-wdired-mode
-    (setq-local +wdired-icons-enabled (if all-the-icons-dired-mode 1 -1))
-    (when all-the-icons-dired-mode
-      (all-the-icons-dired-mode -1)))
+    (setq-local +wdired-icons-enabled (if nerd-icons-dired-mode 1 -1))
+    (when nerd-icons-dired-mode
+      (nerd-icons-dired-mode -1)))
 
   (defadvice! +dired-restore-icons-after-wdired-mode-a (&rest _)
     :after #'wdired-change-to-dired-mode
-    (all-the-icons-dired-mode +wdired-icons-enabled)))
+    (nerd-icons-dired-mode +wdired-icons-enabled)))
 
 
 (use-package! dired-x

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -10,5 +10,5 @@
   (package! dirvish :pin "4fe9c00894304e99aca22ae4b6b656fe94b8f927"))
 (when (and (modulep! +icons)
            (not (modulep! +dirvish)))
-  (package! all-the-icons-dired :pin "5e9b097f9950cc9f86de922b07903a4e5fefc733"))
+  (package! nerd-icons-dired :pin "b7605208215194fb97da703dff8c1a71738a6533"))
 (package! fd-dired :pin "458464771bb220b6eb87ccfd4c985c436e57dc7e")

--- a/modules/emacs/ibuffer/README.org
+++ b/modules/emacs/ibuffer/README.org
@@ -15,7 +15,7 @@ This module augments the built-in [[doom-package:ibuffer]] package.
 
 ** Module flags
 - +icons ::
-  Enable filetype icons for buffers using [[doom-package:all-the-icons]].
+  Enable filetype icons for buffers using [[doom-package:nerd-icons]].
 
 ** Packages
 - [[doom-package:ibuffer-projectile]]

--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -25,11 +25,11 @@
   ;; Display buffer icons on GUI
   (define-ibuffer-column icon (:name "  ")
     (let ((icon (if (and (buffer-file-name)
-                         (all-the-icons-auto-mode-match?))
-                    (all-the-icons-icon-for-file (file-name-nondirectory (buffer-file-name)) :v-adjust -0.05)
-                  (all-the-icons-icon-for-mode major-mode :v-adjust -0.05))))
+                         (nerd-icons-auto-mode-match?))
+                    (nerd-icons-icon-for-file (file-name-nondirectory (buffer-file-name)) :v-adjust -0.05)
+                  (nerd-icons-icon-for-mode major-mode :v-adjust -0.05))))
       (if (symbolp icon)
-          (setq icon (all-the-icons-faicon "file-o" :face 'all-the-icons-dsilver :height 0.8 :v-adjust 0.0))
+          (setq icon (nerd-icons-faicon "nf-fa-file_o" :face 'nerd-icons-dsilver :height 0.8 :v-adjust 0.0))
         icon)))
 
   ;; Redefine size column to display human readable size
@@ -72,8 +72,8 @@
   :config
   (setq ibuffer-projectile-prefix
         (if (modulep! +icons)
-            (concat (all-the-icons-octicon
-                     "file-directory"
+            (concat (nerd-icons-octicon
+                     "nf-oct-file_directory"
                      :face ibuffer-filter-group-name-face
                      :v-adjust -0.05)
                     " ")

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -6,7 +6,7 @@
 * Description :unfold:
 This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]].
 
-- Tidied mu4e headers view, with flags from [[doom-package:all-the-icons]].
+- Tidied mu4e headers view, with flags from [[doom-package:nerd-icons]].
 - Consistent coloring of reply depths (across compose and gnus modes).
 - Prettified =mu4e:main= view.
 - Cooperative locking of the =mu= process. Another Emacs instance may request
@@ -64,12 +64,12 @@ This module requires:
   (recommended, default) or [[http://www.offlineimap.org/][offlineimap]] but you can sync mail in other ways too.
 
 #+name: Install Matrix
-| Platform      | Install command            | Base packages           |
-|---------------+----------------------------+-------------------------|
-| MacOS         | ~$ brew install <pkgs>~    | =mu=                    |
+| Platform      | Install command          | Base packages       |
+|---------------+--------------------------+---------------------|
+| MacOS         | ~$ brew install <pkgs>~    | =mu=                  |
 | Arch          | ~$ pacman -S <pkgs>~       | (AUR, ~$ yay -S~) =mu=  |
 | openSUSE      | ~$ zypper install <pkgs>~  | =maildir-utils=, =mu4e= |
-| Fedora        | ~$ dnf install <pkgs>~     | =maildir-utils=         |
+| Fedora        | ~$ dnf install <pkgs>~     | =maildir-utils=       |
 | Debian/Ubuntu | ~$ apt-get install <pkgs>~ | =maildir-utils=, =mu4e= |
 
 Then install either the =isync= (=mbsync=) or =offlineimap= package.

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -115,11 +115,11 @@ will also be the width of all other printable characters."
 
 (cl-defun +mu4e-normalised-icon (name &key set color height v-adjust)
   "Convert :icon declaration to icon"
-  (let* ((icon-set (intern (concat "all-the-icons-" (or set "faicon"))))
+  (let* ((icon-set (intern (concat "nerd-icons-" (or set "faicon"))))
          (v-adjust (or v-adjust 0.02))
          (height (or height 0.8))
          (icon (if color
-                   (apply icon-set `(,name :face ,(intern (concat "all-the-icons-" color)) :height ,height :v-adjust ,v-adjust))
+                   (apply icon-set `(,name :face ,(intern (concat "nerd-icons-" color)) :height ,height :v-adjust ,v-adjust))
                  (apply icon-set `(,name  :height ,height :v-adjust ,v-adjust))))
          (icon-width (+mu4e--get-string-width icon))
          (space-width (+mu4e--get-string-width " "))
@@ -130,20 +130,20 @@ will also be the width of all other printable characters."
 ;;;###autoload
 (defun +mu4e-initialise-icons ()
   (setq mu4e-use-fancy-chars t
-        mu4e-headers-draft-mark      (cons "D" (+mu4e-normalised-icon "pencil"))
-        mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "flag"))
-        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "sync" :set "material" :height 0.8 :v-adjust -0.10))
-        mu4e-headers-passed-mark     (cons "P" (+mu4e-normalised-icon "arrow-right"))
-        mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "reply"))
+        mu4e-headers-draft-mark      (cons "D" (+mu4e-normalised-icon "nf-fa-pencil"))
+        mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "nf-fa-flag"))
+        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "nf-md-sync" :set "material" :height 0.8 :v-adjust -0.10))
+        mu4e-headers-passed-mark     (cons "P" (+mu4e-normalised-icon "nf-fa-arrow_right"))
+        mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "nf-fa-reply"))
         mu4e-headers-seen-mark       (cons "S" "") ;(+mu4e-normalised-icon "eye" :height 0.6 :v-adjust 0.07 :color "dsilver"))
-        mu4e-headers-trashed-mark    (cons "T" (+mu4e-normalised-icon "trash"))
-        mu4e-headers-attach-mark     (cons "a" (+mu4e-normalised-icon "file-text-o" :color "silver"))
-        mu4e-headers-encrypted-mark  (cons "x" (+mu4e-normalised-icon "lock"))
-        mu4e-headers-signed-mark     (cons "s" (+mu4e-normalised-icon "certificate" :height 0.7 :color "dpurple"))
-        mu4e-headers-unread-mark     (cons "u" (+mu4e-normalised-icon "eye-slash" :v-adjust 0.05))
-        mu4e-headers-list-mark       (cons "l" (+mu4e-normalised-icon "sitemap" :set "faicon"))
-        mu4e-headers-personal-mark   (cons "p" (+mu4e-normalised-icon "user"))
-        mu4e-headers-calendar-mark   (cons "c" (+mu4e-normalised-icon "calendar"))))
+        mu4e-headers-trashed-mark    (cons "T" (+mu4e-normalised-icon "nf-fa-trash"))
+        mu4e-headers-attach-mark     (cons "a" (+mu4e-normalised-icon "nf-fa-file_text_o" :color "silver"))
+        mu4e-headers-encrypted-mark  (cons "x" (+mu4e-normalised-icon "nf-fa-lock"))
+        mu4e-headers-signed-mark     (cons "s" (+mu4e-normalised-icon "nf-fa-certificate" :height 0.7 :color "dpurple"))
+        mu4e-headers-unread-mark     (cons "u" (+mu4e-normalised-icon "nf-fa-eye_slash" :v-adjust 0.05))
+        mu4e-headers-list-mark       (cons "l" (+mu4e-normalised-icon "nf-fa-sitemap" :set "faicon"))
+        mu4e-headers-personal-mark   (cons "p" (+mu4e-normalised-icon "nf-fa-user"))
+        mu4e-headers-calendar-mark   (cons "c" (+mu4e-normalised-icon "nf-fa-calendar"))))
 
 (defun +mu4e-colorize-str (str &optional unique herring)
   "Apply a face from `+mu4e-header-colorized-faces' to STR.

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -127,13 +127,13 @@ is non-nil."
             (cons (make-help-button text1 help-echo)
                   (make-help-button text2 help-echo))))
     (setq mu4e-headers-threaded-label
-          (make-help-button-cons "T" (concat " " (all-the-icons-octicon "git-branch" :v-adjust 0.05))
+          (make-help-button-cons "T" (concat " " (nerd-icons-octicon "nf-oct-git_branch" :v-adjust 0.05))
                                  "Thread view")
           mu4e-headers-related-label
-          (make-help-button-cons "R" (concat " " (all-the-icons-material "link" :v-adjust -0.1))
+          (make-help-button-cons "R" (concat " " (nerd-icons-mdicon "nf-md-link" :v-adjust -0.1))
                                  "Showing related emails")
           mu4e-headers-full-label
-          (make-help-button-cons "F" (concat " " (all-the-icons-material "disc_full"))
+          (make-help-button-cons "F" (concat " " (nerd-icons-mdicon "nf-md-disc"))
                                  "Search is full!")))
 
   ;; set mail user agent
@@ -156,14 +156,14 @@ is non-nil."
   (add-to-list 'mu4e-bookmarks
                '("flag:flagged" "Flagged messages" ?f) t)
 
-  ;; TODO avoid assuming that all-the-icons is present
+  ;; TODO avoid assuming that nerd-icons is present
   (defvar +mu4e-header-colorized-faces
-    '(all-the-icons-green
-      all-the-icons-lblue
-      all-the-icons-purple-alt
-      all-the-icons-blue-alt
-      all-the-icons-purple
-      all-the-icons-yellow)
+    '(nerd-icons-green
+      nerd-icons-lblue
+      nerd-icons-purple-alt
+      nerd-icons-blue-alt
+      nerd-icons-purple
+      nerd-icons-yellow)
     "Faces to use when coloring folders and account stripes.")
 
   (defvar +mu4e-min-header-frame-width 120
@@ -321,8 +321,8 @@ Acts like a singular `mu4e-view-save-attachments', without the saving."
                   sizefmt (format "%%-%ds " maxsizelen))
             (dolist (pinfo partinfo)
               (push (cons (concat (propertize (format "%-2s " (plist-get pinfo :index)) 'face '(bold font-lock-type-face))
-                                  (when (featurep 'all-the-icons)
-                                    (all-the-icons-icon-for-file (or (plist-get pinfo :filename) "")))
+                                  (when (featurep 'nerd-icons)
+                                    (nerd-icons-icon-for-file (or (plist-get pinfo :filename) "")))
                                   (format fnamefmt (or (plist-get pinfo :filename)
                                                        (propertize (plist-get pinfo :type) 'face '(italic font-lock-doc-face))))
                                   (format sizefmt (propertize (plist-get pinfo :size) 'face 'font-lock-builtin-face))

--- a/modules/lang/beancount/README.org
+++ b/modules/lang/beancount/README.org
@@ -22,7 +22,7 @@ you [[https://plaintextaccounting.org/][manage your money in plain text]].
 
 ** Hacks
 - Associates the material =attach_money= icon with =*.beancount= files in the
-  [[doom-package:all-the-icons]] package.
+  [[doom-package:nerd-icons]] package.
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.

--- a/modules/lang/beancount/config.el
+++ b/modules/lang/beancount/config.el
@@ -3,6 +3,13 @@
 (use-package! beancount
   :mode ("\\.beancount\\'" . beancount-mode)
   :hook (beancount-mode . outline-minor-mode)
+  :init
+  (after! nerd-icons
+    (add-to-list 'nerd-icons-extension-icon-alist
+                 '("beancount" nerd-icons-faicon "nf-fa-money" :face nerd-icons-lblue))
+    (add-to-list 'nerd-icons-mode-icon-alist
+                 '(beancount-mode nerd-icons-faicon "nf-fa-money" :face nerd-icons-lblue)))
+
   :config
   (setq beancount-electric-currency t)
 

--- a/modules/lang/graphql/config.el
+++ b/modules/lang/graphql/config.el
@@ -1,18 +1,10 @@
 ;;; lang/graphql/config.el -*- lexical-binding: t; -*-
 
 (after! graphql-mode
-  (defface all-the-icons-rhodamine
+  (defface nerd-icons-rhodamine
     '((t (:foreground "#E10098")))
     "Face for GraphQL icon."
-    :group 'all-the-icons-faces)
-  ;; Define a doom-modeline compatiable major-mode icon
-  (after! all-the-icons
-    (setf (alist-get "graphql" all-the-icons-extension-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine))
-    (setf (alist-get "gql" all-the-icons-extension-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine))
-    (setf (alist-get 'graphql-mode all-the-icons-mode-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine)))
+    :group 'nerd-icons-faces)
   (if (modulep! +lsp)
       (add-hook 'graphql-mode-local-vars-hook #'lsp! 'append)
     (set-company-backend! 'graphql-mode 'company-graphql))

--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -257,13 +257,11 @@ exist, and `org-link' otherwise."
        start end
        (list 'display
              (concat
-              (propertize
-               ""
-               'rear-nonsticky t
-               'display '(raise -0.02)
-               'face (list :family "all-the-icons"
-                           :height 1.0
-                           :inherit (if found 'success 'error)))
+              (nerd-icons-devicon "nf-dev-terminal_badge"
+                                  :rear-nonsticky t
+                                  :display '(raise -0.02)
+                                  :face (list :height 1.0
+                                              :inherit (if found 'success 'error)))
               " "
               (propertize
                executable

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -26,36 +26,36 @@
   (when (modulep! :completion vertico +icons)
     (defvar citar-indicator-files-icons
       (citar-indicator-create
-       :symbol (all-the-icons-faicon
-                "file-o"
-                :face 'all-the-icons-green
+       :symbol (nerd-icons-faicon
+                "nf-fa-file_o"
+                :face 'nerd-icons-green
                 :v-adjust -0.1)
        :function #'citar-has-files
        :padding "  " ; need this because the default padding is too low for these icons
        :tag "has:files"))
     (defvar citar-indicator-links-icons
       (citar-indicator-create
-       :symbol (all-the-icons-octicon
-                "link"
-                :face 'all-the-icons-orange
+       :symbol (nerd-icons-faicon
+                "nf-fa-link"
+                :face 'nerd-icons-orange
                 :v-adjust 0.01)
        :function #'citar-has-links
        :padding "  "
        :tag "has:links"))
     (defvar citar-indicator-notes-icons
       (citar-indicator-create
-       :symbol (all-the-icons-material
-                "speaker_notes"
-                :face 'all-the-icons-blue
+       :symbol (nerd-icons-codicon
+                "nf-cod-note"
+                :face 'nerd-icons-blue
                 :v-adjust -0.3)
        :function #'citar-has-notes
        :padding "    "
        :tag "has:notes"))
     (defvar citar-indicator-cited-icons
       (citar-indicator-create
-       :symbol (all-the-icons-faicon
-                "circle-o"
-                :face 'all-the-icon-green)
+       :symbol (nerd-icons-faicon
+                "nf-fa-circle_o"
+                :face 'nerd-icon-green)
        :function #'citar-is-cited
        :padding "  "
        :tag "is:cited"))

--- a/modules/ui/doom-dashboard/README.org
+++ b/modules/ui/doom-dashboard/README.org
@@ -41,9 +41,9 @@ Besides eye candy, the dashboard serves two other purposes:
 * Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-This module only requires that ~all-the-icons~'s icon fonts are installed, which
+This module only requires that ~nerd-icons~'s icon fonts are installed, which
 should've been installed when you ran ~$ doom install~. Otherwise, use ~M-x
-all-the-icons-install-fonts~ to install them.
+nerd-icons-install-fonts~ to install them.
 
 * Usage
 Once this module is enabled, the dashboard will present itself after opening a
@@ -88,7 +88,7 @@ color from the theme) you can make use of ~custom-set-faces!~ or
 (custom-set-faces!
   '(doom-dashboard-banner :foreground "red" :background "#000000" :weight bold)
   '(doom-dashboard-footer :inherit font-lock-constant-face)
-  '(doom-dashboard-footer-icon :inherit all-the-icons-red)
+  '(doom-dashboard-footer-icon :inherit nerd-icons-red)
   '(doom-dashboard-loaded :inherit font-lock-warning-face)
   '(doom-dashboard-menu-desc :inherit font-lock-string-face)
   '(doom-dashboard-menu-title :inherit font-lock-function-name-face))
@@ -99,7 +99,7 @@ or for a per-theme setting
 (custom-theme-set-faces! 'doom-tomorrow-night
   '(doom-dashboard-banner :foreground "red" :background "#000000" :weight bold)
   '(doom-dashboard-footer :inherit font-lock-constant-face)
-  '(doom-dashboard-footer-icon :inherit all-the-icons-red)
+  '(doom-dashboard-footer-icon :inherit nerd-icons-red)
   '(doom-dashboard-loaded :inherit font-lock-warning-face)
   '(doom-dashboard-menu-desc :inherit font-lock-string-face)
   '(doom-dashboard-menu-title :inherit font-lock-function-name-face))

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -47,32 +47,31 @@ Possible values:
 
 (defvar +doom-dashboard-menu-sections
   '(("Recently opened files"
-     :icon (all-the-icons-octicon "file-text" :face 'doom-dashboard-menu-title)
-     :face (:inherit (doom-dashboard-menu-title bold))
+     :icon (nerd-icons-faicon "nf-fa-file_text" :face 'doom-dashboard-menu-title)
      :action recentf-open-files)
     ("Reload last session"
-     :icon (all-the-icons-octicon "history" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-history" :face 'doom-dashboard-menu-title)
      :when (cond ((modulep! :ui workspaces)
                   (file-exists-p (expand-file-name persp-auto-save-fname persp-save-dir)))
                  ((require 'desktop nil t)
                   (file-exists-p (desktop-full-file-name))))
      :action doom/quickload-session)
     ("Open org-agenda"
-     :icon (all-the-icons-octicon "calendar" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-calendar" :face 'doom-dashboard-menu-title)
      :when (fboundp 'org-agenda)
      :action org-agenda)
     ("Open project"
-     :icon (all-the-icons-octicon "briefcase" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-briefcase" :face 'doom-dashboard-menu-title)
      :action projectile-switch-project)
     ("Jump to bookmark"
-     :icon (all-the-icons-octicon "bookmark" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-bookmark" :face 'doom-dashboard-menu-title)
      :action bookmark-jump)
     ("Open private configuration"
-     :icon (all-the-icons-octicon "tools" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-tools" :face 'doom-dashboard-menu-title)
      :when (file-directory-p doom-user-dir)
      :action doom/open-private-config)
     ("Open documentation"
-     :icon (all-the-icons-octicon "book" :face 'doom-dashboard-menu-title)
+     :icon (nerd-icons-octicon "nf-oct-book" :face 'doom-dashboard-menu-title)
      :action doom/help))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the
@@ -97,9 +96,6 @@ PLIST can have the following properties:
 (defvar +doom-dashboard--old-fringe-indicator fringe-indicator-alist)
 (defvar +doom-dashboard--pwd-alist ())
 (defvar +doom-dashboard--reload-timer nil)
-
-(defvar all-the-icons-scale-factor)
-(defvar all-the-icons-default-adjust)
 
 
 ;;
@@ -151,7 +147,7 @@ PLIST can have the following properties:
   "Face used for the footer on the dashboard"
   :group 'doom-dashboard)
 
-(defface doom-dashboard-footer-icon '((t (:inherit all-the-icons-green)))
+(defface doom-dashboard-footer-icon '((t (:inherit nerd-icons-green)))
   "Face used for the icon of the footer on the dashboard"
   :group 'doom-dashboard)
 
@@ -456,60 +452,58 @@ What it is set to is controlled by `+doom-dashboard-pwd-policy'."
      "\n")))
 
 (defun doom-dashboard-widget-shortmenu ()
-  (let ((all-the-icons-scale-factor 1.45)
-        (all-the-icons-default-adjust -0.02))
-    (insert "\n")
-    (dolist (section +doom-dashboard-menu-sections)
-      (cl-destructuring-bind (label &key icon action when face key) section
-        (when (and (fboundp action)
-                   (or (null when)
-                       (eval when t)))
-          (insert
-           (+doom-dashboard--center
-            (- +doom-dashboard--width 1)
-            (let ((icon (if (stringp icon) icon (eval icon t))))
-              (format (format "%s%%s%%-10s" (if icon "%3s\t" "%3s"))
-                      (or icon "")
-                      (with-temp-buffer
-                        (insert-text-button
-                         label
-                         'action
-                         `(lambda (_)
-                            (call-interactively (or (command-remapping #',action)
-                                                    #',action)))
-                         'face (or face 'doom-dashboard-menu-title)
-                         'follow-link t
-                         'help-echo
-                         (format "%s (%s)" label
-                                 (propertize (symbol-name action) 'face 'doom-dashboard-menu-desc)))
-                        (format "%-37s" (buffer-string)))
-                      ;; Lookup command keys dynamically
-                      (propertize
-                       (or key
-                           (when-let*
-                               ((keymaps
-                                 (delq
-                                  nil (list (when (bound-and-true-p evil-local-mode)
-                                              (evil-get-auxiliary-keymap +doom-dashboard-mode-map 'normal))
-                                            +doom-dashboard-mode-map)))
-                                (key
-                                 (or (when keymaps
-                                       (where-is-internal action keymaps t))
-                                     (where-is-internal action nil t))))
-                             (with-temp-buffer
-                               (save-excursion (insert (key-description key)))
-                               (while (re-search-forward "<\\([^>]+\\)>" nil t)
-                                 (let ((str (match-string 1)))
-                                   (replace-match
-                                    (upcase (if (< (length str) 3)
-                                                str
-                                              (substring str 0 3))))))
-                               (buffer-string)))
-                           "")
-                       'face 'doom-dashboard-menu-desc))))
-           (if (display-graphic-p)
-               "\n\n"
-             "\n")))))))
+  (insert "\n")
+  (dolist (section +doom-dashboard-menu-sections)
+    (cl-destructuring-bind (label &key icon action when face key) section
+      (when (and (fboundp action)
+                 (or (null when)
+                     (eval when t)))
+        (insert
+         (+doom-dashboard--center
+          (- +doom-dashboard--width 1)
+          (let ((icon (if (stringp icon) icon (eval icon t))))
+            (format (format "%s%%s%%-10s" (if icon "%3s\t" "%3s"))
+                    (or icon "")
+                    (with-temp-buffer
+                      (insert-text-button
+                       label
+                       'action
+                       `(lambda (_)
+                          (call-interactively (or (command-remapping #',action)
+                                                  #',action)))
+                       'face (or face 'doom-dashboard-menu-title)
+                       'follow-link t
+                       'help-echo
+                       (format "%s (%s)" label
+                               (propertize (symbol-name action) 'face 'doom-dashboard-menu-desc)))
+                      (format "%-37s" (buffer-string)))
+                    ;; Lookup command keys dynamically
+                    (propertize
+                     (or key
+                         (when-let*
+                             ((keymaps
+                               (delq
+                                nil (list (when (bound-and-true-p evil-local-mode)
+                                            (evil-get-auxiliary-keymap +doom-dashboard-mode-map 'normal))
+                                          +doom-dashboard-mode-map)))
+                              (key
+                               (or (when keymaps
+                                     (where-is-internal action keymaps t))
+                                   (where-is-internal action nil t))))
+                           (with-temp-buffer
+                             (save-excursion (insert (key-description key)))
+                             (while (re-search-forward "<\\([^>]+\\)>" nil t)
+                               (let ((str (match-string 1)))
+                                 (replace-match
+                                  (upcase (if (< (length str) 3)
+                                              str
+                                            (substring str 0 3))))))
+                             (buffer-string)))
+                         "")
+                     'face 'doom-dashboard-menu-desc))))
+         (if (display-graphic-p)
+             "\n\n"
+           "\n"))))))
 
 (defun doom-dashboard-widget-footer ()
   (insert
@@ -517,7 +511,7 @@ What it is set to is controlled by `+doom-dashboard-pwd-policy'."
    (+doom-dashboard--center
     (- +doom-dashboard--width 2)
     (with-temp-buffer
-      (insert-text-button (or (all-the-icons-octicon "octoface" :face 'doom-dashboard-footer-icon :height 1.3 :v-adjust -0.15)
+      (insert-text-button (or (nerd-icons-codicon "nf-cod-octoface" :face 'doom-dashboard-footer-icon :height 1.3 :v-adjust -0.15)
                               (propertize "github" 'face 'doom-dashboard-footer))
                           'action (lambda (_) (browse-url "https://github.com/hlissner/doom-emacs"))
                           'follow-link t

--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -86,8 +86,8 @@ core/core-ui.el has four relevant variables:
 
 ** Strange font symbols
 If you're seeing strange unicode symbols, this is likely because you don't have
-~all-the-icons~'s font icon installed. You can install them with ~M-x
-all-the-icons-install-fonts~.
+~nerd-icons~'s font icon installed. You can install them with ~M-x
+nerd-icons-install-fonts~.
 
 ** Ugly background colors in tty Emacs for daemon users
 [[doom-package:solaire-mode]] is an aesthetic plugin that makes non-file-visiting buffers darker

--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -113,11 +113,9 @@ side of the modeline, and whose CDR is the right-hand side.")
   "Build from ICON-SET the ICON with LABEL.
 Using optionals attributes FACE, HELP-ECHO and VOFFSET."
   (let ((icon-set-fn (pcase icon-set
-                       ('octicon #'all-the-icons-octicon)
-                       ('faicon #'all-the-icons-faicon)
-                       ('material #'all-the-icons-material)
-                       ('alltheicon #'all-the-icons-alltheicon)
-                       ('fileicon #'all-the-icons-fileicon))))
+                       ('octicon #'nerd-icons-octicon)
+                       ('faicon #'nerd-icons-faicon)
+                       ('material #'nerd-icons-mdicon))))
     (propertize (concat (funcall icon-set-fn
                                  icon
                                  :face face
@@ -290,7 +288,7 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                           (evil-mc-frozen 'doom-modeline-highlight)
                           ('doom-modeline-alternate-highlight))))
           (concat (propertize " " 'face face)
-                  (all-the-icons-faicon "i-cursor" :face face :v-adjust -0.0575)
+                  (nerd-icons-faicon "nf-fa-i_cursor" :face face :v-adjust -0.0575)
                   (propertize " " 'face `(:inherit (variable-pitch ,face)))
                   (propertize (format "%d " count)
                               'face face)))))))
@@ -332,7 +330,7 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                             "Macro")
                           'face 'doom-modeline-highlight)
               sep
-              (all-the-icons-octicon "triangle-right"
+              (nerd-icons-octicon "nf-oct-triangle_right"
                                      :face 'doom-modeline-highlight
                                      :v-adjust -0.05)
               sep))))
@@ -532,7 +530,7 @@ lines are selected, or the NxM dimensions of a block selection.")
     mode-line-misc-info
     +modeline-modes
     (vc-mode ("  "
-              ,(all-the-icons-octicon "git-branch" :v-adjust 0.0)
+              ,(nerd-icons-octicon "nf-oct-git_branch" :v-adjust 0.0)
               vc-mode " "))
     "  "
     +modeline-encoding
@@ -540,8 +538,8 @@ lines are selected, or the NxM dimensions of a block selection.")
 
 (def-modeline! 'project
   `(" "
-    ,(all-the-icons-octicon
-      "file-directory"
+    ,(nerd-icons-octicon
+      "nf-oct-file_directory"
       :face 'bold
       :v-adjust -0.06
       :height 1.1)

--- a/modules/ui/modeline/README.org
+++ b/modules/ui/modeline/README.org
@@ -73,11 +73,11 @@ I rarely need to know what minor modes are active, so I removed them. ~M-x
 doom/describe-active-minor-mode~ was written to substitute for it.
 
 ** Icons in my modeline look strange
-1. Check whether ~all-the-icons~ are installed. Run ~M-x
-   all-the-icons-install-fonts~ to install the resource fonts. Note that
-   ~all-the-icons~ only support GUI. See [[https://github.com/domtronn/all-the-icons.el][all-the-icons]] for details.
+1. Check whether ~nerd-icons~ are installed. Run ~M-x
+   nerd-icons-install-fonts~ to install the resource fonts. Note that
+   ~nerd-icons~ only support GUI. See [[https://github.com/domtronn/nerd-icons.el][nerd-icons]] for details.
 
-2. ~cnfonts~ will conflict with ~all-the-icons~. You can refer the following
+2. ~cnfonts~ will conflict with ~nerd-icons~. You can refer the following
    workaround:
     #+begin_src emacs-lisp
     ;; See https://github.com/seagle0128/doom-modeline/issues/278#issuecomment-569510336
@@ -87,18 +87,11 @@ doom/describe-active-minor-mode~ was written to substitute for it.
     (add-hook 'after-setting-font-hook #'cnfonts-set-font)
     #+end_src
 
-3. If ~all-the-icons~ fonts are installed while the icons cannot display
-   correctly, please install the non-free font [[https://dn-works.com/wp-content/uploads/2020/UFAS-Fonts/Symbola.zip][Symbola]]. This issue usually
-   occurs on Windows.
-
 ** The right side of the modeline is cut off
 I believe the consensus is: this is due to oversized icons, i.e. a font issue.
 Some possible solutions:
 
-1. Tweak ~all-the-icons-scale-factor~ (1.2 by default): ~(setq
-   all-the-icons-scale-factor 1.1)~
-
-2. Add some padding to the modeline definition:
+1. Add some padding to the modeline definition:
     #+begin_src emacs-lisp
     (after! doom-modeline
       (doom-modeline-def-modeline 'main
@@ -106,7 +99,7 @@ Some possible solutions:
         '(misc-info minor-modes checker input-method buffer-encoding major-mode process vcs "  "))) ; <-- added padding here
     #+end_src
 
-3. Use another font for the mode line (or a different ~:height~) (source)
+2. Use another font for the mode line (or a different ~:height~) (source)
     #+begin_src emacs-lisp
     (custom-set-faces!
       '(mode-line :family "Noto Sans" :height 0.9)

--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -37,21 +37,7 @@
               (IS-WINDOWS 1)
               (0)))
 
-  ;; Fix modeline icons in daemon-spawned graphical frames. We have our own
-  ;; mechanism for disabling all-the-icons, so we don't need doom-modeline to do
-  ;; it for us. However, this may cause unwanted padding in the modeline in
-  ;; daemon-spawned terminal frames. If it bothers you, you may prefer
-  ;; `doom-modeline-icon' set to `nil'.
-  (when (daemonp)
-    (setq doom-modeline-icon t))
   :config
-  ;; HACK Fix #4102 due to empty all-the-icons return value (caused by
-  ;;      `doom--disable-all-the-icons-in-tty-a' advice) in tty daemon frames.
-  (defadvice! +modeline-disable-icon-in-daemon-a (fn &rest args)
-    :around #'doom-modeline-propertize-icon
-    (when (display-graphic-p)
-      (apply fn args)))
-
   ;; Fix an issue where these two variables aren't defined in TTY Emacs on MacOS
   (defvar mouse-wheel-down-event nil)
   (defvar mouse-wheel-up-event nil)

--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -2,7 +2,7 @@
 ;;; ui/modeline/packages.el
 
 (unless (modulep! +light)
-  (package! doom-modeline :pin "f45a5a200313568d54d73dd38bae76930c2008b5"))
+  (package! doom-modeline :pin "173ad0a27f2c3babe2009a3b760b92d3c8718f5a"))
 (package! anzu :pin "5abb37455ea44fa401d5f4c1bdc58adb2448db67")
 (when (modulep! :editor evil)
   (package! evil-anzu :pin "d1e98ee6976437164627542909a25c6946497899"))


### PR DESCRIPTION
Commits will likely need rebasing in some form, but I've gone through and tested as much as I can.

Per discussion on Discord, we can either disable `all-the-icons` here or in a future PR down the line; makes no difference to me