### PR TITLE
module: fix :lang nim move `nimfmt` to `nimpretty`

### DIFF
--- a/modules/lang/nim/config.el
+++ b/modules/lang/nim/config.el
@@ -12,7 +12,7 @@ nimsuggest isn't installed."
       (when (and nimsuggest-path (file-executable-p nimsuggest-path))
         (nimsuggest-mode))))
 
-  (set-formatter! 'nmfmt '("nimfmt" filepath) :modes '(nim-mode))
+  (set-formatter! 'nmfmt '("nimpretty" filepath) :modes '(nim-mode))
 
   (when IS-WINDOWS
     ;; TODO File PR/report upstream (https://github.com/nim-lang/nim-mode)

--- a/modules/lang/nim/doctor.el
+++ b/modules/lang/nim/doctor.el
@@ -8,5 +8,5 @@
   (warn! "Could not find nim executable; build commands will be disabled."))
 
 (when (modulep! :editor format)
-  (unless (executable-find "nimfmt")
-    (warn! "Could not find nimfmt. Formatting will be disabled.")))
+  (unless (executable-find "nimpretty")
+    (warn! "Could not find nimpretty. Formatting will be disabled.")))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The current implementation of the nim lang module targets `nimfmt` as default formatter, this it's no more compatible with the current stable branch 2.x of the Nim programming language.
I've changed it to target `nimpretty` instead. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
