### PR TITLE
Bump :lang clojure

### DIFF
--- a/modules/lang/clojure/README.org
+++ b/modules/lang/clojure/README.org
@@ -43,6 +43,8 @@ This module adds support for the Clojure(Script) language.
 
 This module requires:
 - [[https://clojure.org/][clojure]]
+
+This module optionally requires:
 - [[https://github.com/borkdude/clj-kondo][clj-kondo]], for linting code (if [[doom-module::checkers syntax]])
 - [[https://clojure-lsp.github.io/clojure-lsp/][clojure-lsp]], for LSP support (if [[doom-module:+lsp]])
 - [[https://github.com/babashka/neil][neil]] for the ability to add packages to your Clojure project from Emacs
@@ -147,10 +149,17 @@ Several bindings used for viewing documentation for various functions, both insi
 | [[kbd:][K]]                 | ~+lookup/documentation~ |
 
 
-* TODO Configuration
-#+begin_quote
- 󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
-#+end_quote
+* Configuration
+** =enrich-classpath=
+In recent versions, an option has been introduced that attempts to improve the experience of CIDER by accessing java source & javadocs, though this option is still currently considered beta.
+
+In order to opt into this, add the following to your =config.el=
+
+#+begin_src emacs-lisp
+(setq cider-enrich-classpath t)
+#+end_src
+
+See [[https://docs.cider.mx/cider/config/basic_config.html#use-enrich-classpath][the docs]] for more
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]

--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -10,17 +10,17 @@
 
 ;; HACK Forward declare these clj-refactor/cider deps so that their deps are
 ;;      byte-compiled first.
-(package! parseclj :pin "4d0e780e00f1828b00c43099e6eebc6582998f72")
-(package! parseedn :pin "a09686fbb9113b8b1b4f20c9e1dc0d6fea01a64f")
+(package! parseclj :pin "74ff7d63fed92a3c859e474ae85f011e794b751a")
+(package! parseedn :pin "c8f07926a688bfe995fde4460103915d401a1aff")
 
 ;;; Core packages
-(package! clojure-mode :pin "3453cd229b412227aaffd1dc2870fa8fa213c5b1")
-(package! clj-refactor :pin "b5abe655e572a6ecfed02bb8164b64716ef76b8e")
-(package! cider :pin "1ed5163433c991c00ea83fdd4447e8daf4aeccbe")
+(package! clojure-mode :pin "25d713a67d8e0209ee74bfc0153fdf677697b43f")
+(package! clj-refactor :pin "0a2a6cbc2e29177f4f55730637a357433a03fa38")
+(package! cider :pin "120fd885d37c07137f1c162e8d522ab3eed1ac3f")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
   (package! flycheck-clj-kondo :pin "ff7bed2315755cfe02ef471edf522e27b78cd5ca"))
-(package! jet :pin "f007660c568e924e32d486a02aa4cd18203313cc")
+(package! jet :pin "7d5157aac692fc761d8ed7a9f820fa6522136254")
 (package! neil
   :recipe (:host github :repo "babashka/neil" :files ("*.el"))
-  :pin "1dbac785cee4af8ad499839adbb83a8a297e7c70")
+  :pin "40993873bb4ef6d88af450e8a96d03275e266f6b")


### PR DESCRIPTION
Bump to the latest versions of everything & add a note about using `enrich-classpath`. 

@vemv my understanding from the docs is this is still a wip flag, or is it ready to be a default yet?

Closes #7515