### PR TITLE
fix(org): call org-reveal in correct buffer

### DIFF
--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -510,8 +510,9 @@ All my (performant) foldings needs are met between this and `org-show-subtree'
        ;; when `org-mode' first initializes.
        (let ((buf (current-buffer)))
          (unless (doom-temp-buffer-p buf)
-           (run-at-time 0.1 nil (λ! (with-current-buffer buf
-                                      (org-reveal '(4)))))))))
+           (run-at-time 0.1 nil (lambda ()
+                                  (with-current-buffer buf
+                                    (org-reveal '(4)))))))))
 
 ;;;###autoload
 (defun +org-remove-occur-highlights-h ()

--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -508,7 +508,10 @@ All my (performant) foldings needs are met between this and `org-show-subtree'
        ;; Must be done on a timer because `org-show-set-visibility' (used by
        ;; `org-reveal') relies on overlays that aren't immediately available
        ;; when `org-mode' first initializes.
-       (run-at-time 0.1 nil #'org-reveal '(4))))
+       (let ((buf (current-buffer)))
+         (unless (doom-temp-buffer-p buf)
+           (run-at-time 0.1 nil (λ! (with-current-buffer buf
+                                      (org-reveal '(4)))))))))
 
 ;;;###autoload
 (defun +org-remove-occur-highlights-h ()


### PR DESCRIPTION
Sometimes, `org-reveal` is called in the wrong buffer which throws an error.  For example, `org-link-open-from-string` creates an temporary org-mode buffer that gets killed very quickly which means that `org-reveal` gets called in a different buffer.  I have also had issues with org-reveal getting called in the org-roam buffer, which is why this commit also saves the buffer it was called in.

<!-- ⚠️ Please do not ignore this template! -->


-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
