### PR TITLE
feat(macos): osx-trash is only needed by emacs < 29

### DIFF
--- a/modules/os/macos/config.el
+++ b/modules/os/macos/config.el
@@ -33,17 +33,20 @@
 (after! auth-source
   (pushnew! auth-sources 'macos-keychain-internet 'macos-keychain-generic))
 
+;; Delete files to trash on macOS, as an extra layer of precaution against
+;; accidentally deleting wanted files.
+(setq delete-by-moving-to-trash t)
+
 
 ;;
 ;;; Packages
 
 (use-package! osx-trash
+  ;; DEPRECATED: Not needed on Emacs 29+. Remove when dropping 28 support.
+  ;;   Fixed by https://debbugs.gnu.org/cgi/bugreport.cgi?bug=21340.
+  :when (< emacs-major-version 29)
   :commands osx-trash-move-file-to-trash
   :init
-  ;; Delete files to trash on macOS, as an extra layer of precaution against
-  ;; accidentally deleting wanted files.
-  (setq delete-by-moving-to-trash t)
-
   ;; Lazy load `osx-trash'
   (when (not (fboundp 'system-move-file-to-trash))
     (defun system-move-file-to-trash (file)

--- a/modules/os/macos/packages.el
+++ b/modules/os/macos/packages.el
@@ -1,5 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; os/macos/packages.el
 
-(package! osx-trash :pin "90f0c99206022fec646206018fcd63d9d2e57325")
+(when (< emacs-major-version 29)
+  (package! osx-trash :pin "90f0c99206022fec646206018fcd63d9d2e57325"))
 (package! ns-auto-titlebar :pin "60273e764bf8d95abc40dd2fdc23af87ea9ee33b")


### PR DESCRIPTION
As the title says, osx-trash is no longer needed nowadays for emacs so one less package to install :-)