### PR TITLE
bump: :editor format

### DIFF
--- a/modules/editor/format/autoload/settings.el
+++ b/modules/editor/format/autoload/settings.el
@@ -74,7 +74,7 @@ Advanced examples:
     \"elm-format --yes --stdin\")"
   (declare (indent defun))
   (cl-check-type name symbol)
-  (after! apheleia-core
+  (after! apheleia
     (if (null args)
         (progn
           (setq apheleia-formatters

--- a/modules/editor/format/packages.el
+++ b/modules/editor/format/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/format/packages.el
 
-(package! apheleia :pin "c222927f7086d407dad01b2609ff68768e9adddb")
+(package! apheleia :pin "56651724ad22f2769bbdaccf54cbe75c1cb35c91")


### PR DESCRIPTION
fbd00b6a08300b453c15410e693823078c9015af changes `aphelia-core` to `aphelia`, but only in 1 out of 2 places *and* this is not the correct name in the version pinned in doom.

This PR fixes the other reference to `apheleia-core` and bumps `apheleia` to match.

Fix: #7568

- fix(format): correct name of feature
- bump: :editor format

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
