### PR TITLE
refactor: factorize external executables

### DIFF
--- a/lisp/cli/doctor.el
+++ b/lisp/cli/doctor.el
@@ -92,7 +92,7 @@ in."
                        version))
            (warn! "Cannot determine Git version. Doom requires git 2.23 or newer!")))))
 
-   (unless (executable-find "rg")
+   (unless (executable-find doom-rg-binary)
      (error! "Couldn't find the `rg' binary; this a hard dependecy for Doom, file searches may not work at all")))
 
   (print! (start "Checking for Emacs config conflicts..."))

--- a/lisp/doom-projects.el
+++ b/lisp/doom-projects.el
@@ -19,6 +19,8 @@ debian, and derivatives). On most it's 'fd'.")
 
 (defvar doom-projects--fd-version nil)
 
+(defvar doom-rg-binary "rg")
+
 
 ;;
 ;;; Packages
@@ -198,8 +200,8 @@ And if it's a function, evaluate it."
                                         "" "--strip-cwd-prefix"))
                         (if doom--system-windows-p " --path-separator=/"))))
            ;; Otherwise, resort to ripgrep, which is also faster than find
-           ((executable-find "rg" t)
-            (concat "rg -0 --files --follow --color=never --hidden -g!.git"
+           ((executable-find doom-rg-binary t)
+            (concat doom-rg-binary " -0 --files --follow --color=never --hidden -g!.git"
                     (if doom--system-windows-p " --path-separator=/")))
            ("find . -type f -print0"))))
 

