### PR TITLE
bump: :emacs vc

### DIFF
--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -6,7 +6,7 @@
 (package! smerge-mode :built-in t)
 
 (package! browse-at-remote :pin "c020975a891438e278ad1855213d4f3d62c9fccb")
-(package! git-commit :pin "97a95f70079b6613bf98d2306279d3e03fe51234")
+(package! git-commit :pin "48818355728c48d986d74dde8b1e9fba25f0fd53")
 (package! git-timemachine
   ;; The original lives on codeberg.org; which has uptime issues.
   :recipe (:host github :repo "emacsmirror/git-timemachine")


### PR DESCRIPTION
magit/magit@97a95f70079b -> magit/magit@48818355728c

The pinned version of `magit` in `:tools magit` needs be the same as that of `git-commit` in `:emacs vc`.

`straight.el` prepares the repo only once, and if `git-commit` is processed first, its pinned version wins out and the more recent pinning of `magit` is ignored.

As noted in #7363, processing order may be non-deterministic, so the inconsistent pinning may not be apparent on every system.

This may not fully close #7363, because in addition to the immediate problem of inconsistent pinned versions of `magit` and `git-commit`, that issue suggests that having to define the pinning in two different places might itself be an issue that should be resolved.

Fix: #7363
Ref: #7277
Ref: 7c63b353d290

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
