### PR TITLE
fix(org): don't call org-reveal in dead buffer

### DIFF
--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -511,8 +511,9 @@ All my (performant) foldings needs are met between this and `org-show-subtree'
        (let ((buf (current-buffer)))
          (unless (doom-temp-buffer-p buf)
            (run-at-time 0.1 nil (lambda ()
-                                  (with-current-buffer buf
-                                    (org-reveal '(4)))))))))
+                                  (when (buffer-live-p buf)
+                                    (with-current-buffer buf
+                                      (org-reveal '(4))))))))))
 
 ;;;###autoload
 (defun +org-remove-occur-highlights-h ()


### PR DESCRIPTION
This fixes a bug introduced in bb3431a (#7509). This shows up for
example in `org-capture`, which uses multiple org buffers and the
initial one (with name `*Capture*`) will be dead already by the time the
timer runs.

Amend: #7509


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
