### PR TITLE
bump: :checkers syntax

### DIFF
--- a/modules/checkers/syntax/packages.el
+++ b/modules/checkers/syntax/packages.el
@@ -2,7 +2,7 @@
 ;;; checkers/syntax/packages.el
 
 (unless (modulep! +flymake)
-  (package! flycheck :pin "e56e30d8c66ffc9776d07740658d3b542c1a8e21")
+  (package! flycheck :pin "e66068989ec5f3e96ff73b22bb8494b23722c8f9")
   (package! flycheck-popup-tip :pin "ef86aad907f27ca076859d8d9416f4f7727619c6")
   (when (modulep! +childframe)
     (package! flycheck-posframe :pin "19896b922c76a0f460bf3fe8d8ebc2f9ac9028d8")))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -8,7 +8,7 @@
         (package! consult-eglot :pin "049c6319b8a48ff66189d49592c7759f0b356596"))
       (when (and (modulep! :checkers syntax)
              (not (modulep! :checkers syntax +flymake)))
-        (package! flycheck-eglot :pin "9ff8d0068be59b1450964b390349d75a68af21ed")))
+        (package! flycheck-eglot :pin "114e1315aaf0dc3196da67da426bbe2b46384fe2")))
   (package! lsp-mode :pin "fb88cc6b8bcad4df5dd1d4e5d785adc7663e5c76")
   (package! lsp-ui :pin "bc58c6664577d1d79060c6b32b7ad20e70ee19d0")
   (when (modulep! :completion ivy)


### PR DESCRIPTION
flycheck/flycheck@e56e30d8c66f -> flycheck/flycheck@e66068989ec5
flycheck/flycheck-eglot@9ff8d0068be5 -> flycheck/flycheck-eglot@114e1315aaf0

<!-- ⚠️ Please do not ignore this template! -->

`@bbatsov` seems took over the `flycheck` package and released two versions already 33 and 34. This merge request updates the `flycheck` package to the latest released version 34.
According to the changelog, all commits were about fixing existing linters or adding new (I checked `doom` configuration and didn't find any required change) linters. I think it should be okay to pull the latest released version (34) into `doom-emacs` but I am completely open to any other solution.

One thing that I also included into this merge request is a small update to the `flycheck-eglot` package. This update doesn't include any code change but rather some doc updates so I opted in to update this package too. Totally fine with dropping that update from this merge request.

Thank you!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
