### PR TITLE
feat: use setq! in helpful

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -584,7 +584,9 @@ current buffer."
                    filename))
           (prog1 (apply fn args)
             (when (buffer-live-p buf)
-              (with-current-buffer buf (goto-char pos)))))))))
+              (with-current-buffer buf (goto-char pos))))))))
+  :config
+  (setq helpful-set-variable-function #'setq!))
 
 
 (use-package! smartparens

--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -30,7 +30,7 @@
 ;; doom-editor.el
 (package! better-jumper :pin "47622213783ece37d5337dc28d33b530540fc319")
 (package! dtrt-indent :pin "e0630f74f915c6cded05f76f66d66e540fcc37c3")
-(package! helpful :pin "66ba816b26b68dd7df08e86f8b96eaae16c8d6a2")
+(package! helpful :pin "a32a5b3d959a7fccf09a71d97b3d7c888ac31c69")
 (package! pcre2el :pin "018531ba0cf8e2b28d1108136a0e031b6a45f1c1")
 (package! smartparens :pin "79a338db115f441cd47bb91e6f75816c5e78a772")
 (package! ws-butler


### PR DESCRIPTION
Hi. Recently my `helpful` PR for using a custom set variable function has been accepted (https://github.com/Wilfred/helpful/pull/332). This means that now we can use `setq!` instead of `setq` for the "Set"  button in `helpful`. This is good because that way we trigger the variable's `:set` property.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.