### PR TITLE
fix(lsp): eglot: prefer built-in eglot

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -3,7 +3,9 @@
 
 (if (modulep! +eglot)
     (progn
-      (package! eglot :pin "2b145778ba5e57f393e50aea76b28e518c401828")
+      (package! eglot
+        :pin "2b145778ba5e57f393e50aea76b28e518c401828"
+        :built-in 'prefer)  ; Built-in as of Emacs 29
       (when (modulep! :completion vertico)
         (package! consult-eglot :pin "db9d41c9812a5a8a7b9a22fa7f3c314e37584d41"))
       (when (and (modulep! :checkers syntax)


### PR DESCRIPTION
Eglot installed via straight caused issues with calls to `consult-imenu` for my emacs installation of version 29.1. The issue caused symbols to not be categorized according to class, function, method, etc. for all languages (other than elisp). Using the built-in version of eglot solves this issue.

As far as I could tell (elisp newbie) the issue was a result of `eglot-imenu` performing wrong formatting for the completion candidates of symbols in the current buffer. The formatting of the candidate list in `consult-imenu` did not result in correct symbol type resolution because of this.

Ref: #7340 - Found this related issue that has the same change as a workaround for a different issue for Emacs 29 installations.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
