### PR TITLE
fix: read correct manpath on MacOS

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -59,11 +59,16 @@
 (after! woman
   ;; The woman-manpath default value does not necessarily match man. If we have
   ;; man available but aren't using it for performance reasons, we can extract
-  ;; it's manpath.
-  (when (executable-find "man")
-    (setq woman-manpath
-          (split-string (cdr (doom-call-process "man" "--path"))
-                        path-separator t))))
+  ;; its manpath.
+  (let ((manpath (cond
+                  ((executable-find "manpath")
+                   (split-string (cdr (doom-call-process "manpath"))
+                                 path-separator t))
+                  ((executable-find "man")
+                   (split-string (cdr (doom-call-process "man" "--path"))
+                                 path-separator t)))))
+    (when manpath
+      (setq woman-manpath manpath))))
 
 
 (use-package! drag-stuff


### PR DESCRIPTION
Versions of `man` shipped with the latest MacOS do not support the `--path` argument, which causes `M-x woman` in Emacs to break. However the `manpath` command gives the same information and exists on MacOS and Linux, at least the systems that I tested. Check for its existence, and if there is no `manpath` command then fall back to the logic that existed before.


Fix: #7021

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
