### PR TITLE
docs: update install instructions for macos

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -293,7 +293,7 @@ to least recommended for Doom (based on compatibility).
   with macOS, native emojis and better childframe support.
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
-  brew install emacs-mac --with-modules
+  brew install emacs-mac --with-modules --with-native-comp
   ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
   #+END_SRC
 

--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -279,7 +279,7 @@ MacPorts package manager installed (you only need one):
 First, Doom's dependencies:
 #+BEGIN_SRC bash
 # required dependencies
-brew install git ripgrep
+brew install git ripgrep gcc libgccjit
 # optional dependencies
 brew install coreutils fd
 # Installs clang


### PR DESCRIPTION
Updating macOS docs because compiling railwaycat/emacs-mac --with-modules --with-native-comp doubles performance on macOs using M2 mac as a backdrop