### PR TITLE
fix(file-templates): correct spelling of contributor in __license-lgpl3

### DIFF
--- a/modules/editor/file-templates/templates/text-mode/__license-lgpl3
+++ b/modules/editor/file-templates/templates/text-mode/__license-lgpl3
@@ -2,7 +2,7 @@
 # name: GNU LGPL v3 License
 # uuid: __license-lgpl3
 # group: Licenses
-# contribuer: https://choosealicense.com/licenses/lgpl-3.0/
+# contributor: https://choosealicense.com/licenses/lgpl-3.0/
 # expand-env: ((yas-indent-line 'fixed))
 # --
                    GNU LESSER GENERAL PUBLIC LICENSE


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Apologies if this goes against the "No less than 3 trivial changes per MR", but this is not just a spelling error, it gives me an error in the minibuffer saying "Ignoring unknown directive "contribuer" in file: /home/ben/.emacs.d/modules/editor/file-templates/templates/text-mode/__license-lgpl3" every start which is a minor annoyance.

This is related to a recent change in yas-snippet: https://github.com/joaotavora/yasnippet/commit/25f5d8808af23fb3b3dd6a7aacb06e17006ffca6 that introduced the warning.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
Maybe borderline, it is a single trivial change, but it does not only fix a spelling error but also removes an annoying warning
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
