### PR TITLE
fix(eshell): fix elisp autocompletion in Eshell

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -229,8 +229,10 @@ Emacs versions < 29."
   (eshell-did-you-mean-output-filter "catt: command not found"))
 
 
-(use-package eshell-syntax-highlighting
-  :hook (eshell-mode . eshell-syntax-highlighting-mode))
+(use-package! eshell-syntax-highlighting
+  :hook (eshell-mode . eshell-syntax-highlighting-mode)
+  :init
+  (add-hook 'eshell-syntax-highlighting-elisp-buffer-setup-hook #'highlight-quoted-mode))
 
 
 (use-package! fish-completion

--- a/modules/term/eshell/packages.el
+++ b/modules/term/eshell/packages.el
@@ -6,7 +6,7 @@
 (package! shrink-path :pin "c14882c8599aec79a6e8ef2d06454254bb3e1e41")
 (package! esh-help :pin "417673ed18a983930a66a6692dbfb288a995cb80")
 (package! eshell-did-you-mean :pin "80cd8c4b186a2fb29621cf634bcf2bcd914f1e3d")
-(package! eshell-syntax-highlighting :pin "8bf0494ca71944b9d4bfb8ec3c93ea29d46bc2f9")
+(package! eshell-syntax-highlighting :pin "4ac27eec6595ba116a6151dfaf0b0e0440101e10")
 
 (unless IS-WINDOWS
   (package! fish-completion :pin "10384881817b5ae38cf6197a077a663420090d2c")


### PR DESCRIPTION
For a long time I have wondered why Elisp autocompletion is broken in Eshell. After reading the code for `eshell-syntax-highlighting`, it is clear:
![image](https://github.com/doomemacs/doomemacs/assets/29102529/61c6098b-556d-4e2a-a6f5-368fdf67e1d1)
The `post-command-hook` is deleting the entire prompt string and re-inserting it with syntax highlighting. This is likely messing with overlays and/or markers that Corfu & Company use to store their completion state. I think the best decision is to disable this feature entirely.

I don't personally know how to highlight a portion of the buffer with Elisp highlighting without modifying the text but if anyone does, please follow up.

EDIT: I made an issue about this in https://github.com/akreisher/eshell-syntax-highlighting/issues/14.

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

