### PR TITLE
fix(latex): avoid stealing focus after compilation

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -102,16 +102,23 @@ If no viewer is found, `latex-preview-pane-mode' is used.")
     (add-hook! '(tex-mode-local-vars-hook
                  latex-mode-local-vars-hook)
                :append #'lsp!))
+  ;; Define a function to compile the project.
+  (defun +latex/compile ()
+    (interactive)
+    (TeX-save-document (TeX-master-file))
+    (TeX-command TeX-command-default 'TeX-master-file -1))
   (map! :localleader
         :map latex-mode-map
         :desc "View"          "v" #'TeX-view
-        :desc "Compile"       "c" #'TeX-command-run-all
+        :desc "Compile"       "c" #'+latex/compile
+        :desc "Run all"       "a" #'TeX-command-run-all
         :desc "Run a command" "m" #'TeX-command-master)
   (map! :after latex
         :localleader
         :map LaTeX-mode-map
         :desc "View"          "v" #'TeX-view
-        :desc "Compile"       "c" #'TeX-command-run-all
+        :desc "Compile"       "c" #'+latex/compile
+        :desc "Run all"       "a" #'TeX-command-run-all
         :desc "Run a command" "m" #'TeX-command-master))
 
 


### PR DESCRIPTION

<!-- ⚠️ Please do not ignore this template! -->

The current LaTeX module uses `TeX-command-run-all` for compilation, which by default opens the compiled document in a viewer. This behavior causes a loss of focus from the Emacs window, interrupting the editing workflow.

I address this by adding a custom compilation function, which saves the documents and compiles the project, but does not open it in a viewer. This allows users to continue editing without the need to manually switch back the focus to Emacs.

`TeX-command-run-all` is still a useful automation, so I keep it there but change the key binding.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
