### PR TITLE
docs(ivy): mention lowered `ivy-sort-max-size`

### DIFF
--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -176,7 +176,16 @@ A wgrep buffer can be opened from swiper with [[kbd:][C-c C-e]].
 ** TODO Change the position of the ivy childframe
 
 * TODO Troubleshooting
-/There are no known problems with this module./ [[doom-report:][Report one?]]
+** Sorting is not applied at all sometimes
+If the number of candidates is greater than ~ivy-sort-max-size~, sorting will be
+disabled completely. Doom lowers the default value to prevent performance
+issues, so increasing the value may fix your issue:
+#+begin_src elisp
+;;; add to $DOOMDIR/config.el
+(after! ivy
+  (setq ivy-sort-max-size 30000))  ; Doom sets this to 7500, but Ivy's default is 30k
+#+end_src
+
 
 * Frequently asked questions
 [[doom-suggest-faq:][Ask a question?]]


### PR DESCRIPTION
Depending on the system, this can cause sorting to be disabled long before the performance hit would be felt, and it's not obvious that this is the reason.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).