### PR TITLE
tweak: add alert and use native alert on macOS

### DIFF
--- a/modules/os/macos/config.el
+++ b/modules/os/macos/config.el
@@ -33,6 +33,9 @@
 (after! auth-source
   (pushnew! auth-sources 'macos-keychain-internet 'macos-keychain-generic))
 
+;; Integrate with notification
+(after! alert
+  (setq alert-default-style 'osx-notifier))
 
 ;;
 ;;; Packages

--- a/modules/ui/alert/README.org
+++ b/modules/ui/alert/README.org
@@ -1,0 +1,48 @@
+#+title:    :ui alert
+#+subtitle: a Growl-like alerts notifier for Emacs
+#+created:  January 14, 2024
+#+since:    #7621
+
+* Description :unfold:
+Alert is a Growl-workalike for Emacs which uses a common notification interface
+and multiple, selectable "styles", whose use is fully customizable by the user.
+
+** Maintainers
+/This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+/This module has no flags./
+
+** Packages
+- [[doom-package:alert]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+# This section will be machine generated. Don't edit it by hand.
+/This module does not have a changelog yet./
+
+* Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+* TODO Usage
+#+begin_quote
+ 󱌣 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+#+end_quote
+
+* TODO Configuration
+#+begin_quote
+ 󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
+#+end_quote
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+ 󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/ui/alert/packages.el
+++ b/modules/ui/alert/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/alert/packages.el
+
+(package! alert :pin "7774b5fd2feb98d4910ff06435d08c19fba93e26")

--- a/templates/init.example.el
+++ b/templates/init.example.el
@@ -28,6 +28,7 @@
        vertico           ; the search engine of the future
 
        :ui
+       ;;alert             ; stop to be slience, start alerting
        ;;deft              ; notational velocity for Emacs
        doom              ; what makes DOOM look the way it does
        doom-dashboard    ; a nifty splash screen for Emacs


### PR DESCRIPTION
This small changes allows to make quite nice setup.

For example after this I may add to my WL configuration:
```
(setq wl-biff-notify-hook '((lambda () (alert "You have new mail!" :title "Wanderlust"))))
```
which leads to alerts like this:
<img width="371" alt="Screenshot 2024-01-14 at 14 05 29" src="https://github.com/doomemacs/doomemacs/assets/37775/a295fb89-5525-4c32-b195-fd9aed6ae35a">

