### PR TITLE
feat: set jump on more kill buffer functions

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -486,6 +486,9 @@ files, so this replace calls to `pp' with the much faster `prin1'."
   ;; I'm not advising `kill-buffer' because I only want this to affect
   ;; interactively killed buffers.
   (advice-add #'kill-current-buffer :around #'doom-set-jump-a)
+  (advice-add #'doom/kill-this-buffer-in-all-windows :around #'doom-set-jump-a)
+  (advice-add #'kill-buffer-and-window :around #'doom-set-jump-a)
+  (advice-add #'kill-this-buffer :around #'doom-set-jump-a)
 
   ;; Create a jump point before jumping with imenu.
   (advice-add #'imenu :around #'doom-set-jump-a))


### PR DESCRIPTION
Hi. There are some interactive commands for killing the current buffer that do not allow for undoing the buffer kill by using the jumps. I made those commands set a jump.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
