### PR TITLE
Add Kagi search features

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -234,6 +234,7 @@ They are (with examples):
 - ~github:hlissner/doom-emacs~
 - ~gmap:Toronto, Ontario~ (Google Maps)
 - ~google:search terms~
+- ~kagi:search terms~
 - ~org:todo.org~ -> ={org-directory}/%s=
 - ~wolfram:sin(x^3)~
 - ~wikipedia:Emacs~

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -517,6 +517,7 @@ relative to `org-directory', unless it is an absolute path."
             '("google"      . "https://google.com/search?q=")
             '("gimages"     . "https://google.com/images?q=%s")
             '("gmap"        . "https://maps.google.com/maps?q=%s")
+            '("kagi"        . "https://kagi.com/search?q=%s")
             '("duckduckgo"  . "https://duckduckgo.com/?q=%s")
             '("wikipedia"   . "https://en.wikipedia.org/wiki/%s")
             '("wolfram"     . "https://wolframalpha.com/input/?i=%s")

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -20,6 +20,7 @@
             ("Google"            +lookup--online-backend-google "https://google.com/search?q=%s")
             ("Google images"     "https://www.google.com/images?q=%s")
             ("Google maps"       "https://maps.google.com/maps?q=%s")
+            ("Kagi"              "https://kagi.com/search?q=%s")
             ("Project Gutenberg" "http://www.gutenberg.org/ebooks/search/?query=%s")
             ("DuckDuckGo"        +lookup--online-backend-duckduckgo "https://duckduckgo.com/?q=%s")
             ("DevDocs.io"        "https://devdocs.io/#q=%s")


### PR DESCRIPTION
Adds some Kagi search goodness in-line with duckduckgo/google.

Didn't bother with the preview because that was ivy specific, and I'm not sure how popular that is anymore, and how many of those users would use the preview.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
