### PR TITLE
fix(tabs): replace all-the-icons with nerd-icons

### DIFF
--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -9,6 +9,7 @@
         centaur-tabs-set-modified-marker t
         centaur-tabs-close-button "✕"
         centaur-tabs-modified-marker "•"
+        centaur-tabs-icon-type 'nerd-icons
         ;; Scrolling (with the mouse wheel) past the end of the tab list
         ;; replaces the tab list with that of another Doom workspace. This
         ;; prevents that.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Current problem: `centaur-tabs` requires explicitly set the icon font, if not, it will use all-the-icons as default. Since all-the-icons has been replaced in doomemacs, `centaur-tabs-icon-type` can be set as `'nerd-icons` by default.

<details open>
  <summary>Before</summary>

![image](https://github.com/doomemacs/doomemacs/assets/10584186/1ceaf994-b5be-4b3c-8c2e-9e584206c235)


</details>

<details open>
  <summary>After</summary>

![image](https://github.com/doomemacs/doomemacs/assets/10584186/d5de56ba-64e0-4161-af08-3c1cf6d66e9a)


</details>

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
