### PR TITLE
Disable lsp packages when eglot enabled

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -42,6 +42,7 @@
 
 (use-package! lsp-dart
   :when (modulep! +lsp)
+  :unless (modulep! :tools lsp +eglot)
   :defer t
   :config
   (map! :map dart-mode-map

--- a/modules/lang/dart/packages.el
+++ b/modules/lang/dart/packages.el
@@ -3,7 +3,7 @@
 
 (package! dart-mode :pin "9c846769abd37f7fdc7ba8388d1f3a2b844b75e3")
 
-(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
+(when (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
   (package! lsp-dart :pin "3db9f93c83052d6a8976c92d67d2b24473930760"))
 
 (when (modulep! +flutter)

--- a/modules/lang/dart/packages.el
+++ b/modules/lang/dart/packages.el
@@ -3,7 +3,7 @@
 
 (package! dart-mode :pin "9c846769abd37f7fdc7ba8388d1f3a2b844b75e3")
 
-(when (modulep! +lsp)
+(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
   (package! lsp-dart :pin "3db9f93c83052d6a8976c92d67d2b24473930760"))
 
 (when (modulep! +flutter)

--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -4,5 +4,5 @@
 (package! sbt-mode :pin "9fe1e8807c22cc1dc56a6233e000969518907f4d")
 (package! scala-mode :pin "5d7cf21c37e345c49f921fe5111a49fd54efd1e0")
 
-(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
+(when (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
   (package! lsp-metals :pin "a2df7263ece6ac69214e41c52d66aab8d3f650eb"))

--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -4,5 +4,5 @@
 (package! sbt-mode :pin "9fe1e8807c22cc1dc56a6233e000969518907f4d")
 (package! scala-mode :pin "5d7cf21c37e345c49f921fe5111a49fd54efd1e0")
 
-(when (modulep! +lsp)
+(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
   (package! lsp-metals :pin "a2df7263ece6ac69214e41c52d66aab8d3f650eb"))

--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -3,6 +3,8 @@
 (after! swift-mode
   (set-repl-handler! 'swift-mode #'run-swift)
 
+  (when (modulep! +lsp)
+    (add-hook 'swift-mode-local-vars-hook #'lsp! 'append))
   (when (modulep! +tree-sitter)
     (add-hook 'swift-mode-local-vars-hook #'tree-sitter! 'append)))
 
@@ -24,8 +26,8 @@
 
 (use-package! lsp-sourcekit
   :when (modulep! +lsp)
+  :unless (modulep! :tools lsp +eglot)
   :after swift-mode
-  :init (add-hook 'swift-mode-local-vars-hook #'lsp! 'append)
   :config
   (set-formatter! 'swiftformat '("swiftformat" "--output" "stdout"))
   (setq lsp-sourcekit-executable

--- a/modules/lang/swift/packages.el
+++ b/modules/lang/swift/packages.el
@@ -3,7 +3,7 @@
 
 (package! swift-mode :pin "1244ee48de1895d33f55fed81fc90acda0c901f1")
 
-(if (modulep! +lsp)
+(if (and (modulep! +lsp) (modulep! :tools lsp +eglot))
     (package! lsp-sourcekit :pin "468c641e35877e4e843f6b7c52a35937de562995")
   (when (modulep! :completion company)
     (package! company-sourcekit :pin "a1860ad4dd3a542acd2fa0dfac2a388cbdf4af0c"))

--- a/modules/lang/swift/packages.el
+++ b/modules/lang/swift/packages.el
@@ -3,7 +3,7 @@
 
 (package! swift-mode :pin "1244ee48de1895d33f55fed81fc90acda0c901f1")
 
-(if (and (modulep! +lsp) (modulep! :tools lsp +eglot))
+(if (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
     (package! lsp-sourcekit :pin "468c641e35877e4e843f6b7c52a35937de562995")
   (when (modulep! :completion company)
     (package! company-sourcekit :pin "a1860ad4dd3a542acd2fa0dfac2a388cbdf4af0c"))

--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -80,4 +80,5 @@ This must be set before `treemacs' has loaded.")
 
 (use-package! lsp-treemacs
   :when (modulep! +lsp)
+  :unless (modulep! :tools lsp +eglot)
   :after (treemacs lsp))

--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -11,5 +11,5 @@
   (package! treemacs-magit))
 (when (modulep! :ui workspaces)
   (package! treemacs-persp))
-(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
+(when (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
   (package! lsp-treemacs :pin "e66ae2196503d4e84334519e56b4388feffa5060"))

--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -11,5 +11,5 @@
   (package! treemacs-magit))
 (when (modulep! :ui workspaces)
   (package! treemacs-persp))
-(when (modulep! +lsp)
+(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
   (package! lsp-treemacs :pin "e66ae2196503d4e84334519e56b4388feffa5060"))


### PR DESCRIPTION
Some lsp-mode related modules doesn't have `:unless (modulep! :tools lsp +eglot)`. This will cause confliction of `eglot` and `lsp-mode` packages, so I added these flags. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
