### PR TITLE
feat(pdf): prefer built-in pdf-tools

### DIFF
--- a/modules/tools/pdf/README.org
+++ b/modules/tools/pdf/README.org
@@ -42,6 +42,16 @@ This module requires the =epdfinfo= program. Unless you're on Windows, the
 pdf-tools-install~ command. See the next section for instructions on how to
 build the =epdfinfo= program on Windows.
 
+Some Linux distributions package [[doom-package:pdf-tools]] with a prebuilt
+=epdfinfo= program.
+- NixOS (home-manager):
+  #+begin_src nix
+  programs.emacs = {
+    enable = true;
+    extraPackages = epkgs: [ epkgs.pdf-tools ];
+  };
+  #+end_src
+
 ** Building =epdfinfo= on Windows
 1. [[https://www.msys2.org/][Install MSYS2]] and update the package database and core packages using the
    instructions provided.

--- a/modules/tools/pdf/packages.el
+++ b/modules/tools/pdf/packages.el
@@ -1,5 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/pdf/packages.el
 
-(package! pdf-tools :pin "c69e7656a4678fe25afbd29f3503dd19ee7f9896")
+(package! pdf-tools
+  :built-in 'prefer
+  :pin "c69e7656a4678fe25afbd29f3503dd19ee7f9896")
 (package! saveplace-pdf-view :pin "abfb5e1f463cffc18218a0f7f2fa141a271b1813")


### PR DESCRIPTION
Nixpkgs provides a pdf-tools with prebuilt epdfinfo, much like vterm. It works on my machine. I added an entry to the docs similar to the vterm module’s, but I held off on distros I’m not able to test myself. People who use a built-in package on other distros can make PRs as desired.

Based on your unconditional use of the `:built-in` keyword for vterm, I assume this gracefully falls back to installing pdf-tools like normal if no built-in package is available?

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] *n/a* Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
