### PR TITLE
feat: reintroduce the `format--org-region` back

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -53,7 +53,33 @@
            (when callback (funcall callback))
            (kill-buffer formatted-buffer)))))))
 
-
+(defun +format--org-region (beg end)
+  "Reformat the region within BEG and END.
+If nil, BEG and/or END will default to the boundaries of the src block at point."
+  (when (eq major-mode 'org-mode)
+    (let ((element (org-element-at-point)))
+      (save-excursion
+        (let* ((block-beg (save-excursion
+                            (goto-char (org-babel-where-is-src-block-head element))
+                            (line-beginning-position 2)))
+               (block-end (save-excursion
+                            (goto-char (org-element-property :end element))
+                            (skip-chars-backward " \t\n")
+                            (line-beginning-position)))
+               (beg (if beg (max beg block-beg) block-beg))
+               (end (if end (min end block-end) block-end))
+               (lang (org-element-property :language element))
+               (major-mode (org-src-get-lang-mode lang)))
+          (if (eq major-mode 'org-mode)
+              (user-error "Cannot reformat an org src block in org-mode")
+            ;; Determine formatter based on language and format the region
+            (let ((formatter (apheleia--get-formatters 'interactive)))
+              (unless formatter
+                (setq formatter (apheleia--get-formatters 'prompt))
+                (unless formatter
+                  (user-error "No formatter configured for language: %s" lang)))
+              (let ((apheleia-formatter formatter))
+                (+format-region beg end)))))))))
 ;;
 ;;; Commands
 
@@ -61,8 +87,11 @@
 (defun +format/buffer (&optional arg)
   "Reformat the current buffer using LSP or `format-all-buffer'."
   (interactive "P")
-  (or (run-hook-with-args-until-success '+format-functions (point-min) (point-max) 'buffer)
-      (call-interactively #'apheleia-format-buffer)))
+  (if (and (eq major-mode 'org-mode)
+           (org-in-src-block-p))
+      (+format--org-region (point-min) (point-max))
+    (or (run-hook-with-args-until-success '+format-functions (point-min) (point-max) 'buffer)
+        (call-interactively #'apheleia-format-buffer))))
 
 ;;;###autoload
 (defun +format/region (beg end &optional arg)


### PR DESCRIPTION
The `format--org-region` function, highly useful and convenient for frequent Org mode users, was removed for some reason from the `format` module in the last refactor (#6369). I suggest re-adding it, as it could be useful.


Fix: https://github.com/doomemacs/doomemacs/pull/6369#discussion_r1441274403
Ref: #6369
Close: https://github.com/doomemacs/doomemacs/pull/6369#discussion_r1441274403


