### PR TITLE
feat(mu4e): use built-in notifications instead of mu4e-alert

### DIFF
--- a/modules/email/mu4e/packages.el
+++ b/modules/email/mu4e/packages.el
@@ -3,5 +3,3 @@
 
 (when (modulep! +org)
   (package! org-msg :pin "0b65f0f77a7a71881ddfce19a8cdc60465bda057"))
-
-(package! mu4e-alert :pin "6beda20fc69771f2778f507c4a9e069dbaf1b628")


### PR DESCRIPTION
Now that mu4e has its own notification feature since 1.10 (and as of
this commit version 1.12 is already out), we can just use that. Much
less code to maintain.

Closes: https://github.com/doomemacs/doomemacs/issues/6896