### PR TITLE
fix(plantuml): flycheck: executable support

### DIFF
--- a/modules/lang/plantuml/config.el
+++ b/modules/lang/plantuml/config.el
@@ -17,7 +17,11 @@
 (use-package! flycheck-plantuml
   :when (modulep! :checkers syntax)
   :after plantuml-mode
-  :config (flycheck-plantuml-setup))
+  :config
+  (flycheck-plantuml-setup)
+  (when (eq plantuml-default-exec-mode 'executable)
+    ;; Surprisingly, this works, even though flycheck-plantuml specifies -Djava.awt...
+    (setq-default flycheck-plantuml-executable plantuml-executable-path)))
 
 
 (after! ob-plantuml


### PR DESCRIPTION
The flycheck-plantuml is by default configured to always run plantuml via "java". This only works with a downloaded plantuml. However, I would prefer to have plantuml installed via my package manager (fedora/dnf).

A locally installed PlantUML executable is already detected by default for normal use (export/preview), we can also use it for flycheck.

If plantuml is downloaded using plantuml-download-jar, this jar is still used by default (see setq plantuml-exec-mode), so this should not affect previous setups.

<!-- ⚠️ Please do not ignore this template! -->

Fix: #0000
Ref: #7546 (implemented together with that feature/diagrams as well)
Close: #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- N/A My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
