### PR TITLE
fix(clojure): leverage evil-collection-cider

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -121,13 +121,34 @@
            (with-current-buffer nrepl-server-buffer
              (buffer-string)))))))
 
-  ;; When in cider-debug-mode, override evil keys to not interfere with debug keys
   (after! evil
-    (add-hook! cider--debug-mode
-      (defun +clojure--cider-setup-debug ()
-        "Setup cider debug to override evil keys cleanly"
-        (evil-make-overriding-map cider--debug-mode-map 'normal)
-        (evil-normalize-keymaps))))
+    (if (modulep! :editor evil +everywhere)
+        ;; Match evil-collection keybindings to debugging overlay
+        (after! (cider-debug evil-collection-cider)
+          (mapc
+           (lambda (replacement)
+             (let* ((from (car replacement))
+                    (to (cadr replacement))
+                    (item (assoc from cider-debug-prompt-commands)))
+               ;; Position matters, hence the update-in-place
+               (setf (car item) (car to))
+               (setf (cdr item) (cdr to))))
+           '((?h (?H "here" "Here"))
+             (?i (?I "in" "In"))
+             (?j (?J "inject" "inJect"))
+             (?l (?L "locals" "Locals"))))
+
+          ;; Prevent evil-snipe from overriding evil-collection
+          (add-hook! cider--debug-mode
+                     'turn-off-evil-snipe-mode
+                     'turn-off-evil-snipe-override-mode))
+
+      ;; When in cider-debug-mode, override evil keys to not interfere with debug keys
+      (add-hook! cider--debug-mode
+        (defun +clojure--cider-setup-debug ()
+          "Setup cider debug to override evil keys cleanly"
+          (evil-make-overriding-map cider--debug-mode-map 'normal)
+          (evil-normalize-keymaps)))))
 
   (when (modulep! :ui modeline +light)
     (defvar-local cider-modeline-icon nil)


### PR DESCRIPTION
We're currently discarding all evil-collection bindings on `cider--debug-mode`. Given that `j` is bound to a particularly disruptive and non-cancellable command, this brings some friction to evil users.

This commit adds those bindings back under `evil +everywhere` and creates some missing debug commands recently added.

The in-buffer and minibuffer displayed keybindings were adjusted to match, but not easy-menu's.

Ref: doomemacs/doomemacs#4627


<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->
