### PR TITLE
fix(workspaces): add check for ivy before setting counsel-projectile-[XXXX]

### DIFF
--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -179,32 +179,34 @@ stored in `persp-save-dir'.")
   (add-hook 'delete-frame-functions #'+workspaces-delete-associated-workspace-h)
   (add-hook 'server-done-hook #'+workspaces-delete-associated-workspace-h)
 
-  ;; per-project workspaces, but reuse current workspace if empty
-  ;; HACK?? needs review
-  (setq projectile-switch-project-action (lambda () (+workspaces-set-project-action-fn) (+workspaces-switch-to-project-h))
-        counsel-projectile-switch-project-action
-        '(1 ("o" +workspaces-switch-to-project-h "open project in new workspace")
-            ("O" counsel-projectile-switch-project-action "jump to a project buffer or file")
-            ("f" counsel-projectile-switch-project-action-find-file "jump to a project file")
-            ("d" counsel-projectile-switch-project-action-find-dir "jump to a project directory")
-            ("D" counsel-projectile-switch-project-action-dired "open project in dired")
-            ("b" counsel-projectile-switch-project-action-switch-to-buffer "jump to a project buffer")
-            ("m" counsel-projectile-switch-project-action-find-file-manually "find file manually from project root")
-            ("w" counsel-projectile-switch-project-action-save-all-buffers "save all project buffers")
-            ("k" counsel-projectile-switch-project-action-kill-buffers "kill all project buffers")
-            ("r" counsel-projectile-switch-project-action-remove-known-project "remove project from known projects")
-            ("c" counsel-projectile-switch-project-action-compile "run project compilation command")
-            ("C" counsel-projectile-switch-project-action-configure "run project configure command")
-            ("e" counsel-projectile-switch-project-action-edit-dir-locals "edit project dir-locals")
-            ("v" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky")
-            ("s" (lambda (project)
-                   (let ((projectile-switch-project-action
-                          (lambda () (call-interactively #'+ivy/project-search))))
-                     (counsel-projectile-switch-project-by-name project))) "search project")
-            ("xs" counsel-projectile-switch-project-action-run-shell "invoke shell from project root")
-            ("xe" counsel-projectile-switch-project-action-run-eshell "invoke eshell from project root")
-            ("xt" counsel-projectile-switch-project-action-run-term "invoke term from project root")
-            ("X" counsel-projectile-switch-project-action-org-capture "org-capture into project")))
+  (when (modulep! :completion ivy)
+    (after! counsel-projectile
+      ;; per-project workspaces, but reuse current workspace if empty
+      ;; HACK?? needs review
+      (setq projectile-switch-project-action (lambda () (+workspaces-set-project-action-fn) (+workspaces-switch-to-project-h))
+            counsel-projectile-switch-project-action
+            '(1 ("o" +workspaces-switch-to-project-h "open project in new workspace")
+              ("O" counsel-projectile-switch-project-action "jump to a project buffer or file")
+              ("f" counsel-projectile-switch-project-action-find-file "jump to a project file")
+              ("d" counsel-projectile-switch-project-action-find-dir "jump to a project directory")
+              ("D" counsel-projectile-switch-project-action-dired "open project in dired")
+              ("b" counsel-projectile-switch-project-action-switch-to-buffer "jump to a project buffer")
+              ("m" counsel-projectile-switch-project-action-find-file-manually "find file manually from project root")
+              ("w" counsel-projectile-switch-project-action-save-all-buffers "save all project buffers")
+              ("k" counsel-projectile-switch-project-action-kill-buffers "kill all project buffers")
+              ("r" counsel-projectile-switch-project-action-remove-known-project "remove project from known projects")
+              ("c" counsel-projectile-switch-project-action-compile "run project compilation command")
+              ("C" counsel-projectile-switch-project-action-configure "run project configure command")
+              ("e" counsel-projectile-switch-project-action-edit-dir-locals "edit project dir-locals")
+              ("v" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky")
+              ("s" (lambda (project)
+                     (let ((projectile-switch-project-action
+                            (lambda () (call-interactively #'+ivy/project-search))))
+                       (counsel-projectile-switch-project-by-name project))) "search project")
+              ("xs" counsel-projectile-switch-project-action-run-shell "invoke shell from project root")
+              ("xe" counsel-projectile-switch-project-action-run-eshell "invoke eshell from project root")
+              ("xt" counsel-projectile-switch-project-action-run-term "invoke term from project root")
+              ("X" counsel-projectile-switch-project-action-org-capture "org-capture into project")))))
 
   (when (modulep! :completion ivy)
     (after! ivy-rich


### PR DESCRIPTION
This change now wraps configuration code for
`counsel-projectile-switch-project-actions` within a conditional check for the Ivy module.

It ensures configuration related to
`counsel-projectile` are only set up if the `:completion ivy` module is enabled by the user.

This is my first PR so forgive me for any mistakes, feedback is highly appreciated.
Thank you


-----
- [x ] I searched the issue tracker and this hasn't been PRed before.
- [x ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x ] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
