### PR TITLE
bump: haskell-mode

### DIFF
--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/haskell/packages.el
 
-(package! haskell-mode :pin "3e146c1a89db257bb75c7b33fa2a5a1a85aabd51")
+(package! haskell-mode :pin "8d0f44bfe2a9ab6b0969c9bafb75089f315ff5ae")
 
 (when (and (modulep! +lsp)
            (not (modulep! :tools lsp +eglot)))


### PR DESCRIPTION
haskell/haskell-mode@3e146c1a89db -> haskell/haskell-mode@8d0f44bfe2a9

- (#7569) Fixes error caused by not loading `flymake-proc`

Fix: #7569.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
