### PR TITLE
feat(latex): allow fill-paragraph in description

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -182,19 +182,21 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   (dolist (env '("itemize" "enumerate" "description"))
     (add-to-list 'LaTeX-indent-environment-list `(,env +latex-indent-item-fn)))
 
-  ;; Fix #1849: allow fill-paragraph in itemize/enumerate.
-  (defadvice! +latex--re-indent-itemize-and-enumerate-a (fn &rest args)
+  ;; Fix #1849: allow fill-paragraph in itemize/enumerate/description.
+  (defadvice! +latex--re-indent-itemize-and-enumerate-and-description-a (fn &rest args)
     :around #'LaTeX-fill-region-as-para-do
     (let ((LaTeX-indent-environment-list
            (append LaTeX-indent-environment-list
-                   '(("itemize"   +latex-indent-item-fn)
-                     ("enumerate" +latex-indent-item-fn)))))
+                   '(("itemize"     +latex-indent-item-fn)
+                     ("enumerate"   +latex-indent-item-fn)
+                     ("description" +latex-indent-item-fn)))))
       (apply fn args)))
-  (defadvice! +latex--dont-indent-itemize-and-enumerate-a (fn &rest args)
+  (defadvice! +latex--dont-indent-itemize-and-enumerate-and-description-a (fn &rest args)
     :around #'LaTeX-fill-region-as-paragraph
     (let ((LaTeX-indent-environment-list LaTeX-indent-environment-list))
       (delq! "itemize" LaTeX-indent-environment-list 'assoc)
       (delq! "enumerate" LaTeX-indent-environment-list 'assoc)
+      (delq! "description" LaTeX-indent-environment-list 'assoc)
       (apply fn args))))
 
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Currently `fill-paragraph` only works with `itemize` and `enumerate`. This PR allows `fill-paragraph` also in `description`.
-----
- [ x] I searched the issue tracker and this hasn't been PRed before.
- [ x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
