### PR TITLE
fix(dired): void-variable dired-omit-files error

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -137,6 +137,7 @@ we have to clean it up ourselves."
   :init (after! dired (dirvish-override-dired-mode))
   :hook (dired-mode . dired-omit-mode)
   :config
+  (require 'dired-x)
   (setq dirvish-cache-dir (concat doom-cache-dir "dirvish/")
         dirvish-hide-details nil
         dirvish-attributes '(git-msg)
@@ -171,7 +172,6 @@ we have to clean it up ourselves."
 
 
 (use-package! dired-x
-  :unless (modulep! +dirvish)
   :unless (modulep! +ranger)
   :hook (dired-mode . dired-omit-mode)
   :config


### PR DESCRIPTION
Hello,

With recent update https://github.com/doomemacs/doomemacs/commit/e242ac9548487ae50857ec1b169a20d946019816 `dired +dirvish` fails with `void-variable dired-omit-files error`.

Fix: #6562
