### PR TITLE
fix(vertico): disable minor mode highlight duly

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -371,7 +371,8 @@ orderless."
       (if (or (eq sym major-mode)
               (and
                (memq sym minor-mode-list)
-               (boundp sym)))
+               (boundp sym)
+               (eval sym)))
           (add-face-text-property 0 (length cmd) 'font-lock-constant-face 'append cmd)))
         cmd))
 

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -372,7 +372,7 @@ orderless."
               (and
                (memq sym minor-mode-list)
                (boundp sym)
-               (eval sym)))
+               (symbol-value sym)))
           (add-face-text-property 0 (length cmd) 'font-lock-constant-face 'append cmd)))
         cmd))
 


### PR DESCRIPTION
Minor mode highlights did not disable as long as the mode was enabled (e.g. I had visual-line-mode highlighted even in buffers when it wasn't on). This should fix that.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
