### PR TITLE
Fix Org docs links

### DIFF
--- a/lisp/lib/docs.el
+++ b/lisp/lib/docs.el
@@ -372,7 +372,7 @@ depending.")
 (defvar doom-docs--cookies nil)
 ;;;###autoload
 (define-minor-mode doom-docs-mode
-  "Hides metadata, tags, & drawers and activates all org-mode pretiffications.
+  "Hides metadata, tags, & drawers and activates all org-mode prettifications.
 This primes `org-mode' for reading."
   :lighter " Doom Docs"
   :after-hook (org-restart-font-lock)
@@ -386,7 +386,7 @@ This primes `org-mode' for reading."
           (if doom-docs-mode
               (set (make-local-variable sym) t)
             (kill-local-variable sym)))
-        `(org-pretty-entities
+        '(org-pretty-entities
           org-hide-emphasis-markers
           org-hide-macro-markers))
   (when doom-docs-mode

--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -245,7 +245,7 @@ exist, and `org-link' otherwise."
               " " package))))))
 
 ;;;###autoload
-(defun +org-link-follow-doom-package-fn (pkg _prefixarg)
+(defun +org-link--doom-package-link-follow-fn (pkg _prefixarg)
   "TODO"
   (doom/describe-package (intern-soft pkg)))
 

--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -98,17 +98,14 @@ exist, and `org-link' otherwise."
   (when buffer-read-only
     (add-text-properties
      start end
-     (list 'display
-           (concat
-            #(" " 0 1
-              (rear-nonsticky
-               t display (raise 0.05)
-               face (:family "github-octicons"
-                     :inherit font-lock-variable-name-face
-                     :height 0.8
-                     :box (:line-width 1 :style none)))
-              1 2 (face (:height 0.2)))
-            var)))))
+     (list
+      'display
+      (concat (nerd-icons-mdicon "nf-md-toggle_switch") ; "󰔡"
+              " " (propertize var
+                              'face
+                              (if (boundp (intern var))
+                                  'font-lock-variable-name-face
+                                'shadow)))))))
 
 ;;;###autoload
 (defun +org-link--fn-link-activate-fn (start end fn _bracketed-p)
@@ -116,12 +113,12 @@ exist, and `org-link' otherwise."
     (add-text-properties
      start end
      (list 'display
-           (concat
-            #("λ " 0 1 (face (:inherit font-lock-function-name-face
-                              :box (:line-width 1 :style none)
-                              :height 0.9))
-              1 2 (face (:height 0.2)))
-            fn)))))
+           (concat (nerd-icons-mdicon "nf-md-function") ; "󰊕"
+                   " " (propertize fn
+                                   'face
+                                   (if (fboundp (intern fn))
+                                       'font-lock-function-name-face
+                                     'shadow)))))))
 
 ;;;###autoload
 (defun +org-link--face-link-activate-fn (start end face _bracketed-p)
@@ -129,18 +126,12 @@ exist, and `org-link' otherwise."
     (add-text-properties
      start end
      (list 'display
-           (concat
-            (propertize
-             ""
-             'rear-nonsticky t
-             'display '(raise -0.02)
-             'face (list '(:family "file-icons" :height 1.0)
-                          (if (facep (intern face))
-                              (intern face)
-                            'default)
-                          '(:underline nil)))
-            #(" " 0 1 (face (:underline nil)))
-            face)))))
+           (concat (nerd-icons-mdicon "nf-md-format_text") ; "󰊄"
+                   " " (propertize face
+                                   'face
+                                   (if (facep (intern face))
+                                       (intern face)
+                                     'shadow)))))))
 
 (defun +org-link--command-keys (command)
   "Convert command reference TEXT to key binding representation."
@@ -183,50 +174,36 @@ exist, and `org-link' otherwise."
         (recenter)))))
 
 ;;;###autoload
