### PR TITLE
bump: :tools tree-sitter

### DIFF
--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -2,7 +2,7 @@
 ;;; tools/tree-sitter/packages.el
 
 (package! tree-sitter :pin "3cfab8a0e945db9b3df84437f27945746a43cc71")
-(package! tree-sitter-langs :pin "3a3ad0527d5f8c7768678878eb5cfe399bedf703")
+(package! tree-sitter-langs :pin "5eb24557f542d5fa18e7baaf07969cf7f297bfcd")
 (package! tree-sitter-indent :pin "4ef246db3e4ff99f672fe5e4b416c890f885c09e")
 
 (when (modulep! :editor evil +everywhere)


### PR DESCRIPTION
This fixes broken syntax highlighting in Clojure buffers.

emacs-tree-sitter/tree-sitter-langs@3a3ad0527d5f -> emacs-tree-sitter/tree-sitter-langs@5eb24557f542

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
