### PR TITLE
fix(format): load after correct library

### DIFF
--- a/modules/editor/format/autoload/settings.el
+++ b/modules/editor/format/autoload/settings.el
@@ -71,7 +71,7 @@ Advanced examples:
 "
   (declare (indent defun))
   (cl-check-type name symbol)
-  (after! apheleia-core
+  (after! apheleia
     (if (null args)
         (progn
           (setq apheleia-formatters


### PR DESCRIPTION
This allows the macro to run late enough that user config overrides the
internal one