-(defun +org-link--doom-module-link-face-fn (module-path)
-  (cl-destructuring-bind (&key category module flag)
-      (+org-link--read-module-spec module-path)
-    (if (and category (doom-module-locate-path category module))
-        `(:inherit org-priority
-          :weight bold)
-      'error)))
-
-;;;###autoload
 (defun +org-link--doom-module-link-activate-fn (start end module-path _bracketed-p)
   (when buffer-read-only
     (cl-destructuring-bind (&key category module flag)
         (+org-link--read-module-spec module-path)
       (let ((overall-face
-             (cond
-              ((doom-module-p category module flag)
-               '((:underline nil) org-link org-block bold))
-              ((and category (doom-module-locate-path category module))
-               '(shadow org-block bold))
-              (t '((:strike-through t) error org-block))))
+             (if (and category (doom-module-locate-path category module))
+                 '((:underline nil) org-link org-block bold)
+               '(shadow org-block bold)))
             (icon-face
-             (if (doom-module-p category module flag) 'success 'error)))
+             (cond
+              ((doom-module-p category module flag) 'success)
+              ((and category (doom-module-locate-path category module)) 'warning)
+              (t 'error))))
         (add-text-properties
          start end
          (list 'face overall-face
                'display
                (concat
-                (propertize
-                 " "
-                 'rear-nonsticky t
-                 'display '(raise -0.02)
-                 'face `(:inherit ,icon-face
-                         :family "FontAwesome"
-                         :height 1.0))
-                module-path)))))))
+                (nerd-icons-octicon "nf-oct-stack" ; ""
+                                    :face icon-face)
+                " " module-path)))))))
 
 ;;;###autoload
 (defun +org-link--doom-package-link-activate-fn (start end package _bracketed-p)
   (when buffer-read-only
     (let ((overall-face
            (if (locate-library package)
-               '((:underline nil) org-link org-block italic)
+               '((:underline nil :weight regular) org-link org-block italic)
              '(shadow org-block italic)))
-          (pkg-face
+          (icon-face
            (cond
             ((featurep (intern package)) 'success)
             ((locate-library package) 'warning)
@@ -236,12 +213,8 @@ exist, and `org-link' otherwise."
        (list 'face overall-face
              'display
              (concat
-              (propertize
-               "\uf0c4" ; Octicon package symbol
-               'rear-nonsticky t
-               'display '(raise -0.02)
-               'face `(:family "github-octicons" :height 1.0
-                       :inherit ,pkg-face))
+              (nerd-icons-octicon "nf-oct-package" ; ""
+                                  :face icon-face)
               " " package))))))
 
 ;;;###autoload
@@ -257,15 +230,11 @@ exist, and `org-link' otherwise."
        start end
        (list 'display
              (concat
-              (nerd-icons-devicon "nf-dev-terminal_badge"
-                                  :rear-nonsticky t
-                                  :display '(raise -0.02)
-                                  :face (list :height 1.0
-                                              :inherit (if found 'success 'error)))
+              (nerd-icons-octicon "nf-oct-terminal" ; ""
+                                  :face (if found 'success 'error))
               " "
-              (propertize
-               executable
-               'face (if found 'org-verbatim 'default))))))))
+              (propertize executable
+                          'face (if found 'org-verbatim 'shadow))))))))
 
 ;;
 ;;; Help-echo / eldoc

--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -124,7 +124,7 @@ exist, and `org-link' otherwise."
             fn)))))
 
 ;;;###autoload
