### PR TITLE
fix(upload): treat variable correctly in after-save-hook

### DIFF
--- a/modules/tools/upload/README.org
+++ b/modules/tools/upload/README.org
@@ -45,9 +45,9 @@ Uses ~ssh-deploy~ to map a local folder to a remote one. Set
 ~ssh-deploy-root-remote~ and ~ssh-deploy-root-local~ in a =.dir-locals.el= file
 to establish this mapping. E.g.
 #+begin_src emacs-lisp
-((nil . ((ssh-deploy-root-local . "/local/path/to/project")
+((nil . ((ssh-deploy-root-local . "/local/path/to/project/")
          (ssh-deploy-root-remote . "/ssh:user@server:/remote/project/")
-         (ssh-deploy-on-explicit-save . t))))
+         (ssh-deploy-on-explicit-save . 1))))
 #+end_src
 
 #+begin_quote
@@ -66,7 +66,7 @@ Check out [[https://github.com/cjohansson/emacs-ssh-deploy#deployment-configurat
 ** ~root-local~ and ~root-remote~ must match
 The final directory names much match:
 #+begin_src emacs-lisp
-((nil . ((ssh-deploy-root-local . "/local/path/to/example-project")
+((nil . ((ssh-deploy-root-local . "/local/path/to/example-project/")
          (ssh-deploy-root-remote . "/ssh:user@server:/remote/example-project/")
 #+end_src
 

--- a/modules/tools/upload/config.el
+++ b/modules/tools/upload/config.el
@@ -37,7 +37,7 @@
   (add-hook! 'after-save-hook
     (defun +upload-init-after-save-h ()
       (when (and (bound-and-true-p ssh-deploy-root-remote)
-                 ssh-deploy-on-explicit-save)
+                 (> ssh-deploy-on-explicit-save 0))
         (ssh-deploy-upload-handler ssh-deploy-force-on-explicit-save))))
 
   ;; Enable ssh-deploy if variables are set, and check for changes on open file


### PR DESCRIPTION
According to upstream package emacs-ssh-deploy, the value 0 should disable the auto-save behavior.
As the ssh-deploy-on-explicit-save is considered true if its value is 0, it triggers the after-save-hook anyway.
This commit fixes the hook so it conforms to upstream [definition](https://github.com/cjohansson/emacs-ssh-deploy/?tab=readme-ov-file#configuration):

> ssh-deploy-on-explicit-save Enabled automatic uploads on save (integer)

WARNING: This breaks compatibility if the variable is set as t, as it was in doom's documentation.

<!-- ⚠️ Please do not ignore this template! -->

Fix: #7512
Close: #7512

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
