### PR TITLE
fix(upload): change ssh-deploy-on-explicit-save's default value to 1

### DIFF
--- a/modules/tools/upload/config.el
+++ b/modules/tools/upload/config.el
@@ -7,7 +7,7 @@
 ;; Example:
 ;;   ((nil . ((ssh-deploy-root-local . "/local/path/to/project")
 ;;            (ssh-deploy-root-remote . "/ssh:user@server:/remote/project/")
-;;            (ssh-deploy-on-explicit-save . t))))
+;;            (ssh-deploy-on-explicit-save . 1))))
 ;;
 ;; Note: `ssh-deploy-root-local' is optional, and will resort to
 ;; `doom-project-root' if unspecified.
@@ -20,7 +20,7 @@
              ssh-deploy-remote-changes-handler)
   :init
   (setq ssh-deploy-revision-folder (concat doom-cache-dir "ssh-revisions/")
-        ssh-deploy-on-explicit-save t
+        ssh-deploy-on-explicit-save 1
         ssh-deploy-automatically-detect-remote-changes nil)
 
   ;; Make these safe as file-local variables


### PR DESCRIPTION
#7513 changed the expected value of `ssh-deploy-on-explicit-save` to be an integer, but the default value was still `t`. This commit changes it to be `1`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.