### PR TITLE
fix(vertico) set root user for consult-dir containers

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -209,10 +209,8 @@ orderless."
                               (apply #'process-lines +vertico-consult-dir-container-executable
                                      (append +vertico-consult-dir-container-args (list "ps")))))
                for cand = (split-string line "[[:space:]]+" t)
-               collect (let ((user (unless (string-empty-p (car cand))
-                                     (concat (car cand) "@")))
-                             (hostname (car (last cand))))
-                         (format "/%s:%s%s:/" host user hostname))))
+               collect (let ((hostname (car (last cand))))
+                         (format "/%s:root@%s:/" host hostname))))
 
     (defun +vertico--consult-dir-podman-hosts ()
       (let ((+vertico-consult-dir-container-executable "podman"))


### PR DESCRIPTION
The tramp string used to connect to the container uses the first 'container-runtime ps' argument as a username. However, the first argument that is returned is the container id, not a username.

Instead of inspecting the container to find the user, just default to 'root' which should work for most cases.

There doesn't seem to be an open issue for this - so if that's needed I can create one first.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
