### PR TITLE
fix: set doom-unicode-font back to nil by default

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -36,7 +36,7 @@ Must be a `font-spec', a font object, an XFT font string, or an XLFD string. See
 
 An omitted font size means to inherit `doom-font''s size.")
 
-(defvar doom-unicode-font (font-spec :family "Symbols Nerd Font Mono")
+(defvar doom-unicode-font nil
   "Fallback font for Unicode glyphs.
 Must be a `font-spec', a font object, an XFT font string, or an XLFD string. See
 `doom-font' for examples.


### PR DESCRIPTION
Previous to this commit, common emoji didn't display correctly on macOS.
This variable was changed in 9787022b839d2d22cb772c6d61cc7f35b9dd5e95
but it *seems* to be an oversight because,

1) in `+unicode-setup-fonts-h' there is logic that checks for
`doom-unicode-font' being nil as a default setting for
`doom-unicode-font-family'

and

2) the commit that changed this was about changing all-the-icons to
nerd-icons which doesn't seem to need a change to doom-unicode-font.