### PR TITLE
fix: treemacs nerd icons

### DIFF
--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -44,7 +44,7 @@ This must be set before `treemacs' has loaded.")
 
 
 (use-package! treemacs-nerd-icons
-  :after treemacs
+  :after ( treemacs  lsp-treemacs nerd-icons)
   :config (treemacs-load-theme "nerd-icons"))
 
 


### PR DESCRIPTION
I changed the load order for treemacs-load-theme after lsp-treemacs is loaded, to fix the missing/wrong icons bug, when using lsp-treemacs. 
https://github.com/rainstormstudio/treemacs-nerd-icons/issues/1



-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
