### PR TITLE
Add lean4 mode

### DIFF
--- a/modules/lang/lean4/README.org
+++ b/modules/lang/lean4/README.org
@@ -1,0 +1,55 @@
+#+title:    :lang lean4
+#+subtitle: The next version of lean
+#+created:  September 17, 2023
+#+since:    21.12.0 (#1759)
+
+* Description :unfold:
+This module adds support for [[https://leanprover.github.io/about/][Lean 4]] to Doom Emacs.
+
+** Maintainers
+/This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+/This module has no flags./
+
+** Packages
+- [[doom-package:lean4-mode]]
+
+** TODO Hacks
+#+begin_quote
+ 󱌣 This module's hacks haven't been documented yet. [[doom-contrib-module:][Document them?]]
+#+end_quote
+
+** TODO Changelog
+# This section will be machine generated. Don't edit it by hand.
+/This module does not have a changelog yet./
+
+* TODO Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+#+begin_quote
+ 󱌣 /This module's prerequisites are not documented./ [[doom-contrib-module:][Document them?]]
+#+end_quote
+
+* TODO Usage
+
+See [[https://github.com/leanprover/lean4-mode][lean4-mode]].
+#+begin_quote
+ 󱌣 This module has no usage documentation yet. [[doom-contrib-module:][Write some?]]
+#+end_quote
+
+* TODO Configuration
+#+begin_quote
+ 󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
+#+end_quote
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+ 󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/lang/lean4/config.el
+++ b/modules/lang/lean4/config.el
@@ -1,0 +1,27 @@
+;;; lang/lean4/config.el -*- lexical-binding: t; -*-
+
+(after! lean4-mode
+  (sp-with-modes 'lean-mode
+    (sp-local-pair "/-" "-/")
+    (sp-local-pair "`" "`")
+    (sp-local-pair "{" "}")
+    (sp-local-pair "«" "»")
+    (sp-local-pair "⟨" "⟩")
+    (sp-local-pair "⟪" "⟫"))
+	(map! :map lean4-mode-map
+		:localleader
+		:desc "Execute"               "R" #'lean4-execute
+		:desc "Execute in standalone" "r" #'lean4-std-exe
+		:desc "Toggle info buffer"    "t" #'lean4-toggle-info
+		(:prefix ("e" . "Error")
+		 :desc "Previous error"       "p" #'flycheck-previous-error
+		 :desc "Next error"           "n" #'flycheck-next-error
+		 :desc "List error"           "l" #'flycheck-list-errors
+		 )
+		:desc "Lake build"            "b" #'lean4-lake-build
+		(:prefix ("p" . "leanpkg")
+		 :desc "Test"                 "t" #'lean4-leanpkg-test
+		 :desc "Build"                "b" #'lean4-leanpkg-build
+		 :desc "Configure"            "c" #'lean4-leanpkg-configure
+		 )
+		))

--- a/modules/lang/lean4/packages.el
+++ b/modules/lang/lean4/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/lean4/packages.el
+
+(package! lean4-mode :pin "d1c936409ade7d93e67107243cbc0aa55cda7fd5"
+	:recipe (:host github
+		:repo "leanprover/lean4-mode"
+		:files ("*.el" "data")))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
Lean 4's [first official release](https://github.com/leanprover/lean4/releases/tag/v4.0.0) has been created. There is no module for Lean 4 in doomemacs yet so I am opening this PR. This is my first time contributing so please tell me if I missed something.

Lean 4 is not compatible with Lean 3 and for a while they may coexist. This is why I opted to not change the existing `lang/lean` module. Unfortunately their file extensions are the same so when both `lean` and `lean4` are loaded, `.lean` files will default to Lean 3.