### PR TITLE
fix(popup): allow killing popup buffers

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -210,10 +210,7 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 `kill-current-buffer'."
   :before-until #'kill-current-buffer
   (let ((buf (current-buffer)))
-    (cond ((window-dedicated-p)
-           (delete-window)
-           t)
-          ((eq buf (doom-fallback-buffer))
+    (cond ((eq buf (doom-fallback-buffer))
            (message "Can't kill the fallback buffer.")
            t)
           ((doom-real-buffer-p buf)


### PR DESCRIPTION
Currently, `SPC b k` does not allow us to kill popup buffers. If we are say using a comint/eshell/eat buffer and we borked the state while testing hooks or we sent EOF to the underlying process, or the buffer has a process that is frozen, etc., our intention with `SPC b k` is to kill the underlying buffer.

I am interested in any other solutions people have to this. Maybe we should make a `:dedicated` parameter and set it to `nil` for `comint`, `eshell`, and `vterm` buffers.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to finish it.
