### PR TITLE
fix(file-templates): invalid function call

### DIFF
--- a/modules/editor/file-templates/autoload.el
+++ b/modules/editor/file-templates/autoload.el
@@ -81,7 +81,7 @@ evil is loaded and enabled)."
                    (and yas--active-field-overlay
                         (overlay-buffer yas--active-field-overlay)
                         (overlay-get yas--active-field-overlay 'yas--field)))
-          (evil-initialize-state 'insert))))))
+          (evil-change-state 'insert))))))
 
 ;;;###autoload
 (defun +file-templates-get-short-path ()


### PR DESCRIPTION
Replaced a call to `evil-initialize-state` with a call to `evil-change-state` since the former was recently changed to no longer accept any arguments.

See:
emacs-evil/evil@1c4c3bf

-----
- [X ] I searched the issue tracker and this hasn't been PRed before.
- [X ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X ] Any relevant issues or PRs have been linked to.