### PR TITLE
mu4e: fix advice for new mu4e release

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -35,9 +35,9 @@ If STRICT only accept an unset lock file."
          (when (or strict (/= (emacs-pid) pid)) t))))
 
 ;;;###autoload
-(defun +mu4e-lock-file-delete-maybe ()
+(defun +mu4e-lock-file-delete-maybe (&optional bury)
   "Check `+mu4e-lock-file', and delete it if this process is responsible for it."
-  (when (+mu4e-lock-available)
+  (when (and (+mu4e-lock-available) (not bury))
     (delete-file +mu4e-lock-file)
     (file-notify-rm-watch +mu4e-lock--request-watcher)))
 


### PR DESCRIPTION
mu4e-quit now takes an optional argument, BURY, which is a boolean that determines whether to bury the buffer or kill it. This commit updates the advice to reflect this change.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