--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -694,7 +694,7 @@ config blocks in your private config."
 (defvar counsel-rg-base-command)
 (defun doom--help-search (dirs query prompt)
   ;; REVIEW Replace with deadgrep
-  (unless (executable-find "rg")
+  (unless (executable-find doom-rg-binary)
     (user-error "Can't find ripgrep on your system"))
   (cond ((fboundp 'consult--grep)
          (consult--grep prompt #'consult--ripgrep-make-builder (cons data-directory dirs) query))
@@ -708,7 +708,7 @@ config blocks in your private config."
         ;; () TODO Helm support?
         ((grep-find
           (string-join
-           (append (list "rg" "-L" "--search-zip" "--no-heading" "--color=never"
+           (append (list doom-rg-binary "-L" "--search-zip" "--no-heading" "--color=never"
                          (shell-quote-argument query))
                    (mapcar #'shell-quote-argument dirs))
            " ")))))

--- a/modules/completion/helm/autoload/helm.el
+++ b/modules/completion/helm/autoload/helm.el
@@ -49,7 +49,7 @@ workspace."
 :recursive BOOL
   Whether or not to search files recursively from the base directory."
   (declare (indent defun))
-  (unless (executable-find "rg")
+  (unless (executable-find doom-rg-binary)
     (user-error "Couldn't find ripgrep in your PATH"))
   (require 'helm-rg)
   (let ((this-command 'helm-rg)

--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -248,7 +248,7 @@ The point of this is to avoid Emacs locking up indexing massive file trees."
 :recursive BOOL
   Whether or not to search files recursively from the base directory."
   (declare (indent defun))
-  (unless (executable-find "rg")
+  (unless (executable-find doom-rg-binary)
     (user-error "Couldn't find ripgrep in your PATH"))
   (require 'counsel)
   (let* ((this-command 'counsel-rg)

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -292,8 +292,8 @@ workable results ripgrep produces, despite the error."
                                   collect "--exclude"
                                   collect dir)
                          (if (featurep :system 'windows) '("--path-separator=/")))))
-              ((executable-find "rg" t)
-               (append (list "rg" "--hidden" "--files" "--follow" "--color=never" "--no-messages")
+              ((executable-find doom-rg-binary t)
+               (append (list doom-rg-binary "--hidden" "--files" "--follow" "--color=never" "--no-messages")
                        (cl-loop for dir in projectile-globally-ignored-directories
                                 collect "--glob"
                                 collect (concat "!" dir))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -17,14 +17,14 @@
 :args LIST
   Arguments to be appended to `consult-ripgrep-args'."
   (declare (indent defun))
-  (unless (executable-find "rg")
+  (unless (executable-find doom-rg-binary)
     (user-error "Couldn't find ripgrep in your PATH"))
   (require 'consult)
   (setq deactivate-mark t)
   (let* ((project-root (or (doom-project-root) default-directory))
          (directory (or in project-root))
          (consult-ripgrep-args
-          (concat "rg "
+          (concat doom-rg-binary " "
                   (if all-files "-uu ")
                   (unless recursive "--maxdepth 1 ")
                   "--null --line-buffered --color=never --max-columns=1000 "

--- a/modules/completion/vertico/doctor.el
+++ b/modules/completion/vertico/doctor.el
@@ -13,6 +13,6 @@
     (explain! "Some advanced consult filtering features will not work as a result, see the module readme."))
 
   ;; TODO: Move this to core in v3.0
-  (unless (consult--grep-lookahead-p "rg" "-P")
+  (unless (consult--grep-lookahead-p doom-rg-binary "-P")
     (warn! "The installed ripgrep binary was not built with support for PCRE lookaheads.")
     (explain! "Some advanced consult filtering features will not work as a result, see the module readme.")))

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -10,13 +10,15 @@
 (defvar +clojure-load-clj-refactor-with-lsp nil
   "Whether or not to include clj-refactor along with clojure-lsp.")
 
+(defvar +clojure-cljfmt-binary "cljfmt")
+
 ;;
 ;;; Packages
 
 (use-package! clojure-mode
   :hook (clojure-mode . rainbow-delimiters-mode)
   :config
-  (set-formatter! 'cljfmt '("cljfmt" "fix" "-") :modes '(clojure-mode clojurec-mode clojurescript-mode))
+  (set-formatter! 'cljfmt `(,+clojure-cljfmt-binary "fix" "-") :modes '(clojure-mode clojurec-mode clojurescript-mode))
 
   (when (modulep! +lsp)
     (add-hook! '(clojure-mode-local-vars-hook

--- a/modules/lang/clojure/doctor.el
+++ b/modules/lang/clojure/doctor.el
@@ -7,5 +7,5 @@
     (warn! "Couldn't find clj-kondo. flycheck-clj-kondo will not work.")))
 
 (when (modulep! :editor format)
-  (unless (executable-find "cljfmt")
+  (unless +clojure-cljfmt-binary
     (warn! "Couldn't find cljfmt. Formatting will be disabled.")))

--- a/modules/lang/data/config.el
+++ b/modules/lang/data/config.el
@@ -1,5 +1,7 @@
 ;;; lang/data/config.el -*- lexical-binding: t; -*-
 
+(defvar +data-xmllint-binary "xmllint")
+
 (use-package! nxml-mode
   :mode "\\.p\\(?:list\\|om\\)\\'" ; plist, pom
   :mode "\\.xs\\(?:d\\|lt\\)\\'"   ; xslt, xsd
@@ -12,7 +14,7 @@
     (sp-local-pair 'nxml-mode "<" ">" :post-handlers '(("[d1]" "/"))))
   (set-company-backend! 'nxml-mode '(company-nxml company-yasnippet))
   (setq-hook! 'nxml-mode-hook tab-width nxml-child-indent)
-  (set-formatter! 'xmllint '("xmllint" "--format" "-") :modes '(nxml-mode)))
+  (set-formatter! 'xmllint `(+data-xmllint-binary "--format" "-") :modes '(nxml-mode)))
 
 
 ;;;###package csv-mode

--- a/modules/lang/data/doctor.el
+++ b/modules/lang/data/doctor.el
@@ -1,5 +1,5 @@
 ;;; lang/data/doctor.el -*- lexical-binding: t; -*-
 
 (when (modulep! :editor format)
-  (unless (executable-find "xmllint")
+  (unless (executable-find +data-xmllint-binary)
     (warn! "Couldn't find xmllint. Formatting will be disabled.")))


### PR DESCRIPTION
I'd like to see external executable dependencies (ripgrep, etc.)  better consolidated in the code.

Currently they're scattered all over the place. Ideally there would be a single defvar/defcustom for each that would allow for easy overriding, in particular for Guix/Nix users like me who would like to patch the code in a packaging step so all the various external deps don't have to be installed globally (but it would be useful to everyone else too and it's good practice anyway).

THIS IS A DRAFT PR. Just a start on how this might look and to get feedback.

Some considerations:
- `rg`/`fd` use is inconsistent with respect to remote files
- perform `executable-find` at the point of definition or at each point of use (where necessary)?
- doctor checks for executables depended-on by packages that themselves define a var for the executable should do `executable-find` on that var, not the raw command as a string

WDYT?