### PR TITLE
bump: :ui doom

### DIFF
--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/doom/packages.el
 
-(package! doom-themes :pin "4aee1f5a0e54552669f747aa7c25e6027e73d76d")
+(package! doom-themes :pin "ff26f26ea3d761375f5fc4070438fbd0f3473d33")
 (package! solaire-mode :pin "8af65fbdc50b25ed3214da949b8a484527c7cc14")


### PR DESCRIPTION
doomemacs/themes@4aee1f5a0e54 -> doomemacs/themes@ff26f26ea3d7

Improves Emacs 30 compatibility (see ref).

Ref: https://github.com/doomemacs/themes/issues/809

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

