### PR TITLE
fix(vertico): don't shell-quote consult-ripgrep-args

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -31,7 +31,7 @@
                   "--path-separator /   --smart-case --no-heading "
                   "--with-filename --line-number --search-zip "
                   "--hidden -g !.git -g !.svn -g !.hg "
-                  (mapconcat #'shell-quote-argument args " ")))
+                  (mapconcat #'identity args " ")))
          (prompt (if (stringp prompt) (string-trim prompt) "Search"))
          (query (or query
                     (when (doom-region-active-p)

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -13,7 +13,9 @@
 :in PATH
   Sets what directory to base the search out of. Defaults to the current project's root.
 :recursive BOOL
-  Whether or not to search files recursively from the base directory."
+  Whether or not to search files recursively from the base directory.
+:args LIST
+  Arguments to be appended to `consult-ripgrep-args'."
   (declare (indent defun))
   (unless (executable-find "rg")
     (user-error "Couldn't find ripgrep in your PATH"))


### PR DESCRIPTION
Fixes the `:args` parameter of `+vertico-file-search` being unusable: the command-line args given through this parameter were being incorrectly escaped before appending them to `consult-ripgrep-args`. The fix is to not escape them at all.

We were using `shell-quote-argument`, which is meant for passing file
names, strings and so on, not command-line arguments. For example,
`(shell-quote-argument "--foo=bar")` yields "--foo\\=bar", which is
obviously invalid unless we're trying to pass an option named '--foo\'.

At any rate, there is no quoting/escaping for shells in the default
value of `consult-ripgrep-args`, so it doesn't look like this is
something we need to do.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
