### PR TITLE
fix(lib): doom/bumpify-diff: respect structure of given list

### DIFF
--- a/lisp/lib/packages.el
+++ b/lisp/lib/packages.el
@@ -239,7 +239,7 @@ Must be run from a magit diff buffer."
         (unless (= (length before) (length after))
           (user-error "Uneven number of packages being bumped"))
         (dolist (p1 before)
-          (when (and (listp p1) (eq (car p1) 'package!))
+          (when (and (listp p1) (plist-get (cdr p1) :package))
             (cl-destructuring-bind (package &key plist _beg _end &allow-other-keys) p1
               (let ((p2 (cdr (assq package after))))
                 (if (null p2)


### PR DESCRIPTION
The old check was a bug fix to work around noisy values that somehow made it into diff checks. The `package!` symbol is never actually present in the list of values yielded by the search in `read-package`, so this commit alters the lookup to respect what is actually present, thus guaranteeing that `destructuring-bind` succeeds and bump diffs are actually detected.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
