### PR TITLE
fix(treemacs): do not overwrite git mode when treemacs-python-executable is set

### DIFF
--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -33,6 +33,7 @@ This must be set before `treemacs' has loaded.")
   (when +treemacs-git-mode
     ;; If they aren't supported, fall back to simpler methods
     (when (and (memq +treemacs-git-mode '(deferred extended))
+               (not treemacs-python-executable)
                (not (executable-find "python3")))
       (setq +treemacs-git-mode 'simple))
     (treemacs-git-mode +treemacs-git-mode)


### PR DESCRIPTION
If the variable `treemacs-python-executable` is set, then the git mode shouldn't be overwritten, even if python cannot be found in the PATH.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
