### PR TITLE
fix(ocaml): add dune-project to ocaml projectile root files

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -1,5 +1,8 @@
 ;;; lang/ocaml/config.el -*- lexical-binding: t; -*-
 
+(after! projectile
+  (pushnew! projectile-project-root-files "dune-project"))
+
 ;;
 ;;; Packages
 


### PR DESCRIPTION
Added `dune-project` to the `projectile-project-root-files` for the `ocaml` module.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
