### PR TITLE
fix(evil): obsolete `evil-command-window` advice

### DIFF
--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -102,26 +102,6 @@ were followed."
 
 ;;;###package evil
 (progn
-  ;; Make evil-mode cooperate with popups
-  (defadvice! +popup--evil-command-window-a (hist cmd-key execute-fn)
-    "Monkey patch the evil command window to use `pop-to-buffer' instead of
-`switch-to-buffer', allowing the popup manager to handle it."
-    :override #'evil-command-window
-    (when (eq major-mode 'evil-command-window-mode)
-      (user-error "Cannot recursively open command line window"))
-    (dolist (win (window-list))
-      (when (equal (buffer-name (window-buffer win))
-                   "*Command Line*")
-        (kill-buffer (window-buffer win))
-        (delete-window win)))
-    (setq evil-command-window-current-buffer (current-buffer))
-    (ignore-errors (kill-buffer "*Command Line*"))
-    (with-current-buffer (pop-to-buffer "*Command Line*")
-      (setq-local evil-command-window-execute-fn execute-fn)
-      (setq-local evil-command-window-cmd-key cmd-key)
-      (evil-command-window-mode)
-      (evil--command-window-insert-commands hist)))
-
   (defadvice! +popup--evil-command-window-execute-a ()
     "Execute the command under the cursor in the appropriate buffer, rather than
 the command buffer."


### PR DESCRIPTION
As noted in #7556, the advice `+popup--evil-command-window-a` fails, preventing the command window from being opened. This is because `evil-command-window` has been rewritten extensively.

In particular, https://github.com/emacs-evil/evil/commit/a09fdca0b35ef4289cf55d7b0ffadf4cf3a5c9fc made it use `display-buffer` instead of `switch-to-buffer`, so that users could customize how the window opens. Since this was the function of this advice, it is obsolete and can be removed.

Fix: #7556 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.