### PR TITLE
docs(mu4e): update NixOS installation instructions

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -93,10 +93,22 @@ If you use =msmtp=:
 #+begin_src nix
 environment.systemPackages = with pkgs; [
     mu
+    # For nixpkgs versions after 23.05: this installs Emacs with mu4e already
+    # included (you still need mu above; it just doesn't ship with mu4e anymore)
+    ((emacsPackagesFor emacs).emacsWithPackages (epkgs: [ epkgs.mu4e ]))
     # And one of the following
     isync
     offlineimap
 ];
+#+end_src
+
+If you use ~home-manager~ you should specify ~mu4e~ as an additionally included
+package as follows (requires ~nixpkgs~ > 23.05):
+#+begin_src nix
+programs.emacs = {
+  enable = true;
+  extraPackages = epkgs: [ epkgs.mu4e ];
+}
 #+end_src
 
 [[https://github.com/Emiller88/dotfiles/blob/5eaabedf1b141c80a8d32e1b496055231476f65e/modules/shell/mail.nix][An example of setting up mbsync and mu with home-manager]]
@@ -280,9 +292,9 @@ mail retrieval/indexing, change the value of ~mu4e-update-interval~:
 You will get =No such file or directory, mu4e= errors if you don't run ~$ doom
 sync~ after installing =mu= through your package manager.
 
-Some times the ~mu~ package does not include ~mu4e~ (*cough Ubuntu*). if
-that's the case you will need to [[https://github.com/djcb/mu][install]] it and add it to your ~load-path~ you
-can do that by:
+Sometimes the ~mu~ package does not include ~mu4e~ (*cough Ubuntu*). If that's
+the case you will need to [[https://github.com/djcb/mu][install]] it and add it to your ~load-path~. You can
+do that by:
 #+begin_src emacs-lisp
 (add-to-list 'load-path "your/path/to/mu4e")
 ;; if you installed it using your package manager


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Recently, the Emacs package `mu4e` has been [moved into a separate derivation output](https://github.com/NixOS/nixpkgs/commit/2081e7e07de42d7e991d863ab8ec72ce3718ae12) (which broke my existing setup after a system upgrade). Now you need both the `mu` package (installing the program) as well as its `mu4e` output, which adds the Emacs package to the system.

I've updated the docs accordingly, but since the change is very recent, I've added disclaimer explaining that only newer versions of `nixpkgs` need it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
