### PR TITLE
fix(data): correct XML closing tag insertion

### DIFF
--- a/modules/lang/data/config.el
+++ b/modules/lang/data/config.el
@@ -7,6 +7,9 @@
   :config
   (setq nxml-slash-auto-complete-flag t
         nxml-auto-insert-xml-declaration-flag t)
+  ;; https://github.com/Fuco1/smartparens/issues/397#issuecomment-501059014
+  (after! smartparens
+    (sp-local-pair 'nxml-mode "<" ">" :post-handlers '(("[d1]" "/"))))
   (set-company-backend! 'nxml-mode '(company-nxml company-yasnippet))
   (setq-hook! 'nxml-mode-hook tab-width nxml-child-indent)
   (set-formatter! 'xmllint '("xmllint" "--format" "-") :modes '(nxml-mode)))


### PR DESCRIPTION
`nxml-slash-auto-complete-flag` inserts the rest of the closing tag when `</` is inserted, but smartparens also defines `(sp-local-pair "<" ">")` for `sp--html-modes`, so two `>` are inserted for closing tags. Apply the upstream developer’s suggested fix.

Fix: https://github.com/doomemacs/doomemacs/issues/6331
Ref: https://github.com/Fuco1/smartparens/issues/397

Not sure why upstream doesn’t just include this in smartparens-html itself, but it’s straightforward enough to handle in the Doom module for now.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
