### PR TITLE
docs(bidi): how to size different fonts

### DIFF
--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -8,7 +8,9 @@
 Must be a `font-spec', see `doom-font' for examples.
 
 WARNING: if you specify a size for this font it will hard-lock any usage of this
-font to that size. It's rarely a good idea to do so!")
+font to that size. It's rarely a good idea to do so! If you want a different
+size for this font use `face-font-rescale-alist' e.g.
+(pushnew! face-font-rescale-alist `(\"FONT FAMILY NAME\" . 1.2))")
 
 (defface +bidi-hebrew-face `((t :font ,+bidi-hebrew-font)) "")
 
@@ -17,7 +19,9 @@ font to that size. It's rarely a good idea to do so!")
 Must be a `font-spec', see `doom-font' for examples.
 
 WARNING: if you specify a size for this font it will hard-lock any usage of this
-font to that size. It's rarely a good idea to do so!")
+font to that size. It's rarely a good idea to do so! If you want a different
+size for this font use `face-font-rescale-alist' e.g.
+(pushnew! face-font-rescale-alist `(\"FONT FAMILY NAME\" . 1.2))")
 
 (defface +bidi-arabic-face `((t :font ,+bidi-arabic-font)) "")
 


### PR DESCRIPTION
Document how to scale different fonts differently in the docs of `+bidi-arabic/hebrew-font`. Related [thread on discourse](https://discourse.doomemacs.org/t/font-size-is-bidi-module/3199).

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.