### PR TITLE
mu4e: add icons for mu4e's internal modeline

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -113,7 +113,7 @@ will also be the width of all other printable characters."
       (insert str)
       (car (window-text-pixel-size)))))
 
-(cl-defun +mu4e-normalised-icon (name &key set color height v-adjust)
+(cl-defun +mu4e-normalised-icon (name &key set color height v-adjust space-right)
   "Convert :icon declaration to icon"
   (let* ((icon-set (intern (concat "nerd-icons-" (or set "faicon"))))
          (v-adjust (or v-adjust 0.02))
@@ -125,8 +125,10 @@ will also be the width of all other printable characters."
          (space-width (+mu4e--get-string-width " "))
          (space-factor (- 2 (/ (float icon-width) space-width)))
          ;; always pad the left
-         (space-left (propertize " " 'display `(space . (:width ,space-factor)))))
-    (format "%s%s" space-left icon)))
+         (space-left (propertize " " 'display `(space . (:width ,space-factor))))
+         ;; optionally pad the right
+         (space-right (if space-right space-left "")))
+    (format "%s%s%s" space-left icon space-right)))
 
 ;; Set up all the fancy icons
 ;;;###autoload

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -123,8 +123,10 @@ will also be the width of all other printable characters."
                  (apply icon-set `(,name  :height ,height :v-adjust ,v-adjust))))
          (icon-width (+mu4e--get-string-width icon))
          (space-width (+mu4e--get-string-width " "))
-         (space-factor (- 2 (/ (float icon-width) space-width))))
-    (concat (propertize " " 'display `(space . (:width ,space-factor))) icon)))
+         (space-factor (- 2 (/ (float icon-width) space-width)))
+         ;; always pad the left
+         (space-left (propertize " " 'display `(space . (:width ,space-factor)))))
+    (format "%s%s" space-left icon)))
 
 ;; Set up all the fancy icons
 ;;;###autoload

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -132,7 +132,7 @@ will also be the width of all other printable characters."
   (setq mu4e-use-fancy-chars t
         mu4e-headers-draft-mark      (cons "D" (+mu4e-normalised-icon "nf-fa-pencil"))
         mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "nf-fa-flag"))
-        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "nf-md-sync" :set "mdicon" :height 0.8 :v-adjust -0.10))
+        mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "nf-md-sync" :set "mdicon" :v-adjust -0.10))
         mu4e-headers-passed-mark     (cons "P" (+mu4e-normalised-icon "nf-fa-arrow_right"))
         mu4e-headers-replied-mark    (cons "R" (+mu4e-normalised-icon "nf-fa-reply"))
         mu4e-headers-seen-mark       (cons "S" "") ;(+mu4e-normalised-icon "eye" :height 0.6 :v-adjust 0.07 :color "dsilver"))

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -134,6 +134,12 @@ will also be the width of all other printable characters."
 ;;;###autoload
 (defun +mu4e-initialise-icons ()
   (setq mu4e-use-fancy-chars t
+
+        mu4e-modeline-all-clear      (cons "C:" (+mu4e-normalised-icon "nf-md-check" :set "mdicon" :height 1.0 :space-right t)) ;;󰄬
+        mu4e-modeline-all-read       (cons "R:" (+mu4e-normalised-icon "nf-md-email_check" :set "mdicon" :height 1.0 :space-right t)) ;;󰪱
+        mu4e-modeline-unread-items   (cons "U:" (+mu4e-normalised-icon "nf-md-email_alert" :set "mdicon" :height 1.0 :space-right t)) ;;󰛏
+        mu4e-modeline-new-items      (cons "N:" (+mu4e-normalised-icon "nf-md-sync" :set "mdicon" :height 1.0 :space-right t)) ;;󰓦
+
         mu4e-headers-draft-mark      (cons "D" (+mu4e-normalised-icon "nf-fa-pencil"))
         mu4e-headers-flagged-mark    (cons "F" (+mu4e-normalised-icon "nf-fa-flag"))
         mu4e-headers-new-mark        (cons "N" (+mu4e-normalised-icon "nf-md-sync" :set "mdicon" :v-adjust -0.10))

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -221,6 +221,9 @@ is non-nil."
   ;; Wrap text in messages
   (setq-hook! 'mu4e-view-mode-hook truncate-lines nil)
 
+  ;; mu4e now uses `display-buffer-alist' so we need to add some rules of our own
+  (set-popup-rule! "^\\*mu4e-\\(main\\|headers\\)\\*" :ignore t)
+
   ;; Html mails might be better rendered in a browser
   (add-to-list 'mu4e-view-actions '("View in browser" . mu4e-action-view-in-browser))
   (when (fboundp 'make-xwidget)

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -120,6 +120,7 @@ is non-nil."
   ;; Better search symbols
   (letf! ((defun make-help-button (text help-echo)
             (with-temp-buffer
+              (insert " ")
               (insert-text-button text
                                   'help-echo help-echo
                                   'mouse-face nil)
@@ -128,13 +129,13 @@ is non-nil."
             (cons (make-help-button text1 help-echo)
                   (make-help-button text2 help-echo))))
     (setq mu4e-headers-threaded-label
-          (make-help-button-cons "T" (concat " " (nerd-icons-octicon "nf-oct-git_branch" :v-adjust 0.05))
+          (make-help-button-cons "T" (nerd-icons-octicon "nf-oct-git_branch" :v-adjust 0.05)
                                  "Thread view")
           mu4e-headers-related-label
-          (make-help-button-cons "R" (concat " " (nerd-icons-mdicon "nf-md-link" :v-adjust -0.1))
+          (make-help-button-cons "R" (nerd-icons-mdicon "nf-md-link" :v-adjust -0.1)
                                  "Showing related emails")
           mu4e-headers-full-label
-          (make-help-button-cons "F" (concat " " (nerd-icons-mdicon "nf-md-disc"))
+          (make-help-button-cons "F" (nerd-icons-mdicon "nf-md-disc")
                                  "Search is full!")))
 
   ;; set mail user agent


### PR DESCRIPTION
`mu4e` now has its own modeline that is quite flexible. These changes add icons inline with doom's style.

Also adds `mu4e`'s buffers to a popup rule since it now uses display-buffer-alist.