### PR TITLE
fix: premature use of emoji fontset in <=28.1

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -546,7 +546,9 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
         (dolist (script '(symbol mathematical))
           (set-fontset-font t script symbol-font)))
       (when emoji-font
-        (set-fontset-font t 'emoji emoji-font)
+        ;; DEPRECATED: make unconditional when we drop 27 support
+        (when (version<= "28.1" emacs-version)
+          (set-fontset-font t 'emoji emoji-font))
         ;; some characters in the Emacs symbol script are often covered by emoji
         ;; fonts
         (set-fontset-font t 'symbol emoji-font nil 'append)))


### PR DESCRIPTION
317cea5eefda (part of https://github.com/doomemacs/doomemacs/pull/7448) assumed Emacs 28, but Doom still tries to support 27.

Closes https://github.com/doomemacs/doomemacs/issues/7505

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
