### PR TITLE
bump: :completion vertico

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -150,8 +150,8 @@ If DIR is not a project, it will be indexed (but not cached)."
                 #'counsel-projectile-find-file
               #'projectile-find-file)))
           ((and (bound-and-true-p vertico-mode)
-                (fboundp '+vertico/find-file-in))
-           (+vertico/find-file-in default-directory))
+                (fboundp '+vertico/consult-fd-or-find))
+           (+vertico/consult-fd-or-find default-directory))
           ((and (bound-and-true-p ivy-mode)
                 (fboundp 'counsel-file-jump))
            (call-interactively #'counsel-file-jump))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -137,26 +137,6 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
         (+vertico/embark-preview)
       (user-error (vertico-directory-enter)))))
 
-(defvar +vertico/find-file-in--history nil)
-;;;###autoload
-(defun +vertico/find-file-in (&optional dir initial)
-  "Jump to file under DIR (recursive).
-If INITIAL is non-nil, use as initial input."
-  (interactive)
-  (require 'consult)
-  (let* ((default-directory (or dir default-directory))
-         (prompt-dir (consult--directory-prompt "Find" default-directory))
-         (cmd (split-string-and-unquote +vertico-consult-fd-args " ")))
-    (find-file
-     (consult--read
-      (split-string (cdr (apply #'doom-call-process cmd)) "\n" t)
-      :prompt default-directory
-      :sort nil
-      :initial (if initial (shell-quote-argument initial))
-      :add-history (thing-at-point 'filename)
-      :category 'file
-      :history '(:input +vertico/find-file-in--history)))))
-
 ;;;###autoload
 (defun +vertico/jump-list (jump)
   "Go to an entry in evil's (or better-jumper's) jumplist."
@@ -229,27 +209,10 @@ targets."
                    (not (string-suffix-p "-argument" (cdr binding))))))))
 
 ;;;###autoload
-(defun +vertico--consult--fd-make-builder ()
-  (let ((cmd (split-string-and-unquote +vertico-consult-fd-args)))
-    (lambda (input)
-      (pcase-let* ((`(,arg . ,opts) (consult--command-split input))
-                   (`(,re . ,hl) (funcall consult--regexp-compiler
-                                          arg 'extended t)))
-        (when re
-          (cons (append cmd
-                        (list (consult--join-regexps re 'extended))
-                        opts)
-                hl))))))
-
-(autoload #'consult--directory-prompt "consult")
-;;;###autoload
-(defun +vertico/consult-fd (&optional dir initial)
+(defun +vertico/consult-fd-or-find (&optional dir initial)
   (interactive "P")
   (if doom-projectile-fd-binary
-      (pcase-let* ((`(,prompt ,paths ,dir) (consult--directory-prompt "Fd" dir))
-                   (default-directory dir)
-                   (builder (consult--find-make-builder paths)))
-        (find-file (consult--find prompt builder initial)))
+      (consult-fd dir initial)
     (consult-find dir initial)))
 
 ;;;###autoload

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -210,8 +210,21 @@ targets."
 
 ;;;###autoload
 (defun +vertico/consult-fd-or-find (&optional dir initial)
+  "Runs consult-fd if fd version > 8.6.0 exists, consult-find otherwise.
+See URL `https://github.com/minad/consult/issues/770'."
   (interactive "P")
-  (if doom-projectile-fd-binary
+  ;; TODO this condition was adapted from a similar one in lisp/doom-projects.el, to be replaced with a more robust check post v3
+  (if (when-let*
+          ((bin (if (ignore-errors (file-remote-p default-directory nil t))
+                    (cl-find-if (doom-rpartial #'executable-find t)
+                                (list "fdfind" "fd"))
+                  doom-projectile-fd-binary))
+           (version (with-memoization doom-projects--fd-version
+                      (cadr (split-string (cdr (doom-call-process bin "--version"))
+                                          " " t))))
+           ((ignore-errors (version-to-list version))))
+        ;; TODO remove once fd 8.6.0 is widespread enough to be the minimum version for doom
+        (version< "8.6.0" version))
       (consult-fd dir initial)
     (consult-find dir initial)))
 

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -149,7 +149,7 @@ orderless."
   (if doom-projectile-fd-binary
       (setq consult-fd-args
             '(doom-projectile-fd-binary
-              "--full-path --color=never -H -E .git --regex"
+              "--full-path --color=never -H -E .git"
               (when IS-WINDOWS "--path-separator=/"))))
 
   (consult-customize

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -149,7 +149,7 @@ orderless."
   (if doom-projectile-fd-binary
       (setq consult-fd-args
             '(doom-projectile-fd-binary
-              "--full-path --color=never -i -H -E .git --regex"
+              "--full-path --color=never -H -E .git --regex"
               (when IS-WINDOWS "--path-separator=/"))))
 
   (consult-customize

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -7,9 +7,6 @@ The completion/vertico module uses the orderless completion style by default,
 but this returns too broad a candidate set for company completion. This variable
 overrides `completion-styles' during company completion sessions.")
 
-(defvar +vertico-consult-fd-args nil
-  "Shell command and arguments the vertico module uses for fd.")
-
 (defvar +vertico-consult-dir-container-executable "docker"
   "Command to call for listing container hosts.")
 
@@ -149,13 +146,11 @@ orderless."
         consult-async-refresh-delay  0.15
         consult-async-input-throttle 0.2
         consult-async-input-debounce 0.1)
-  (unless +vertico-consult-fd-args
-    (setq +vertico-consult-fd-args
-          (if doom-projectile-fd-binary
-              (format "%s --color=never -i -H -E .git --regex %s"
-                      doom-projectile-fd-binary
-                      (if IS-WINDOWS "--path-separator=/" ""))
-            consult-find-args)))
+  (if doom-projectile-fd-binary
+      (setq consult-fd-args
+            '(doom-projectile-fd-binary
+              "--full-path --color=never -i -H -E .git --regex"
+              (when IS-WINDOWS "--path-separator=/"))))
 
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep
@@ -305,9 +300,9 @@ orderless."
   (map! (:map embark-file-map
          :desc "Open target with sudo"        "s"   #'doom/sudo-find-file
          (:when (modulep! :tools magit)
-          :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
+           :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (modulep! :ui workspaces)
-          :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace))))
+           :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace))))
 
 
 (use-package! marginalia

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -149,7 +149,10 @@ orderless."
   (if doom-projectile-fd-binary
       (setq consult-fd-args
             '(doom-projectile-fd-binary
-              "--full-path --color=never -H -E .git"
+              "--color=never"
+              ;; https://github.com/sharkdp/fd/issues/839
+              "--full-path --absolute-path"
+              "--hidden --exclude .git"
               (when IS-WINDOWS "--path-separator=/"))))
 
   (consult-customize

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -139,7 +139,7 @@ orderless."
     :before (list #'consult-recent-file #'consult-buffer)
     (recentf-mode +1))
 
-  (setq consult-project-root-function #'doom-project-root
+  (setq consult-project-function #'doom-project-root
         consult-narrow-key "<"
         consult-line-numbers-widen t
         consult-async-min-input 2

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -1,22 +1,19 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; completion/vertico/packages.el
 
-(package! vertico
-  :recipe (:host github :repo "minad/vertico"
-           :files ("*.el" "extensions/*.el"))
-  :pin "a28370d07f35c5387c7a9ec2e5b67f0d4598058d")
+(package! vertico  :pin "03bfb71a2b5db296a93eeb0752bd934d112e0792")
 
-(package! orderless :pin "e6784026717a8a6a7dcd0bf31fd3414f148c542e")
+(package! orderless :pin "d6b402a89e234d0e6166247ed6025f9acc8b4d9a")
 
-(package! consult :pin "fe49dedd71802ff97be7b89f1ec4bd61b98c2b13")
-(package! consult-dir :pin "ed8f0874d26f10f5c5b181ab9f2cf4107df8a0eb")
+(package! consult :pin "43380042daaaf57f60aa22962a97ed904a7d56ce")
+(package! consult-dir :pin "3f5f4b71ebe819392cb090cda71bd39a93bd830a")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
   (package! consult-flycheck :pin "3f2a7c17cc2fe64e0c07e3bf90e33c885c0d7062"))
-(package! embark :pin "9a44418c349e41020cdc5ad1bd21e8c77a429062")
-(package! embark-consult :pin "9a44418c349e41020cdc5ad1bd21e8c77a429062")
+(package! embark :pin "7758a1ac64d784fa71f14b202b7a26c27f29d03e")
+(package! embark-consult :pin "7758a1ac64d784fa71f14b202b7a26c27f29d03e")
 
-(package! marginalia :pin "866e50aee4f066b0903752c69b33e9b7cab93f97")
+(package! marginalia :pin "f1734375a5d8fa18e9cecb47ae4b5ae86c72399f")
 
 (package! wgrep :pin "3132abd3750b8c87cbcf6942db952acfab5edccd")
 
@@ -26,4 +23,4 @@
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "7da6d648ff4202a48eb6647ee7dce8d65de48779"))
+    :pin "db9fbc95bb8316165ec74e500a76d6857e6ced1a"))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -1,19 +1,19 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; completion/vertico/packages.el
 
-(package! vertico  :pin "03bfb71a2b5db296a93eeb0752bd934d112e0792")
+(package! vertico  :pin "e8edac107df5883f2fa8690356a8d8deee1a83de")
 
-(package! orderless :pin "d6b402a89e234d0e6166247ed6025f9acc8b4d9a")
+(package! orderless :pin "b24748093b00b37c3a572c4909f61c08fa27504f")
 
-(package! consult :pin "43380042daaaf57f60aa22962a97ed904a7d56ce")
+(package! consult :pin "9c7dbbe4d626987e40d7a157430021e13a6906bd")
 (package! consult-dir :pin "3f5f4b71ebe819392cb090cda71bd39a93bd830a")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
-  (package! consult-flycheck :pin "3f2a7c17cc2fe64e0c07e3bf90e33c885c0d7062"))
-(package! embark :pin "7758a1ac64d784fa71f14b202b7a26c27f29d03e")
-(package! embark-consult :pin "7758a1ac64d784fa71f14b202b7a26c27f29d03e")
+  (package! consult-flycheck :pin "0662839aa5db429130f5ffd15c14d4a980b2e694"))
+(package! embark :pin "b9f2b3b9a5b9c72cf1416097b9941c4f275dae94")
+(package! embark-consult :pin "b9f2b3b9a5b9c72cf1416097b9941c4f275dae94")
 
-(package! marginalia :pin "f1734375a5d8fa18e9cecb47ae4b5ae86c72399f")
+(package! marginalia :pin "27ccfd2213bb9432883427cf058c63af10196aa6")
 
 (package! wgrep :pin "3132abd3750b8c87cbcf6942db952acfab5edccd")
 
@@ -23,4 +23,4 @@
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "db9fbc95bb8316165ec74e500a76d6857e6ced1a"))
+    :pin "15168c92ca06a39fbf84ac27d4e2ae02216300b5"))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -1,21 +1,21 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; completion/vertico/packages.el
 
-(package! vertico  :pin "e8edac107df5883f2fa8690356a8d8deee1a83de")
+(package! vertico  :pin "cf8b2abf5207696c054c33214c86e3969d415054")
 
 (package! orderless :pin "b24748093b00b37c3a572c4909f61c08fa27504f")
 
-(package! consult :pin "9c7dbbe4d626987e40d7a157430021e13a6906bd")
+(package! consult :pin "e4d371235647a7f4967f093eff2125652796957c")
 (package! consult-dir :pin "3f5f4b71ebe819392cb090cda71bd39a93bd830a")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
-  (package! consult-flycheck :pin "0662839aa5db429130f5ffd15c14d4a980b2e694"))
-(package! embark :pin "b9f2b3b9a5b9c72cf1416097b9941c4f275dae94")
-(package! embark-consult :pin "b9f2b3b9a5b9c72cf1416097b9941c4f275dae94")
+  (package! consult-flycheck :pin "d83f87581af74f7a2739d8b1b90c37da5ae3d310"))
+(package! embark :pin "33c392cf3ce5b92ad73ed5c4f44dbca5d0741cde")
+(package! embark-consult :pin "33c392cf3ce5b92ad73ed5c4f44dbca5d0741cde")
 
-(package! marginalia :pin "27ccfd2213bb9432883427cf058c63af10196aa6")
+(package! marginalia :pin "ea356ebb1ddb8d6da78574b517155475cf52d46f")
 
-(package! wgrep :pin "3132abd3750b8c87cbcf6942db952acfab5edccd")
+(package! wgrep :pin "208b9d01cfffa71037527e3a324684b3ce45ddc4")
 
 (when (modulep! +icons)
   (package! nerd-icons-completion :pin "c2db8557a3c1a9588d111f8c8e91cae96ee85010"))
@@ -23,4 +23,4 @@
 (when (modulep! +childframe)
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
-    :pin "15168c92ca06a39fbf84ac27d4e2ae02216300b5"))
+    :pin "bc0e67cbbba4daaf6ce7b8701a0dc7797d468752"))

--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -283,7 +283,7 @@ otherwise falling back to ffap.el (find-file-at-point)."
            (counsel-file-jump guess (doom-project-root)))
           ((and (modulep! :completion vertico)
                 (doom-project-p))
-           (+vertico/find-file-in (doom-project-root) guess))
+           (+vertico/consult-fd-or-find (doom-project-root) guess))
           ((find-file-at-point (ffap-prompter guess))))
     t))
 


### PR DESCRIPTION
This PR bumps the vertico module, switches to use consult-fd now that it's upstream instead of re implementing it, and adapts to an upstream variable rename that happened way back that slipped by at the time