### PR TITLE
fix(tools): replaced obsolete featurep! macro

### DIFF
--- a/modules/tools/collab/config.el
+++ b/modules/tools/collab/config.el
@@ -3,6 +3,6 @@
 (use-package! crdt
   :commands (crdt-share-buffer crdt-connect)
   :init
-  (when (featurep! +tunnel)
+  (when (modulep! +tunnel)
     (setq crdt-use-tuntox t)
     (setq crdt-tuntox-password-in-url t)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The macro  `featurep!` has been obsolete as of `3.0.0`. 
-----
It was lingering on in the module `collab`. I replaced it with the `modulep!`, macro
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
