### PR TITLE
tweak(default): add binding for undo-tree

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -760,8 +760,9 @@
              ((modulep! :completion helm)      #'swiper-isearch-thing-at-point))
        :desc "Dictionary"                   "t" #'+lookup/dictionary-definition
        :desc "Thesaurus"                    "T" #'+lookup/synonyms
-       (:when (fboundp 'vundo)
-         :desc "Undo history"               "u" #'vundo))
+       :desc "Undo history"                 "u"
+       (cond ((modulep! :emacs undo +tree)     #'undo-tree-visualize)
+             ((modulep! :emacs undo)           #'vundo)))
 
       ;;; <leader> t --- toggle
       (:prefix-map ("t" . "toggle")


### PR DESCRIPTION
This also makes the check for the presence of vundo consistent with the rest of the file by using modulep! instead of fboundp.

If there's interest, I could also add an emacs binding. The built-in binding of undo-tree-visualize is C-x u, so we could use the same for vundo. But feel free to suggest a better one, I'm not familiar with the conventions for emacs bindings.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

