### PR TITLE
fix(mu4e): extend popup rule to all mu4e- prefixed buffers

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -223,7 +223,7 @@ is non-nil."
   (setq-hook! 'mu4e-view-mode-hook truncate-lines nil)
 
   ;; mu4e now uses `display-buffer-alist' so we need to add some rules of our own
-  (set-popup-rule! "^\\*mu4e-\\(main\\|headers\\)\\*" :ignore t)
+  (set-popup-rule! "^\\*mu4e-" :ignore t)
 
   ;; Html mails might be better rendered in a browser
   (add-to-list 'mu4e-view-actions '("View in browser" . mu4e-action-view-in-browser))


### PR DESCRIPTION
It was too restrictive before so let's just match anything that is prefixed with `mu4e-`.