### PR TITLE
bump(clojure): new CIDER release

### DIFF
--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -11,16 +11,16 @@
 ;; HACK Forward declare these clj-refactor/cider deps so that their deps are
 ;;      byte-compiled first.
 (package! parseclj :pin "4d0e780e00f1828b00c43099e6eebc6582998f72")
-(package! parseedn :pin "a09686fbb9113b8b1b4f20c9e1dc0d6fea01a64f")
+(package! parseedn :pin "c8f07926a688bfe995fde4460103915d401a1aff")
 
 ;;; Core packages
-(package! clojure-mode :pin "3453cd229b412227aaffd1dc2870fa8fa213c5b1")
-(package! clj-refactor :pin "b5abe655e572a6ecfed02bb8164b64716ef76b8e")
-(package! cider :pin "1ed5163433c991c00ea83fdd4447e8daf4aeccbe")
+(package! clojure-mode :pin "525fc1b131b1fc537aa82d83d9eb2ea833cface6")
+(package! clj-refactor :pin "b476345c580ae7cbc6b356ba0157db782684c47f")
+(package! cider :pin "944d6773ac254d9fcac55c05489bff3d91d91402")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
-  (package! flycheck-clj-kondo :pin "ff7bed2315755cfe02ef471edf522e27b78cd5ca"))
+  (package! flycheck-clj-kondo :pin "d8a6ee9a16aa24b5be01f1edf9843d41bdc75555"))
 (package! jet :pin "f007660c568e924e32d486a02aa4cd18203313cc")
 (package! neil
   :recipe (:host github :repo "babashka/neil" :files ("*.el"))
-  :pin "1dbac785cee4af8ad499839adbb83a8a297e7c70")
+  :pin "f597921dcbf4774d799be62d8fbbce7171b12c3f")


### PR DESCRIPTION
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

This is not a draft, but I wonder if we can remove the hack for Paredit - it seems that CIDER does not (anymore) depend on paredit.