### PR TITLE
fix(format): update missing values & set buffer modification

### DIFF
--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -35,6 +35,10 @@ be formatted and returned to the buffer using
 As of writing this, apheleia doesn't /yet/ support regions or similar kinds of
 buffers, so there are a couple of hacks to attempt to rectify this.
 
+For the most part, things should work as expected. However, because the
+formatting occurs on an isolated version of the buffer; lisp/scheme or similarly
+indentation-based languages may produce poor results.
+
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
 /This module does not have a changelog yet./

--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -8,7 +8,7 @@
 
 (defun +format-region (start end &optional callback)
   "Format from START to END with `apheleia'."
-  (when-let* ((command (apheleia--get-formatter-command
+  (when-let* ((command (apheleia--get-formatters
                         (if current-prefix-arg
                             'prompt
                           'interactive)))
@@ -23,7 +23,7 @@
       ;; Ensure this temp buffer seems as much like the origin buffer as
       ;; possible, in case the formatter is an elisp function, like `gofmt'.
       (cl-loop for (var . val)
-               in (cl-remove-if-not #'listp (buffer-local-variables origin-buffer))
+               in (cl-remove-if-not #'listp (buffer-local-variables cur-buffer))
                ;; Making enable-multibyte-characters buffer-local causes an
                ;; error.
                unless (eq var 'enable-multibyte-characters)
@@ -45,7 +45,8 @@
              ;; restore indentation without affecting new
              ;; indentation
              (indent-rigidly (point-min) (point-max)
-                             (max 0 (- indent (+format--current-indentation))))))
+                             (max 0 (- indent (+format--current-indentation)))))
+           (set-buffer-modified-p nil))
          (with-current-buffer cur-buffer
            (delete-region start end)
            (insert-buffer-substring-no-properties formatted-buffer)


### PR DESCRIPTION
This prevents apheleia complaining about the editing buffer being
killed.

From https://github.com/doomemacs/doomemacs/pull/6369#issuecomment-1720717000