### PR TITLE
feat(common-lisp): introduce `sly-overlay`

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -110,12 +110,13 @@
           :desc "Remove notes"          "n" #'sly-remove-notes
           :desc "Compile region"        "r" #'sly-compile-region)
          (:prefix ("e" . "evaluate")
-          :desc "Evaluate buffer"     "b" #'sly-eval-buffer
-          :desc "Evaluate last"       "e" #'sly-eval-last-expression
-          :desc "Evaluate/print last" "E" #'sly-eval-print-last-expression
-          :desc "Evaluate defun"      "f" #'sly-eval-defun
-          :desc "Undefine function"   "F" #'sly-undefine-function
-          :desc "Evaluate region"     "r" #'sly-eval-region)
+          :desc "Evaluate buffer"        "b" #'sly-eval-buffer
+          :desc "Evaluate defun"         "d" #'sly-overlay-eval-defun
+          :desc "Evaluate last"          "e" #'sly-eval-last-expression
+          :desc "Evaluate/print last"    "E" #'sly-eval-print-last-expression
+          :desc "Evaluate defun (async)" "f" #'sly-eval-defun
+          :desc "Undefine function"      "F" #'sly-undefine-function
+          :desc "Evaluate region"        "r" #'sly-eval-region)
          (:prefix ("g" . "goto")
           :desc "Go back"              "b" #'sly-pop-find-definition-stack
           :desc "Go to"                "d" #'sly-edit-definition

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -4,4 +4,5 @@
 (when (package! sly :pin "ed17d2c2bd7aead0fbb09c3d22861c80a522a097")
   (package! sly-asdf :pin "6f9d751469bb82530db1673c22e7437ca6c95f45")
   (package! sly-macrostep :pin "5113e4e926cd752b1d0bcc1508b3ebad5def5fad")
-  (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048"))
+  (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048")
+  (package! sly-overlay :pin "916b50297a1f3bb110f840b89b8717d194623e5f"))


### PR DESCRIPTION
`sly-overlay` is an extension for [Sly](https://github.com/joaotavora/sly) that enables the overlay of Common Lisp evaluation results directly into the buffer in the spirit of [CIDER](https://github.com/clojure-emacs/cider) (Clojure) and [Eros](https://github.com/xiongtx/eros) (Emacs Lisp).

Strangely, `SPC m e d` is the defaulting `eval` binding for Emacs Lisp and Clojure, but it wasn't for Common Lisp. So this new function swoops in and claims that as the default. The old binding remains on `SPC m e f`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.


