### PR TITLE
fix(vertico): use consult-dir/fd for find

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -149,9 +149,10 @@ If DIR is not a project, it will be indexed (but not cached)."
             (if (doom-module-p :completion 'ivy)
                 #'counsel-projectile-find-file
               #'projectile-find-file)))
-          ((and (bound-and-true-p vertico-mode)
-                (fboundp '+vertico/find-file-in))
-           (+vertico/find-file-in default-directory))
+          ((bound-and-true-p vertico-mode)
+           (if (executable-find "fd")
+               (consult-fd dir)
+             (consult-find dir)))
           ((and (bound-and-true-p ivy-mode)
                 (fboundp 'counsel-file-jump))
            (call-interactively #'counsel-file-jump))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -135,26 +135,6 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
         (+vertico/embark-preview)
       (user-error (vertico-directory-enter)))))
 
-(defvar +vertico/find-file-in--history nil)
-;;;###autoload
-(defun +vertico/find-file-in (&optional dir initial)
-  "Jump to file under DIR (recursive).
-If INITIAL is non-nil, use as initial input."
-  (interactive)
-  (require 'consult)
-  (let* ((default-directory (or dir default-directory))
-         (prompt-dir (consult--directory-prompt "Find" default-directory))
-         (cmd (split-string-and-unquote +vertico-consult-fd-args " ")))
-    (find-file
-     (consult--read
-      (split-string (cdr (apply #'doom-call-process cmd)) "\n" t)
-      :prompt default-directory
-      :sort nil
-      :initial (if initial (shell-quote-argument initial))
-      :add-history (thing-at-point 'filename)
-      :category 'file
-      :history '(:input +vertico/find-file-in--history)))))
-
 ;;;###autoload
 (defun +vertico/jump-list (jump)
   "Go to an entry in evil's (or better-jumper's) jumplist."

--- a/modules/config/default/autoload/files.el
+++ b/modules/config/default/autoload/files.el
@@ -32,10 +32,14 @@
   (doom-project-find-file org-directory))
 
 ;;;###autoload
-(defun +default/find-file-under-here ()
-  "Perform a recursive file search from the current directory."
-  (interactive)
-  (doom-project-find-file default-directory))
+(defun +default/find-file-under-here (&optional prefix)
+  "Perform a recursive file search from the current directory.
+Prompt for directory if PREFIX."
+  (interactive "P")
+  (let ((dir (if prefix
+                 (read-directory-name "Directory: ")
+               default-directory)))
+    (doom-project-find-file dir)))
 
 ;;;###autoload
 (defun +default/discover-projects (arg)


### PR DESCRIPTION
Use the built-in functions for `fd` and `find` instead for `vertico`. These are better because ours loads all the files into `vertico` immediately, which is slow for large directories, whereas `consult-fd` and `consult-find` does the searches asynchronously. I also added an optional prefix arg to query for a directory before searching.

Please check that these vertico commands exist in your pinned version of `vertico`, since I have all my packages unpinned.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to finish it.
