### PR TITLE
fix(lib): sudo file path: expand-file-name

### DIFF
--- a/lisp/lib/files.el
+++ b/lisp/lib/files.el
@@ -487,7 +487,7 @@ If FORCE-P, overwrite the destination file if it exists, without confirmation."
 (defun doom/sudo-find-file (file)
   "Open FILE as root."
   (interactive "FOpen file as root: ")
-  (find-file (doom--sudo-file-path file)))
+  (find-file (doom--sudo-file-path (expand-file-name file))))
 
 ;;;###autoload
 (defun doom/sudo-this-file ()


### PR DESCRIPTION
It's possible for the user to type shell variables (something like `$MYVAR/dir/filename`) as part of the filepath, so we need to call `expand-file-name`.


- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).