### PR TITLE
feat(dired): omit flycheck file in dired

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -179,6 +179,7 @@ we have to clean it up ourselves."
         dired-omit-files
         (concat dired-omit-files
                 "\\|^\\.DS_Store\\'"
+                "\\|^flycheck_.*"
                 "\\|^\\.project\\(?:ile\\)?\\'"
                 "\\|^\\.\\(?:svn\\|git\\)\\'"
                 "\\|^\\.ccls-cache\\'"


### PR DESCRIPTION
Omit the flycheck file in Dired, which can show up while flycheck is checking a buffer.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.