### PR TITLE
fix(popup): change evil function to call following upstream rename

### DIFF
--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -120,7 +120,7 @@ were followed."
       (setq-local evil-command-window-execute-fn execute-fn)
       (setq-local evil-command-window-cmd-key cmd-key)
       (evil-command-window-mode)
-      (evil-command-window-insert-commands hist)))
+      (evil--command-window-insert-commands hist)))
 
   (defadvice! +popup--evil-command-window-execute-a ()
     "Execute the command under the cursor in the appropriate buffer, rather than


### PR DESCRIPTION
https://github.com/emacs-evil/evil/commit/a09fdca0b35ef4289cf55d7b0ffadf4cf3a5c9fc renames `evil-command-window-insert-commands` to `evil--command-window-insert-commands` so we have to change our function calls. Without this PR `evil-command-window` gives a blank buffer as no command is inserted.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