-(defun +org-link--face-link-activate-face (start end face _bracketed-p)
+(defun +org-link--face-link-activate-fn (start end face _bracketed-p)
   (when buffer-read-only
     (add-text-properties
      start end
@@ -156,7 +156,7 @@ exist, and `org-link' otherwise."
     (concat prefix (and prefix " ") key-text)))
 
 ;;;###autoload
-(defun +org-link--command-link-activate-command (start end command _bracketed-p)
+(defun +org-link--command-link-activate-fn (start end command _bracketed-p)
   (when buffer-read-only
     (add-text-properties
      start end (list 'display (+org-link--command-keys command)))))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -548,12 +548,12 @@ relative to `org-directory', unless it is an absolute path."
      "var"
      :follow (-call-interactively #'helpful-variable)
      :activate-func #'+org-link--var-link-activate-fn
-     :face 'org-code)
+     :face '(font-lock-variable-name-face underline))
     (org-link-set-parameters
      "fn"
      :follow (-call-interactively #'helpful-callable)
      :activate-func #'+org-link--fn-link-activate-fn
-     :face 'org-code)
+     :face '(font-lock-function-name-face underline))
     (org-link-set-parameters
      "face"
      :follow (-call-interactively #'describe-face)
@@ -569,13 +569,11 @@ relative to `org-directory', unless it is an absolute path."
      "doom-package"
      :follow #'+org-link--doom-package-link-follow-fn
      :activate-func #'+org-link--doom-package-link-activate-fn
-     :face (lambda (_) '(:inherit org-priority :slant italic))
      :help-echo #'+org-link-doom--help-echo-from-textprop)
     (org-link-set-parameters
      "doom-module"
      :follow #'+org-link--doom-module-link-follow-fn
      :activate-func #'+org-link--doom-module-link-activate-fn
-     :face #'+org-link--doom-module-link-face-fn
      :help-echo #'+org-link-doom--help-echo-from-textprop)
     (org-link-set-parameters
      "doom-executable"
@@ -614,7 +612,7 @@ relative to `org-directory', unless it is an absolute path."
                 (format "https://github.com/%s"
                         (string-remove-prefix
                          "@" (+org-link-read-desc-at-point link)))))
-     :face (lambda (_) 'org-priority))
+     :face 'org-priority)
     (org-link-set-parameters
      "doom-changelog"
      :follow (lambda (link)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -567,7 +567,7 @@ relative to `org-directory', unless it is an absolute path."
      :help-echo #'+org-link-doom--help-echo-from-textprop)
     (org-link-set-parameters
      "doom-package"
-     :follow #'+org-link-follow-doom-package-fn
+     :follow #'+org-link--doom-package-link-follow-fn
      :activate-func #'+org-link--doom-package-link-activate-fn
      :face (lambda (_) '(:inherit org-priority :slant italic))
      :help-echo #'+org-link-doom--help-echo-from-textprop)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -557,12 +557,12 @@ relative to `org-directory', unless it is an absolute path."
     (org-link-set-parameters
      "face"
      :follow (-call-interactively #'describe-face)
-     :activate-func #'+org-link--face-link-activate-face
+     :activate-func #'+org-link--face-link-activate-fn
      :face '(font-lock-type-face underline))
     (org-link-set-parameters
      "cmd"
      :follow (-call-interactively #'describe-command)
-     :activate-func #'+org-link--command-link-activate-command
+     :activate-func #'+org-link--command-link-activate-fn
      :face 'help-key-binding
      :help-echo #'+org-link-doom--help-echo-from-textprop)
     (org-link-set-parameters

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -573,7 +573,7 @@ relative to `org-directory', unless it is an absolute path."
      :help-echo #'+org-link-doom--help-echo-from-textprop)
     (org-link-set-parameters
      "doom-module"
-     :follow #'+org-link-follow-doom-module-fn
+     :follow #'+org-link--doom-module-link-follow-fn
      :activate-func #'+org-link--doom-module-link-activate-fn
      :face #'+org-link--doom-module-link-face-fn
      :help-echo #'+org-link-doom--help-echo-from-textprop)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The fancy Org docs links had some regressions with the switch to Nerd Fonts. In the process of addressing those, I ended up finding and taking care of several other quirks. See the commit messages for more details.

Before:

![image](https://github.com/doomemacs/doomemacs/assets/44043764/711c11e3-591a-46e2-9531-ce80ce30bb26)

Note the changed codepoint for the variable icon resulting in a folder glyph from Nerd Fonts as well as the scissors in place of the package Octicon. Also, the face icon (U+E90F, ) will appear as tofu for people who don’t happen to have all-the-icons installed, Nerd Fonts don’t have a glyph at that code point.

After:

![image](https://github.com/doomemacs/doomemacs/assets/44043764/8783f70d-608a-4732-911a-cd0d1458ae78)

Note the shadowed unbound symbols and the passthrough of the `fixed-pitch-serif` face (it’s a bit subtle in this particular case, but you can at least see the difference in the `f` glyphs). Packages (italic) and modules (bold) that are found on their load paths get blue links, and disabled modules and unloaded packages get `warning` icons to align with their `help-echo` messages. Since executables don’t have a follow function for more information, they don’t look like links.

There were often breadcrumbs in the existing implementation indicating that some of these behaviors were intended from the start; they just needed a little polish.

Here’s the source for the example:
```org
- [[var:doom-font]]
- [[var:foo]]
- [[fn:doom-big-font-mode]]
- [[fn:foo]]
- [[face:fixed-pitch-serif]]
- [[face:foo]]
  
- [[doom-package:org]]
- [[doom-package:eglot]]
- [[doom-package:lsp-mode]]
- [[doom-module::tools lsp]]
- [[doom-module::tools ansible]]
- [[doom-module::tools foo]]
- [[doom-executable:latex]]
- [[doom-executable:gnuplot]]
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] *n/a* Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
