### PR TITLE
feat(default): use consult-yasnippet when possible

### DIFF
--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -27,3 +27,7 @@
   (package! vertico-posframe
     :recipe (:host github :repo "tumashu/vertico-posframe")
     :pin "7da6d648ff4202a48eb6647ee7dce8d65de48779"))
+
+(when (modulep! :editor snippets)
+  (package! consult-yasnippet
+    :pin "ae0450889484f23dc4ec37518852a2c61b89f184"))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -154,7 +154,7 @@
          :desc "Emoji"                       "e"   #'emojify-insert-emoji)
        :desc "Current file name"             "f"   #'+default/insert-file-path
        :desc "Current file path"             "F"   (cmd!! #'+default/insert-file-path t)
-       :desc "Snippet"                       "s"   #'yas-insert-snippet
+       :desc "Snippet"                       "s"   #'+default/insert-snippet
        :desc "Unicode"                       "u"   #'insert-char
        :desc "From clipboard"                "y"   #'+default/yank-pop)
 

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -504,7 +504,7 @@
        :desc "Current file path"             "F"   (cmd!! #'+default/insert-file-path t)
        :desc "Evil ex path"                  "p"   (cmd! (evil-ex "R!echo "))
        :desc "From evil register"            "r"   #'evil-show-registers
-       :desc "Snippet"                       "s"   #'yas-insert-snippet
+       :desc "Snippet"                       "s"   #'+default/insert-snippet
        :desc "Unicode"                       "u"   #'insert-char
        :desc "From clipboard"                "y"   #'+default/yank-pop)
 

--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -173,3 +173,10 @@ possible, or just one char if that's not possible."
                         ((doom/backward-delete-whitespace-to-column)))))))
         ;; Otherwise, do simple deletion.
         ((delete-char (- n) killflag))))
+
+;;;###autoload
+(defun +default/insert-snippet ()
+  (interactive)
+  (cond ((modulep! :completion vertico)
+         (call-interactively #'consult-yasnippet))
+        (t (call-interactively #'yas-insert-snippet))))


### PR DESCRIPTION
Hi. This PR enables `consult-yasnippet` for inserting snippets. This package provides annotations and previews for the snippets.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.