### PR TITLE
fix(rust): make cargo popups consistent

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -30,6 +30,7 @@
   (add-hook 'rustic-mode-hook #'rainbow-delimiters-mode)
   (set-docsets! 'rustic-mode "Rust")
   (set-popup-rule! "^\\*rustic-compilation" :vslot -1)
+  (set-popup-rule! "^\\*cargo-run" :vslot -1)
 
   (setq rustic-indent-method-chain t)
 


### PR DESCRIPTION
When invoking `rustic-cargo-run` a buffer called `*cargo-run*` is opened. This adds a rule such that this buffer opens in a popup window that is the same as the popup windows for other rustic cargo commands.

This PR is adding to the solution to [this issue](https://github.com/doomemacs/doomemacs/issues/2623).

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).