### PR TITLE
fix(projectile): disable colors in fd invocation

### DIFF
--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -40,7 +40,7 @@
   :pin "572a10c11b6cb88293de48acbb59a059d36f9ba5")
 
 ;; doom-projects.el
-(package! projectile :pin "971cd5c4f25ff1f84ab7e8337ffc7f89f67a1b52")
+(package! projectile :pin "d24b8173223fd0e10ecd4b5e0cfa676dfc3b90c4")
 (package! project :pin "ce140cdb70138a4938c999d4606a52dbeced4676")
 
 ;; doom-keybinds.el


### PR DESCRIPTION
bbatsov/projectile@971cd5c4f25f -> bbatsov/projectile@d24b8173223f

The pinned `projectile` version erroneously calls `fd` without explicitly disabling colors, which inserts color terminal codes into filenames when used over `tramp`. This completely breaks projectile over `tramp`.

The linked change adds `-c never` (shorthand form of `--color=never`) to `projectile-git-fd-args`. This is the only change in `projectile` between the two versions linked above, and it completely resolves the issue.

Ref: https://github.com/bbatsov/projectile/issues/1860
Ref: https://github.com/bbatsov/projectile/pull/1859

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
