### PR TITLE
fix(mu4e): replace obsolete/removed functions

### DIFF
--- a/modules/email/mu4e/autoload/advice.el
+++ b/modules/email/mu4e/autoload/advice.el
@@ -1,37 +1,5 @@
 ;;; email/mu4e/autoload/advice.el -*- lexical-binding: t; -*-
 
-;;;###autoload
-(defun +mu4e~main-action-str-prettier-a (str &optional func-or-shortcut)
-  "Highlight the first occurrence of [.] in STR.
-If FUNC-OR-SHORTCUT is non-nil and if it is a function, call it
-when STR is clicked (using RET or mouse-2); if FUNC-OR-SHORTCUT is
-a string, execute the corresponding keyboard action when it is
-clicked."
-  (let ((newstr
-         (replace-regexp-in-string
-          "\\[\\(..?\\)\\]"
-          (lambda(m)
-            (format "%s"
-                    (propertize (match-string 1 m) 'face 'mu4e-highlight-face)))
-          (replace-regexp-in-string "\t\\*" (format "\t%s" +mu4e-main-bullet) str)))
-        (map (make-sparse-keymap))
-        (func (if (functionp func-or-shortcut)
-                  func-or-shortcut
-                (if (stringp func-or-shortcut)
-                    (lambda()(interactive)
-                      (execute-kbd-macro func-or-shortcut))))))
-    (define-key map [mouse-2] func)
-    (define-key map (kbd "RET") func)
-    (put-text-property 0 (length newstr) 'keymap map newstr)
-    (put-text-property (string-match "[A-Za-z].+$" newstr)
-                       (- (length newstr) 1) 'mouse-face 'highlight newstr)
-    newstr))
-
-;;;###autoload
-(defun +mu4e~main-keyval-str-prettier-a (str)
-  "Replace '*' with `+mu4e-main-bullet' in STR."
-  (replace-regexp-in-string "\t\\*" (format "\t%s" +mu4e-main-bullet) str))
-
 ;; Org msg LaTeX image scaling
 
 ;;;###autoload

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -360,18 +360,6 @@ This should already be the case yet it does not always seem to be."
     :before #'mu4e-compose-resend
     (read-only-mode -1))
 
-  (defvar +mu4e-main-bullet "⚫"
-    "Prefix to use instead of \"	*\" in the mu4e main view.
-This is enacted by `+mu4e--main-action-str-prettier-a' and
-`+mu4e--main-keyval-str-prettier-a'.")
-
-  (advice-add #'mu4e--key-val :filter-return #'+mu4e--main-keyval-str-prettier-a)
-  (advice-add #'mu4e--main-action-str :override #'+mu4e--main-action-str-prettier-a)
-  (when (modulep! :editor evil)
-    ;; As +mu4e--main-action-str-prettier replaces [k]ey with key [q]uit should
-    ;; become quit
-    (setq evil-collection-mu4e-end-region-misc "quit"))
-
   ;; process lock control
   (when IS-WINDOWS
     (setq

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -42,7 +42,8 @@
                "read-patch-directory" "replace-first-line-matching"
                "request-contacts-maybe" "rfc822-phrase-type" "start" "stop"
                "temp-window" "update-contacts" "update-mail-and-index-real"
-               "update-mail-mode" "update-sentinel-func"))
+               "update-mail-mode" "update-sentinel-func" "view-gather-mime-parts"
+               "view-open-file" "view-mime-part-to-temp-file"))
       (defalias (intern (concat "mu4e--" transferable-suffix))
         (intern (concat "mu4e~" transferable-suffix))
         "Alias to provide the API of mu4e 1.8 (mu4e~ ⟶ mu4e--).")
@@ -272,7 +273,7 @@ Acts like a singular `mu4e-view-save-attachments', without the saving."
                                  (lambda (part)
                                    (when (assoc "attachment" (cdr part))
                                      part))
-                                 (mu4e~view-gather-mime-parts))))
+                                 (mu4e--view-gather-mime-parts))))
                (files (+mu4e-part-selectors parts)))
           (cdr (assoc (completing-read "Select attachment: " (mapcar #'car files)) files))
         (user-error (mu4e-format "No attached files found"))))
@@ -280,13 +281,13 @@ Acts like a singular `mu4e-view-save-attachments', without the saving."
     (defun +mu4e-view-open-attachment ()
       "Select an attachment, and open it."
       (interactive)
-      (mu4e~view-open-file
-       (mu4e~view-mime-part-to-temp-file (cdr (+mu4e-view-select-attachment)))))
+      (mu4e--view-open-file
+       (mu4e--view-mime-part-to-temp-file (cdr (+mu4e-view-select-attachment)))))
 
     (defun +mu4e-view-select-mime-part-action ()
       "Select a MIME part, and perform an action on it."
       (interactive)
-      (let ((labeledparts (+mu4e-part-selectors (mu4e~view-gather-mime-parts))))
+      (let ((labeledparts (+mu4e-part-selectors (mu4e--view-gather-mime-parts))))
         (if labeledparts
             (mu4e-view-mime-part-action
              (cadr (assoc (completing-read "Select part: " (mapcar #'car labeledparts))
@@ -361,13 +362,14 @@ This should already be the case yet it does not always seem to be."
 
   (defvar +mu4e-main-bullet "⚫"
     "Prefix to use instead of \"	*\" in the mu4e main view.
-This is enacted by `+mu4e~main-action-str-prettier-a' and
-`+mu4e~main-keyval-str-prettier-a'.")
+This is enacted by `+mu4e--main-action-str-prettier-a' and
+`+mu4e--main-keyval-str-prettier-a'.")
 
-  (advice-add #'mu4e--key-val :filter-return #'+mu4e~main-keyval-str-prettier-a)
-  (advice-add #'mu4e--main-action-str :override #'+mu4e~main-action-str-prettier-a)
+  (advice-add #'mu4e--key-val :filter-return #'+mu4e--main-keyval-str-prettier-a)
+  (advice-add #'mu4e--main-action-str :override #'+mu4e--main-action-str-prettier-a)
   (when (modulep! :editor evil)
-    ;; As +mu4e~main-action-str-prettier replaces [k]ey with key q]uit should become quit
+    ;; As +mu4e--main-action-str-prettier replaces [k]ey with key [q]uit should
+    ;; become quit
     (setq evil-collection-mu4e-end-region-misc "quit"))
 
   ;; process lock control


### PR DESCRIPTION
This commit fixes several Doom mu4e functions which are broken on later versions of mu4e due to the variable prefix change from mu4e~ to mu4e--. I also added them to the forwards-compatibility aliases.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
