### PR TITLE
fix(vertico): mapping for embark open in workspace

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -305,7 +305,8 @@ orderless."
          (:when (modulep! :tools magit)
            :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (modulep! :ui workspaces)
-           :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace))))
+           :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace
+           :desc "Open in new workspace"       "<tab>" #'+vertico/embark-open-in-new-workspace))))
 
 
 (use-package! marginalia


### PR DESCRIPTION
Bind to both `TAB` and `<tab>` - if they have been mapped to different commands anywhere, Emacs will no longer treat them as equivalent, and this mapping will not work.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).