### PR TITLE
bump: :term eshell

### DIFF
--- a/modules/term/eshell/packages.el
+++ b/modules/term/eshell/packages.el
@@ -9,5 +9,5 @@
 (package! eshell-syntax-highlighting :pin "4ac27eec6595ba116a6151dfaf0b0e0440101e10")
 
 (unless IS-WINDOWS
-  (package! fish-completion :pin "df42e153082927536763bdf408184152a7c938c3")
+  (package! fish-completion :pin "d34d0b96fde63feedf13c4288183d8d4d4d748cf")
   (package! bash-completion :pin "f1daac0386c24cbe8a244a62c7588cc6847b07ae"))


### PR DESCRIPTION
Hi. Attempting to upgrade `doomemacs` with the `upgrade` or the `sync` command fails if you have enabled the `eshell` module:

```
✓ (212/338) emacs-fish-completion: d34d0b9 -> df42e15 [1 commit(s)]
        ERROR: Couldn't collect commit list because: fatal: bad object df42e153082927536763bdf408184152a7c938c3
```

It seems that `emacs-fish-completion` package has a new owner and it was moved to GitHub now - https://github.com/Ambrevar/emacs-fish-completion

This merge request updates the `emacs-fish-completion` pkg recipe to the new home. I think that the fix here should work. Let me know if this should be done in another way. Thanks!

ambrevar/emacs-fish-completion@df42e1530829 -> LemonBreezes/emacs-fish-completion@d34d0b96fde6

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
