### PR TITLE
docs(nix): mention +lsp flag

### DIFF
--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -22,6 +22,12 @@ Includes:
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
   editing. Requires [[doom-module::tools tree-sitter]].
+- +lsp ::
+  Enable an LSP hook for ~nix-mode~. Requires [[doom-module::tools lsp]] and a language
+  server (one of either ~nil~ or ~rnix-lsp~).
+
+  You can still start a nix lsp manually without this flag, this just adds
+  a hook to always start the lsp when loading ~nix-mode~.
 
 ** Packages
 - [[doom-package:company-nixos-options]] if [[doom-module::completion company]]


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Add a note about the `+lsp` flag of the nix module — I was pleasantly surprised to discover that it already exists when I needed it & wanted to look at how to add it, after I didn't find it in the module's documentation, so I thought having a note about it would be nice.

Ref: #6592 (added the flag)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
