### PR TITLE
bump: :lang markdown

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -26,10 +26,6 @@ capture, the end position, and the output buffer.")
         markdown-make-gfm-checkboxes-buttons t
         markdown-fontify-whole-heading-line t
 
-        ;; HACK Due to jrblevin/markdown-mode#578, invoking `imenu' throws a
-        ;;      'wrong-type-argument consp nil' error if you use native-comp.
-        markdown-nested-imenu-heading-index (not (ignore-errors (native-comp-available-p)))
-
         ;; `+markdown-compile' offers support for many transpilers (see
         ;; `+markdown-compile-functions'), which it tries until one succeeds.
         markdown-command #'+markdown-compile

--- a/modules/lang/markdown/packages.el
+++ b/modules/lang/markdown/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/markdown/packages.el
 
-(package! markdown-mode :pin "c765b73b370f0fcaaa3cee28b2be69652e2d2c39")
+(package! markdown-mode :pin "b1a862f0165b7bafe0f874738a55be1b1720dd7d")
 (package! markdown-toc :pin "3d724e518a897343b5ede0b976d6fb46c46bcc01")
 (package! edit-indirect :pin "f80f63822ffae78de38dbe72cacaeb1aaa96c732")
 


### PR DESCRIPTION
fixes the workaround for introduced in   aad7bc521f188ebee47
that was fixed in jrblevin/markdown-mode@44f0e89534e6

jrblevin/markdown-mode@c765b73b370f -> jrblevin/markdown-mode@b1a862f0165b

Ref: jrblevin/markdown-mode#578

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.