### PR TITLE
feat(common-lisp): use `sly-asdf`

### DIFF
--- a/modules/lang/common-lisp/autoload/common-lisp.el
+++ b/modules/lang/common-lisp/autoload/common-lisp.el
@@ -19,49 +19,8 @@
       (recurse 1))))
 
 ;;;###autoload
-(defun +lisp/load-project-systems ()
-  "Load all systems of the current Lisp project into Sly."
-  (interactive)
-  (thread-last (+lisp--project-asd-file)
-               (+lisp--systems-from-asd)
-               (mapcar (lambda (s) (format ":%s" s)))
-               (funcall (lambda (ss) (string-join ss " ")))
-               (format "(ql:quickload '(%s))")
-               (sly-interactive-eval)))
-
-(defun +lisp--project-asd-file ()
-  "Yield an absolute file path to the current project's `.asd' file."
-  (let* ((proot (doom-project-root))
-         (files (doom-files-in proot :depth 1 :match "[.]asd$")))
-    (pcase files
-      ('() (error "No .asd file found in: %s" proot))
-      (`(,asdf) asdf)
-      (_ (error "Too many .asd files found in : %s" proot)))))
-
-(defun +lisp--systems-from-asd (asdf)
-  "Given a path to an ASDF project definition, extract the names of
-the systems defined therein."
-  (let ((file (doom-file-read asdf))
-        (patt "defsystem \"\\([a-z-/]+\\)"))
-    (when (not (string-match patt file))
-      (error "No systems defined in: %s" asdf))
-    (thread-last (s-match-strings-all patt file)
-                 (mapcar #'cl-second))))
-
-;; TODO Get this to run in a comint buffer?
-;;;###autoload
-(defun +lisp/test-system ()
-  "Run `asdf:test-system' on the selected system of the current project."
-  (interactive)
-  (thread-last (+lisp--project-asd-file)
-               (+lisp--systems-from-asd)
-               (completing-read "Test which Lisp system?")
-               (format "(asdf:test-system :%s)")
-               (sly-interactive-eval)))
-
-;;;###autoload
 (defun +lisp/reload-project ()
-  "Restart the Sly session and reload the current project."
+  "Restart the Sly session and reload a chosen system."
   (interactive)
   (sly-restart-inferior-lisp)
   (cl-labels ((recurse (attempt)
@@ -72,7 +31,7 @@ the systems defined therein."
                              (error "Failed to reload Lisp project in 5 attempts.")
                            (recurse (1+ attempt)))))))
     (recurse 1)
-    (+lisp/load-project-systems)))
+    (sly-asdf-load-system)))
 
 ;;;###autoload
 (defun +lisp/find-file-in-quicklisp ()

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -141,7 +141,7 @@
           :desc "Who sets"                "S" #'sly-who-sets)
          (:prefix ("r" . "repl")
           :desc "Clear REPL"         "c" #'sly-mrepl-clear-repl
-          :desc "Load Project"       "l" #'+lisp/load-project-systems
+          :desc "Load System"        "l" #'sly-asdf-load-system
           :desc "Quit connection"    "q" #'sly-quit-lisp
           :desc "Restart connection" "r" #'sly-restart-inferior-lisp
           :desc "Reload Project"     "R" #'+lisp/reload-project
@@ -154,7 +154,7 @@
           :desc "Replay stickers"          "r" #'sly-stickers-replay
           :desc "Add/remove sticker"       "s" #'sly-stickers-dwim)
          (:prefix ("t" . "test")
-          :desc "Test System" "s" #'+lisp/test-system)
+          :desc "Test System" "s" #'sly-asdf-test-system)
          (:prefix ("T" . "trace")
           :desc "Toggle"         "t" #'sly-toggle-trace-fdefinition
           :desc "Toggle (fancy)" "T" #'sly-toggle-fancy-trace
@@ -168,3 +168,8 @@
   :defer t
   :init
   (add-to-list 'sly-contribs 'sly-repl-ansi-color))
+
+(use-package! sly-asdf
+  :defer t
+  :init
+  (add-to-list 'sly-contribs 'sly-asdf 'append))

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/common-lisp/packages.el
 
-(when (package! sly :pin "f34c22289a2b3ab10e607f9f8822d62bb5c98cf5")
+(when (package! sly :pin "ed17d2c2bd7aead0fbb09c3d22861c80a522a097")
   (package! sly-macrostep :pin "5113e4e926cd752b1d0bcc1508b3ebad5def5fad")
   (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048"))

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -2,5 +2,6 @@
 ;;; lang/common-lisp/packages.el
 
 (when (package! sly :pin "ed17d2c2bd7aead0fbb09c3d22861c80a522a097")
+  (package! sly-asdf :pin "6f9d751469bb82530db1673c22e7437ca6c95f45")
   (package! sly-macrostep :pin "5113e4e926cd752b1d0bcc1508b3ebad5def5fad")
   (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048"))


### PR DESCRIPTION
This allows us to offload system loading and testing to a third-party library.

Close: #7488 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

