### PR TITLE
fix(org): add missing autoloads for org-attach

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -481,7 +481,9 @@ relative to `org-directory', unless it is an absolute path."
 
   ;; Autoload all these commands that org-attach doesn't autoload itself
   (use-package! org-attach
-    :commands (org-attach-new
+    :commands (org-attach-delete-one
+               org-attach-delete-all
+               org-attach-new
                org-attach-open
                org-attach-open-in-emacs
                org-attach-reveal-in-emacs


### PR DESCRIPTION
org-attach-delete-one and -all are bound to keys, thus requiring autoload. Otherwise an error occurs when executing them before org-attach is loaded.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

