### PR TITLE
fix(format): correct behaviour when disabling apheleia

### DIFF
--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -60,8 +60,9 @@ When this flag is enabled, you shouldn't need to do anything other than write
 code and save it.
 
 ** Without +onsave
-Without the flag, formatting will only occur when either =apheleia-format-buffer=
-or =+format/buffer= is called.
+Without the flag, formatting will only occur when either =+format/buffer=
+or =apheleia-format-buffer= is called. The difference between them is
+=+format/buffer= will use a LSP server if configured and available.
 
 * Configuration
 
@@ -113,7 +114,7 @@ This behaviour is controlled via [[var:+format-on-save-disabled-modes]] thus;
 
 In this case, =emacs-lisp-mode=, =sql-mode=, =tex-mode= and =latex-mode= will not be
 formatted on save, but can still be formatted by manually invoking the commands
-=apheleia-format-buffer= or =+format/buffer=.
+=+format/buffer= or =apheleia-format-buffer=.
 
 ** Disabling the LSP formatter
 If you are in a buffer with ~lsp-mode~ enabled and a server that supports

--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -117,7 +117,7 @@ formatted on save, but can still be formatted by manually invoking the commands
 
 ** Disabling the LSP formatter
 If you are in a buffer with ~lsp-mode~ enabled and a server that supports
-=textDocument/formatting=, it will be used instead of [[doom-package:format-all]]'s formatter.
+=textDocument/formatting=, it will be used instead of [[doom-package:apheleia]]'s formatter.
 
 + To disable this behavior universally use: ~(setq +format-with-lsp nil)~
 + To disable this behavior in one mode: ~(setq-hook! 'python-mode-hook

--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -25,8 +25,8 @@ be formatted and returned to the buffer using
 ** Module flags
 - +onsave ::
   Enable reformatting of a buffer when it is saved. See
-  [[var:+format-on-save-disabled-modes]] to control what major modes to (or not to)
-  format on save.
+  [[var:+format-on-save-disabled-modes]] to disable format on save for certain
+  major modes.
 
 ** Packages
 - [[doom-package:apheleia]]

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -43,7 +43,7 @@ This is controlled by `+format-on-save-disabled-modes'."
       (not (null (memq major-mode +format-on-save-disabled-modes)))))
 
 
-(after! apheleia-core
+(after! apheleia
   (add-to-list 'doom-debug-variables '(apheleia-log-only-errors . nil))
 
   (when (modulep! +onsave)

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -21,7 +21,8 @@ Indentation is always preserved when formatting regions.")
   "If non-nil, format with LSP formatter if it's available.
 
 This can be set buffer-locally with `setq-hook!' to disable LSP formatting in
-select buffers.")
+select buffers.
+This has no effect on the +onsave flag, apheleia will always be used there.")
 
 (defvaralias '+format-with 'apheleia-formatter
   "Set this to explicitly use a certain formatter for the current buffer.")

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -5,11 +5,10 @@
     tex-mode           ; latexindent is broken
     latex-mode
     org-msg-edit-mode) ; doesn't need a formatter
-  "A list of major modes in which to reformat the buffer upon saving.
-If this list begins with `not', then it negates the list.
-If it is `t', it is enabled in all modes.
-If nil, it is disabled in all modes, the same as if the +onsave flag wasn't
-  used at all.
+  "A list of major modes in which to not reformat the buffer upon saving.
+If it is t, it is disabled in all modes, the same as if the +onsave flag
+  wasn't used at all.
+If nil, formatting is enabled in all modes.
 Irrelevant if you do not have the +onsave flag enabled for this module.")
 
 (defvar +format-preserve-indentation t
@@ -39,6 +38,7 @@ select buffers.")
 This is controlled by `+format-on-save-disabled-modes'."
   (or (eq major-mode 'fundamental-mode)
       (string-blank-p (buffer-name))
+      (eq +format-on-save-disabled-modes t)
       (not (null (memq major-mode +format-on-save-disabled-modes)))))
 
 

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -33,8 +33,8 @@ select buffers.")
 (when (modulep! +onsave)
   (add-hook 'doom-first-file-hook #'apheleia-global-mode))
 
-(defun +format-inhibit-maybe-h ()
-  "Enable formatting on save in certain major modes.
+(defun +format-maybe-inhibit-h ()
+  "Check if formatting should be disabled for current buffer.
 This is controlled by `+format-on-save-disabled-modes'."
   (or (eq major-mode 'fundamental-mode)
       (string-blank-p (buffer-name))
@@ -46,7 +46,7 @@ This is controlled by `+format-on-save-disabled-modes'."
   (add-to-list 'doom-debug-variables '(apheleia-log-only-errors . nil))
 
   (when (modulep! +onsave)
-    (add-to-list 'apheleia-inhibit-functions #'+format-inhibit-maybe-h)))
+    (add-to-list 'apheleia-inhibit-functions #'+format-maybe-inhibit-h)))
 
 
 ;;


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Edit 2023/11/21 - added an extra commit and updated the title to better reflect the PR's contents.

Previously, it was impossible to disable saving in certain modes. This was due to 
1) Improper feature name in `after!` call
2) Docs referencing behaviour which was not implemented in code
3) Docs not updated properly after 4ecd616cd8f60640d6b0be2ffc3d762e88099bb4 updated this module to use apheleia

Original PR text follows:

------
I was looking into forcing apheleia to always use the LSP formatter if available and wasn't sure if that should be done here or directly in the apheleia code. In the process of investigating that, I found several issues with the format module docs. I figured those should be addressed in a separate PR, I'm still looking into the LSP stuff but that may or may not come after this depending on if I can get it working right.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
