### PR TITLE
fix(lib): use unibyte in binary temp buffers

### DIFF
--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -245,7 +245,8 @@ special values:
 'read*       -- read all forms in FILE and return it as a list of S-exps.
 '(read . N)  -- read the first N (an integer) S-exps in FILE.
 
-CODING dictates the encoding of the buffer. This defaults to `utf-8'.
+CODING dictates the encoding of the buffer. This defaults to `utf-8'. If set to
+nil, `binary' is used.
 
 If NOERROR is non-nil, don't throw an error if FILE doesn't exist. This will
 still throw an error if FILE is unreadable, however.
@@ -305,7 +306,7 @@ MODE dictates the permissions of the file. If FILE already exists, its
 permissions will be changed.
 
 CODING dictates the encoding to read/write with (see `coding-system-for-write').
-If set to nil, `binary' is used.
+This defaults to `utf-8'. If set to nil, `binary' is used.
 
 APPEND dictates where CONTENTS will be written. If neither is set,
 the file will be overwritten. If both are, the contents will be written to both

--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -326,7 +326,12 @@ ends. Set either APPEND or PREPEND to `noerror' to silently ignore read errors."
               ((let ((standard-output (current-buffer))
                      (print-quoted t)
                      (print-level nil)
-                     (print-length nil))
+                     (print-length nil)
+                     ;; Escape special chars to avoid any shenanigans
+                     (print-escape-newlines t)
+                     (print-escape-control-characters t)
+                     (print-escape-nonascii t)
+                     (print-escape-multibyte t))
                  (funcall printfn datum))))))
     (let (write-region-annotate-functions
           write-region-post-annotation-function)

--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -220,7 +220,7 @@ single file or nested compound statement of `and' and `or' statements."
              (let* ((buffer-file-name (doom-path ,file))
                     (coding-system-for-read  (or ,coding 'binary))
                     (coding-system-for-write (or coding-system-for-write coding-system-for-read 'binary)))
-               (unless (eq coding-system-for-read 'binary)
+               (when (eq coding-system-for-read 'binary)
                  (set-buffer-multibyte nil)
                  (setq-local buffer-file-coding-system 'binary))
                ,@body))


### PR DESCRIPTION
This avoids an issue where emacs yells at me with a popup like the following when I open `init.29.el`, e.g., when pressing `SPC c k` when the cursor is over `set-popup-rules!`:

```
These default coding systems were tried to encode the following
problematic characters in the buffer ‘init.29.el’:
  Coding System           Pos  Codepoint  Char
  utf-8-unix            25779  #x3FFFD0   
                        25780  #x3FFFCF   
                        25784  #x3FFFE1   
[...]
```

Strictly speaking, this issue goes away with either the second or the third commit, but I believe both are good changes.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
