### PR TITLE
fix(swift): don't load lsp-sourcekit with eglot

### DIFF
--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -4,7 +4,9 @@
   (set-repl-handler! 'swift-mode #'run-swift)
 
   (when (modulep! +lsp)
-    (add-hook 'swift-mode-local-vars-hook #'lsp! 'append))
+    (add-hook 'swift-mode-local-vars-hook #'lsp! 'append)
+    (when (modulep! :tools lsp +eglot)
+      (set-eglot-client! swift-mode 'swift-mode '("sourcekit-lsp"))))
   (when (modulep! +tree-sitter)
     (add-hook 'swift-mode-local-vars-hook #'tree-sitter! 'append)))
 
@@ -25,7 +27,7 @@
 
 
 (use-package! lsp-sourcekit
-  :when (modulep! +lsp)
+  :when (and (modulep! +lsp) (not (modulep! :tools lsp +eglot)))
   :after swift-mode
   :init (add-hook 'swift-mode-local-vars-hook #'lsp! 'append)
   :config


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The `use-package!` declaration for lsp-sourcekit in `config.el` did not match the `package!` declaration in `packages.el`: this meant that `lsp-sourcekit` would be loaded, but it was never actually installed. The removal of this package also resulted in there no longer being a proper LSP client with eglot—this has also been fixed.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
