### PR TITLE
fix(format): use +vc-gutter-update-h instead

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -68,4 +68,4 @@ This is controlled by `+format-on-save-disabled-modes'."
 
  (defun +format--refresh-git-gutter-h ()
    (when (fboundp '+vc-gutter-update-h)
-     (+vc-gutter-init-maybe-h))))
+     (+vc-gutter-update-h))))


### PR DESCRIPTION
The function `+vc-gutter-init-maybe-h` is not defined for `+diff-hl` so I am getting a void function error without this PR.