### PR TITLE
fix(ruby): return robe repl buffer

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -48,7 +48,8 @@
           (bound-and-true-p lsp--buffer-deferred)
           (robe-mode +1))))
   :config
-  (set-repl-handler! 'ruby-mode #'robe-start)
+  (set-repl-handler! 'ruby-mode (λ! (robe-start)
+                                    (robe-inf-buffer)))
   (set-company-backend! 'ruby-mode 'company-robe 'company-dabbrev-code)
   (set-lookup-handlers! 'ruby-mode
     :definition #'robe-jump


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

`robe-start` just returns nil which breaks an assumption held by `set-repl-handler!`. Using `robe-inf-buffer` seems to have solved it.
-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
