### PR TITLE
fix(ocaml): Prevent clobbering +format-with globally

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -109,7 +109,7 @@
   :config
   ;; TODO Fix region-based formatting support
   (defun +ocaml-init-ocamlformat-h ()
-    (setq +format-with 'ocp-indent)
+    (setq-local +format-with 'ocp-indent)
     (when (and (executable-find "ocamlformat")
                (locate-dominating-file default-directory ".ocamlformat"))
       (when buffer-file-name
@@ -118,7 +118,7 @@
                  (setq-local ocamlformat-file-kind 'implementation))
                 ((equal ext ".eliomi")
                  (setq-local ocamlformat-file-kind 'interface)))))
-      (setq +format-with 'ocamlformat))))
+      (setq-local +format-with 'ocamlformat))))
 
 ;; Tree sitter
 (eval-when! (modulep! +tree-sitter)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Previously, loading the `ocaml` module and opening a file in Tuareg mode would result in every buffer having its formatter set to `ocp-indent`. This now restricts the formatter override to the current buffer.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
