### PR TITLE
feat(java): java.el takes java-ts-mode into account

### DIFF
--- a/modules/lang/java/autoload/java.el
+++ b/modules/lang/java/autoload/java.el
@@ -44,8 +44,9 @@ It does this by ignoring everything before the nearest package root (see
 root)."
   (cond ((doom-special-buffer-p (current-buffer))
          "{PackageName}")
-        ((not (eq major-mode 'java-mode))
-         (user-error "Not in java-mode"))
+        ((and (not (eq major-mode 'java-mode))
+              (not (eq major-mode 'java-ts-mode))
+              (user-error "Not in java-mode or java-ts-mode")))
         ((when-let (project-root (doom-project-root))
            (let* ((project-root (file-truename project-root))
                   (file-path
@@ -73,8 +74,9 @@ root)."
   "Get the class name for the current file."
   (cond ((doom-special-buffer-p (current-buffer))
          "{ClassName}")
-        ((not (eq major-mode 'java-mode))
-         (user-error "Not in java-mode"))
+        ((and (not (eq major-mode 'java-mode))
+              (not (eq major-mode 'java-ts-mode))
+              (user-error "Not in java-mode or java-ts-mode")))
         (buffer-file-name
          (file-name-sans-extension (file-name-base (buffer-file-name))))
         ((user-error "Can't deduce the class name"))))


### PR DESCRIPTION
allow `+java-current-package` and `+java-current-class` functions to operate on `java-ts-mode` (the java tree-sitter mode) not just `java-mode`.

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.