### PR TITLE
fix: doom-module-load-path typo

### DIFF
--- a/lisp/doom-modules.el
+++ b/lisp/doom-modules.el
@@ -279,7 +279,7 @@ configdepth. See `doom-module-set' for details."
              (append (seq-remove #'cdr (doom-module-list nil initorder?))
                      (doom-files-in (if (listp paths-or-all)
                                         paths-or-all
-                                      doom-modules-load-path)
+                                      doom-module-load-path)
                                     :map #'doom-module-from-path
                                     :type 'dirs
                                     :mindepth 1


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Fix `SPC h d m` error "Symbol's value as variable is void: doom-modules-load-path".

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
