### PR TITLE
fix(fold): reorder fold type checks

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -75,8 +75,8 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
            (cl-letf (((symbol-function #'outline-hide-subtree)
                       (symbol-function #'outline-hide-entry)))
              (outline-toggle-children)))
-          ((+fold--ts-fold-p) (ts-fold-toggle))
-          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-toggle-hiding))))))
+          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-toggle-hiding)))
+          ((+fold--ts-fold-p) (ts-fold-toggle)))))
 
 ;;;###autoload
 (defun +fold/open ()
@@ -89,8 +89,8 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
           ((+fold--outline-fold-p)
            (outline-show-children)
            (outline-show-entry))
-          ((+fold--ts-fold-p) (ts-fold-open))
-          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-show-block))))))
+          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-show-block)))
+          ((+fold--ts-fold-p) (ts-fold-open)))))
 
 ;;;###autoload
 (defun +fold/close ()
@@ -100,9 +100,9 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
     (cond ((+fold--vimish-fold-p) (vimish-fold-refold))
-          ((+fold--ts-fold-p) (ts-fold-close))
+          ((+fold--outline-fold-p) (outline-hide-subtree))
           ((+fold--hideshow-fold-p) (+fold-from-eol (hs-hide-block)))
-          ((+fold--outline-fold-p) (outline-hide-subtree)))))
+          ((+fold--ts-fold-p) (ts-fold-close)))))
 
 ;;;###autoload
 (defun +fold/open-all (&optional level)


### PR DESCRIPTION
`+fold--ts-fold-p` just checks that treesitter mode is active and the `ts-fold` feature is active, which will block any other fold-method checks following it. So having the `cond` conditions for folds out of order can lead to inconsistent behavior if using specific folding mechanisms directly.

Move it to the end so other fold types have a chance, and consistently order fold type checks so unfolding will (more likely) use the same underlying mechanism as folding.

Here's a repro, which (for me) this PR resolves:
Create this Python file and, with point on `class`, call `(hs-hide-level)`.
```
class TestHideShow:
    def __init__(self):
        pass
```
You get:
```
class TestHideShow:
    def __init__(self):  [ ... ]
```
Move point to `def` and call `+fold/open`. It will do nothing — it's a `hideshow` fold but `+fold/open` tries to unfold it with 
`ts-fold-open`. It can be opened with `hs-show-block`.

As an aside, when I searched for related issues, I found https://github.com/doomemacs/doomemacs/issues/6737 and was unable to repro it, with or without this fix.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.