### PR TITLE
fix(common-lisp): detect defsystem declarations

### DIFF
--- a/modules/lang/common-lisp/autoload/common-lisp.el
+++ b/modules/lang/common-lisp/autoload/common-lisp.el
@@ -42,11 +42,11 @@
   "Given a path to an ASDF project definition, extract the names of
 the systems defined therein."
   (let ((file (doom-file-read asdf))
-        (patt "defsystem \"\\([a-z-/]+\\)"))
+        (patt "defsystem \\(\"\\|#?:\\)\\([a-z-/]+\\)"))
     (when (not (string-match patt file))
       (error "No systems defined in: %s" asdf))
     (thread-last (s-match-strings-all patt file)
-                 (mapcar #'cl-second))))
+                 (mapcar #'cl-third))))
 
 ;; TODO Get this to run in a comint buffer?
 ;;;###autoload


### PR DESCRIPTION
currently it only detects declarations of the form: `(defsystem "name")`
but many projects are of the form:
`(defsystem #:name)`
or:
`(defsystem :name)`
this should detect all three possible variations

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.