### PR TITLE
bump: :lang dart

### DIFF
--- a/modules/lang/dart/packages.el
+++ b/modules/lang/dart/packages.el
@@ -5,7 +5,7 @@
 
 (when (and (modulep! +lsp)
            (not (modulep! :tools lsp +eglot)))
-  (package! lsp-dart :pin "e7ee6afc2e165291360fd35d16648307920837c7"))
+  (package! lsp-dart :pin "f51c80f5458d8ba4db9dd3781d190c6c32213250"))
 
 (when (modulep! +flutter)
   (package! flutter :pin "004c91e070a9b4a2a5042f5bb20015ec65453acf")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

An issue happened recently where the lsp-dart daemon failed to start. See https://github.com/emacs-lsp/lsp-dart/issues/209

While the thread mentioned Emacs built from master, I confirm it happens on 29.2 (and I think 29.1 as well), so I'm not really sure what update broke the setup. Anyway, the `lsp-dart` team have merged a fix and this PR bumps the `lsp-dart` version.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
