### PR TITLE
fix(org): correct :face parameter for doom-user links

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -614,7 +614,9 @@ relative to `org-directory', unless it is an absolute path."
                 (format "https://github.com/%s"
                         (string-remove-prefix
                          "@" (+org-link-read-desc-at-point link)))))
-     :face 'org-priority)
+     :face (lambda (_)
+             ;; Avoid confusion with function `org-priority'
+             'org-priority))
     (org-link-set-parameters
      "doom-changelog"
      :follow (lambda (link)


### PR DESCRIPTION
Currently the documentation for `:lang org`, among some others, does not load correctly. It would not enter `doom-docs-org-mode` with error
```
File mode specification error: (user-error Invalid action)
```

It turns out that `org-link-set-parameters` accepts `:face` for a function returning a face or a symbol naming a face. Passing `org-priority` directly would cause it being evaluated as a function, preventing documents containing `doom-user:` links from loading.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
