### PR TITLE
fix(format): correct lisp indenting function

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -26,7 +26,7 @@
   (after! lisp-mode
     (set-repl-handler! 'lisp-mode #'+lisp/open-repl)
     (set-eval-handler! 'lisp-mode #'sly-eval-region)
-    (set-formatter! 'lisp-indent #'apheleia--indent-lisp-buffer :modes '(lisp-mode))
+    (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer :modes '(lisp-mode))
     (set-lookup-handlers! 'lisp-mode
       :definition #'sly-edit-definition
       :documentation #'sly-describe-symbol))

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -39,7 +39,7 @@ See `+emacs-lisp-non-package-mode' for details.")
     :documentation #'+emacs-lisp-lookup-documentation)
   (set-docsets! '(emacs-lisp-mode lisp-interaction-mode) "Emacs Lisp")
   (set-ligatures! 'emacs-lisp-mode :lambda "lambda")
-  (set-formatter! 'lisp-indent #'apheleia--indent-lisp-buffer :modes '(emacs-lisp-mode))
+  (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer :modes '(emacs-lisp-mode))
   (set-rotate-patterns! 'emacs-lisp-mode
     :symbols '(("t" "nil")
                ("let" "let*")

--- a/modules/lang/hy/config.el
+++ b/modules/lang/hy/config.el
@@ -5,5 +5,5 @@
   :interpreter "hy"
   :config
   (set-repl-handler! 'hy-mode #'hy-shell-start-or-switch-to-shell)
-  (set-formatter! 'lisp-indent #'apheleia--indent-lisp-buffer :modes '(hy-mode))
+  (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer :modes '(hy-mode))
   (set-company-backend! 'hy-mode 'company-hy))

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -4,7 +4,7 @@
   :interpreter ("scsh" . scheme-mode)
   :hook (scheme-mode . rainbow-delimiters-mode)
   :config
-  (set-formatter! 'lisp-indent #'apheleia--indent-lisp-buffer :modes '(scheme-mode))
+  (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer :modes '(scheme-mode))
   (advice-add #'scheme-indent-function :override #'+scheme-indent-function-a))
 
 


### PR DESCRIPTION
This was either a typo or due to a recent change in Apheleia itself, but either way formatting was failing for various Lisps due to this.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.