### PR TITLE
fix(vertico): embark open in new workspace action

### DIFF
--- a/modules/completion/vertico/autoload/workspaces.el
+++ b/modules/completion/vertico/autoload/workspaces.el
@@ -86,8 +86,8 @@ buffer will be opened in the current workspace instead."
           (funcall consult--buffer-display (car buffer)))))))
 
 ;;;###autoload
-(defun +vertico/embark-open-in-new-workspace (x)
-  "Open X (a file) in a new workspace."
-  (interactive)
+(defun +vertico/embark-open-in-new-workspace (file)
+  "Open file in a new workspace."
+  (interactive "GFile:")
   (+workspace/new)
-  (find-file x))
+  (find-file file))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This fixes the embark file action +vertico/embark-open-in-new-workspace not being interactivity callable which meant we get the following error when calling the action via embark:

```
embark PCH: (wrong-number-of-arguments ((t) (file) "Open file in a new workspace." (interactive) (+workspace/new) (find-file file)) 0)
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
