### PR TITLE
tweak(org): honor default command when archiving

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -957,7 +957,7 @@ between the two."
         (:when (modulep! :completion vertico)
          "." #'consult-org-heading
          "/" #'consult-org-agenda)
-        "A" #'org-archive-subtree
+        "A" #'org-archive-subtree-default
         "e" #'org-export-dispatch
         "f" #'org-footnote-action
         "h" #'org-toggle-heading
@@ -1090,7 +1090,7 @@ between the two."
          "n" #'org-narrow-to-subtree
          "r" #'org-refile
          "s" #'org-sparse-tree
-         "A" #'org-archive-subtree
+         "A" #'org-archive-subtree-default
          "N" #'widen
          "S" #'org-sort)
         (:prefix ("p" . "priority")


### PR DESCRIPTION
Change the binding for archiving to `org-archive-subtree-default`, which is the recommend "catch-all" command in the org manual. The user can specify the actual command in `org-archive-default-command`. The default for this variable is `org-archive-subtree`, which we previously used for the binding, so this commit changes behavior only for users who have set `org-archive-default-command` explicitly.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

