### PR TITLE
feat(vertico): completion highlights a la ivy

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -342,6 +342,10 @@ orderless."
   (add-hook 'doom-after-reload-hook #'posframe-delete-all))
 
 ;; From https://github.com/minad/vertico/wiki#candidate-display-transformations-custom-candidate-highlighting
+;;
+;; Uses `add-face-text-property' instead of `propertize' unlike the above snippet
+;; because `'append' is necessary to not override the match font lock
+;; See: https://github.com/minad/vertico/issues/389
 (use-package! vertico-multiform
   :hook (vertico-mode . vertico-multiform-mode)
   :config
@@ -355,20 +359,20 @@ orderless."
 
   (defun +vertico-highlight-directory (file)
     "If FILE ends with a slash, highlight it as a directory."
-    (if (string-suffix-p "/" file)
-        (propertize file 'face 'marginalia-file-priv-dir)
-      file))
+    (when (string-suffix-p "/" file)
+      (add-face-text-property 0 (length file) 'marginalia-file-priv-dir 'append file))
+    file)
 
   (defun +vertico-highlight-enabled-mode (cmd)
     "If MODE is enabled, highlight it as font-lock-constant-face."
     (let ((sym (intern cmd)))
       (with-current-buffer (nth 1 (buffer-list))
-        (if (or (eq sym major-mode)
-                (and
-                 (memq sym minor-mode-list)
-                 (boundp sym)))
-            (propertize cmd 'face 'font-lock-constant-face)
-          cmd))))
+      (if (or (eq sym major-mode)
+              (and
+               (memq sym minor-mode-list)
+               (boundp sym)))
+          (add-face-text-property 0 (length cmd) 'font-lock-constant-face 'append cmd)))
+        cmd))
 
   (add-to-list 'vertico-multiform-categories
                '(file

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -362,12 +362,13 @@ orderless."
   (defun +vertico-highlight-enabled-mode (cmd)
     "If MODE is enabled, highlight it as font-lock-constant-face."
     (let ((sym (intern cmd)))
-      (if (or (eq sym major-mode)
-              (and
-               (memq sym minor-mode-list)
-               (boundp sym)))
-          (propertize cmd 'face 'font-lock-constant-face)
-        cmd)))
+      (with-current-buffer (nth 1 (buffer-list))
+        (if (or (eq sym major-mode)
+                (and
+                 (memq sym minor-mode-list)
+                 (boundp sym)))
+            (propertize cmd 'face 'font-lock-constant-face)
+          cmd))))
 
   (add-to-list 'vertico-multiform-categories
                '(file


### PR DESCRIPTION
Adds completion highlighting that works similarly to ivy/counsel's one (which is enabled by default). It'll highlight enabled major/minor modes and directories in a different face. On by default.

Before:
![20240304_19h20m07s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/f8bf5c87-e192-457e-a109-d7d4085e6228)
After:
![20240304_19h20m45s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/bf05283f-55df-45f6-b6fa-717b9fcf8f25)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] (N/A) Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
