### PR TITLE
perf(lsp): turn off eglot events buffer

### DIFF
--- a/modules/tools/lsp/+eglot.el
+++ b/modules/tools/lsp/+eglot.el
@@ -16,6 +16,12 @@
   (setq eglot-sync-connect 1
         eglot-autoshutdown t
         eglot-send-changes-idle-time 0.5
+        ;; NOTE This setting disable the eglot-events-buffer enabling more
+        ;;      consistent performance on long running emacs instance.
+        ;;      Default is 2000000 lines. After each new event the whole buffer
+        ;;      is pretty printed which causes steady performance decrease over time.
+        ;;      CPU is spent on pretty priting and Emacs GC is put under high pressure.
+        eglot-events-buffer-size 0
         ;; NOTE We disable eglot-auto-display-help-buffer because :select t in
         ;;      its popup rule causes eglot to steal focus too often.
         eglot-auto-display-help-buffer nil)
@@ -32,7 +38,7 @@
     :type-definition #'eglot-find-typeDefinition
     :documentation   #'+eglot-lookup-documentation)
 
-  (add-to-list 'doom-debug-variables '(eglot-events-buffer-size . 0))
+  (add-to-list 'doom-debug-variables '(eglot-events-buffer-size . 2000000))
 
   (defadvice! +lsp--defer-server-shutdown-a (fn &optional server)
     "Defer server shutdown for a few seconds.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The `eglot-events-buffer-size` setting disables the `eglot-events-buffer` when 0, enabling more consistent performance on long running emacs instance. Default is 2000000 lines. After each new event the events buffer is pretty printed as a whole, which causes steady performance decrease over time. Quite a bit of CPU is spent on pretty printing and Emacs GC is put under high pressure.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
