### PR TITLE
Remove fish-completion HACK for inhibitting error

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -244,12 +244,5 @@ Emacs versions < 29."
 (use-package! fish-completion
   :unless IS-WINDOWS
   :hook (eshell-mode . fish-completion-mode)
-  :init (setq fish-completion-fallback-on-bash-p t)
-  :config
-  ;; HACK Even with `fish-completion-fallback-on-bash-p' non-nil,
-  ;;      `fish-completion--list-completions-with-desc' will throw an error if
-  ;;      fish isn't installed (and so, will fail to fall back to bash), so we
-  ;;      advise it to fail silently.
-  (defadvice! +eshell--fallback-to-bash-a (&rest _)
-    :before-until #'fish-completion--list-completions-with-desc
-    (unless (executable-find "fish") "")))
+  :init (setq fish-completion-fallback-on-bash-p t
+              fish-completion-inhibit-missing-fish-command-warning t))


### PR DESCRIPTION
Hi. I have taken over maintainership of `fish-completion` and have added a customization option for inhibiting the warning for a missing `fish` executable.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.