### PR TITLE
fix(mu4e): re-add removed mu4e commands

### DIFF
--- a/modules/email/mu4e/autoload/compat.el
+++ b/modules/email/mu4e/autoload/compat.el
@@ -1,0 +1,26 @@
+;;; email/mu4e/autoload/compat.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun mu4e-compose-goto-top ()
+  "Go to the beginning of the message or buffer.
+Go to the beginning of the message or, if already there, go to the
+beginning of the buffer."
+  (interactive)
+  (let ((old-position (point)))
+    (message-goto-body)
+    (when (equal (point) old-position)
+      (beginning-of-buffer))))
+
+;;;###autoload
+(defun mu4e-compose-goto-bottom ()
+  "Go to the end of the message or buffer.
+Go to the end of the message (before signature) or, if already there, go to the
+end of the buffer."
+  (interactive)
+  (let ((old-position (point))
+        (message-position (save-excursion (message-goto-body) (point))))
+    (end-of-buffer)
+    (when (re-search-backward "^-- $" message-position t)
+      (previous-line))
+    (when (equal (point) old-position)
+      (end-of-buffer))))


### PR DESCRIPTION
These two mu4e commands were removed recently, but they are still referenced by evil-collection-mu4e. This commit re-adds them.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
