### PR TITLE
feat(racket): add support for +hash-lang

### DIFF
--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -14,8 +14,12 @@ This module adds support for the [[https://www.racket-lang.org/][Racket programm
   Enable support for ~racket-mode~. Requires [[doom-module::tools lsp]] and a langserver
   (supports [[https://github.com/jeapostrophe/racket-langserver][racket-langserver]]).
 - +xp ::
-  Enable the explore mode (~racket-xp-mode~), which "analyzes expanded code to
+  Enable the explore minor mode (~racket-xp-mode~), which "analyzes expanded code to
   explain and explore."
+- +hash-lang ::
+  Enable the hash-lang major mode (~racket-hash-lang-mode~), which
+  "uses color-lexer, indent, and navigation supplied by a #lang."
+  This flag can be used along with the ~+xp~ flag.
 
 ** Packages
 - [[doom-package:racket-mode]]

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -3,92 +3,118 @@
 (after! projectile
   (add-to-list 'projectile-project-root-files "info.rkt"))
 
+(defmacro racket-use-package (major-mode-var mode-map mode mode-hook local-vars-hook &rest body)
+  `(use-package! racket-mode
+     :mode ,mode
+     :config
+     (set-repl-handler! ',major-mode-var #'+racket/open-repl)
+     (set-lookup-handlers! '(,major-mode-var racket-repl-mode)
+       :definition    #'+racket-lookup-definition
+       :documentation #'+racket-lookup-documentation)
+     (set-docsets! ',major-mode-var "Racket")
+     (set-ligatures! ',major-mode-var
+                     :lambda  "lambda"
+                     :map     "map"
+                     :dot     ".")
+     (set-rotate-patterns! ',major-mode-var
+                           :symbols '(("#true" "#false")))
+     (set-formatter! 'raco-fmt '("raco" "fmt") :modes '(,major-mode-var))
+
+     (add-hook! ',mode-hook
+                #'rainbow-delimiters-mode
+                #'highlight-quoted-mode)
+
+     (when (modulep! +lsp)
+       (add-hook ',local-vars-hook #'lsp! 'append))
+
+     (when (modulep! +xp)
+       (add-hook ',local-vars-hook #'racket-xp-mode)
+       ;; Both flycheck and racket-xp produce error popups, but racket-xp's have
+       ;; higher quality so disable flycheck's:
+       (when (modulep! :checkers syntax)
+         (add-hook! 'racket-xp-mode-hook
+           (defun +racket-disable-flycheck-h ()
+             (setq-local flycheck-standard-error-navigation nil)
+             (cl-pushnew 'racket flycheck-disabled-checkers)))))
+
+     (map! (:map racket-xp-mode-map
+                 [remap racket-doc] #'racket-xp-documentation)
+           (:localleader
+            :map ,mode-map
+            "a" #'racket-align
+            "A" #'racket-unalign
+            "f" #'racket-fold-all-tests
+            "F" #'racket-unfold-all-tests
+            "h" #'racket-doc
+            "i" #'racket-unicode-input-method-enable
+            "l" #'racket-logger
+            "o" #'racket-profile
+            "p" #'racket-cycle-paren-shapes
+            "r" #'racket-run
+            "R" #'racket-run-and-switch-to-repl
+            "t" #'racket-test
+            "u" #'racket-backward-up-list
+            "y" #'racket-insert-lambda
+            (:prefix ("m" . "macros")
+                     "d" #'racket-expand-definition
+                     "e" #'racket-expand-last-sexp
+                     "r" #'racket-expand-region
+                     "a" #'racket-expand-again)
+            (:prefix ("g" . "goto")
+                     "b" #'xref-pop-marker-stack
+                     "d" #'xref-find-definitions
+                     "m" #'xref-find-definitions
+                     "r" #'racket-open-require-path)
+            (:prefix ("s" . "send")
+                     "d" #'racket-send-definition
+                     "e" #'racket-send-last-sexp
+                     "r" #'racket-send-region)
+            :map racket-repl-mode-map
+            "l" #'racket-logger
+            "h" #'racket-repl-documentation
+            "y" #'racket-insert-lambda
+            "u" #'racket-backward-up-list
+            (:prefix ("m" . "macros")
+                     "d" #'racket-expand-definition
+                     "e" #'racket-expand-last-sexp
+                     "f" #'racket-expand-file
+                     "r" #'racket-expand-region)
+            (:prefix ("g" . "goto")
+                     "b" #'xref-pop-marker-stack
+                     "m" #'xref-find-definitions
+                     "d" #'xref-find-definitions)))
+
+     ,@body))
 
 ;;
 ;;; Packages
 
-(use-package! racket-mode
-  :mode "\\.rkt\\'"  ; give it precedence over :lang scheme
-  :config
-  (set-repl-handler! 'racket-mode #'+racket/open-repl)
-  (set-lookup-handlers! '(racket-mode racket-repl-mode)
-    :definition    #'+racket-lookup-definition
-    :documentation #'+racket-lookup-documentation)
-  (set-docsets! 'racket-mode "Racket")
-  (set-ligatures! 'racket-mode
-    :lambda  "lambda"
-    :map     "map"
-    :dot     ".")
-  (set-rotate-patterns! 'racket-mode
-    :symbols '(("#true" "#false")))
-  (set-formatter! 'raco-fmt '("raco" "fmt") :modes '(racket-mode))
-
-  (add-hook! 'racket-mode-hook
-             #'rainbow-delimiters-mode
-             #'highlight-quoted-mode)
-
-  (when (modulep! +lsp)
-    (add-hook 'racket-mode-local-vars-hook #'lsp! 'append))
-
-  (when (modulep! +xp)
-    (add-hook 'racket-mode-local-vars-hook #'racket-xp-mode)
-    ;; Both flycheck and racket-xp produce error popups, but racket-xp's are
-    ;; higher quality so disable flycheck's:
-    (when (modulep! :checkers syntax)
-      (add-hook! 'racket-xp-mode-hook
-        (defun +racket-disable-flycheck-h ()
-          (cl-pushnew 'racket flycheck-disabled-checkers)))))
-
-  (unless (or (modulep! :editor parinfer)
-              (modulep! :editor lispy))
-    (add-hook 'racket-mode-hook #'racket-smart-open-bracket-mode))
-
-  (map! (:map racket-xp-mode-map
-         [remap racket-doc]              #'racket-xp-documentation
-         [remap racket-visit-definition] #'racket-xp-visit-definition
-         [remap next-error]              #'racket-xp-next-error
-         [remap previous-error]          #'racket-xp-previous-error)
-        (:localleader
-         :map racket-mode-map
-         "a" #'racket-align
-         "A" #'racket-unalign
-         "f" #'racket-fold-all-tests
-         "F" #'racket-unfold-all-tests
-         "h" #'racket-doc
-         "i" #'racket-unicode-input-method-enable
-         "l" #'racket-logger
-         "o" #'racket-profile
-         "p" #'racket-cycle-paren-shapes
-         "r" #'racket-run
-         "R" #'racket-run-and-switch-to-repl
-         "t" #'racket-test
-         "u" #'racket-backward-up-list
-         "y" #'racket-insert-lambda
-         (:prefix ("m" . "macros")
-          "d" #'racket-expand-definition
-          "e" #'racket-expand-last-sexp
-          "r" #'racket-expand-region
-          "a" #'racket-expand-again)
-         (:prefix ("g" . "goto")
-          "b" #'racket-unvisit
-          "d" #'racket-visit-definition
-          "m" #'racket-visit-module
-          "r" #'racket-open-require-path)
-         (:prefix ("s" . "send")
-          "d" #'racket-send-definition
-          "e" #'racket-send-last-sexp
-          "r" #'racket-send-region)
-         :map racket-repl-mode-map
-         "l" #'racket-logger
-         "h" #'racket-repl-documentation
-         "y" #'racket-insert-lambda
-         "u" #'racket-backward-up-list
-         (:prefix ("m" . "macros")
-          "d" #'racket-expand-definition
-          "e" #'racket-expand-last-sexp
-          "f" #'racket-expand-file
-          "r" #'racket-expand-region)
-         (:prefix ("g" . "goto")
-          "b" #'racket-unvisit
-          "m" #'racket-visit-module
-          "d" #'racket-repl-visit-definition))))
+(if (modulep! +hash-lang)
+    (racket-use-package
+     ;; mode
+     racket-hash-lang-mode
+     ;; mode-map
+     racket-hash-lang-mode-map
+     ;; mode
+     (("\\.rkt\\'" . racket-hash-lang-mode) ; Racket
+      ("\\.scrbl\\'" . racket-hash-lang-mode) ; Scribble
+      ("\\.rhm\\'" . racket-hash-lang-mode)) ; Rhombus
+     ;; mode-hook
+     racket-hash-lang-mode-hook
+     ;; local-vars-hook
+     racket-hash-lang-mode-local-vars-hook)
+  (racket-use-package
+   ;; mode
+   racket-mode
+   ;; mode-map
+   racket-mode-map
+   ;; mode
+   "\\.rkt\\'"
+   ;; mode-hook
+   racket-mode-hook
+   ;; local-vars-hook
+   racket-mode-local-vars-hook
+   ;; body
+   (unless (or (modulep! :editor parinfer)
+               (modulep! :editor lispy))
+     (add-hook 'racket-mode-hook #'racket-smart-open-bracket-mode))))

--- a/modules/lang/racket/packages.el
+++ b/modules/lang/racket/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/racket/packages.el
 
-(package! racket-mode :pin "947d9806ee27ef241643f978c7901fd1f9e10c98")
+(package! racket-mode :pin "6b832a34bd8d3fae40b8c02a71c74123f81e75b9")


### PR DESCRIPTION
Racket Mode recently added `racket-hash-lang-mode` as an alternative major mode to the old `racket-mode`. This PR adds `+hash-lang` to support this new major mode. It also bumps the pinned commit to the latest version which includes the `racket-hash-lang-mode` feature.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
