### PR TITLE
fix(vertico): ensure recentf-mode for consult-buffer

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -136,9 +136,10 @@ orderless."
     [remap yank-pop]                      #'consult-yank-pop
     [remap persp-switch-to-buffer]        #'+vertico/switch-workspace-buffer)
   :config
-  (defadvice! +vertico--consult-recent-file-a (&rest _args)
-    "`consult-recent-file' needs to have `recentf-mode' on to work correctly"
-    :before #'consult-recent-file
+  (defadvice! +vertico--consult-recentf-a (&rest _args)
+    "`consult-recent-file' needs to have `recentf-mode' on to work correctly.
+`consult-buffer' needs `recentf-mode' to show file candidates."
+    :before (list #'consult-recent-file #'consult-buffer)
     (recentf-mode +1))
 
   (setq consult-project-root-function #'doom-project-root


### PR DESCRIPTION
`consult-buffer` uses `recentf` to populate file candidates. It is not uncommon to use `consult-buffer` as a single entry point to buffers, bookmarks and recent files, effectively replacing `recentf` and `consult-recent-file`.

To improve startup performance, Doom enables `recentf-mode` after the first file is opened (0e851ace9ba4). When executing `consult-buffer` at startup, `recentf-mode` won’t be enabled yet. Add it to the `consult-recent-file` advice to ensure that can’t happen.

Unlike `consult-recent-file`, `consult-buffer` does have significant functionality without `recentf-mode`, but for the tiny fraction of Doom users that disable `recentf-mode`, this is easy enough to `advice-remove`.

Fix: https://github.com/doomemacs/doomemacs/issues/7461

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
