### PR TITLE
[RFC]🔥 feat: add buffer-name-relative

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -201,6 +201,9 @@ or if the current buffer is read-only or not file-visiting."
 ;;
 ;;; Buffers
 
+(use-package! buffer-name-relative
+  :hook (doom-first-buffer . buffer-name-relative-mode))
+
 (defadvice! doom--switch-to-fallback-buffer-maybe-a (&rest _)
   "Switch to `doom-fallback-buffer' if on last real buffer.
 

--- a/lisp/packages.el
+++ b/lisp/packages.el
@@ -21,6 +21,7 @@
 (package! highlight-numbers :pin "8b4744c7f46c72b1d3d599d4fb75ef8183dee307")
 (package! rainbow-delimiters :pin "f40ece58df8b2f0fb6c8576b527755a552a5e763")
 (package! restart-emacs :pin "1607da2bc657fe05ae01f7fdf26f716eafead02c")
+(package! buffer-name-relative :pin "6c1e98f761344b2d2d51f38d587161f71ca0e750")
 
 ;; doom-editor.el
 (package! better-jumper :pin "47622213783ece37d5337dc28d33b530540fc319")


### PR DESCRIPTION
This will help unify the people and quell, once and for all, the
test.foo<20> buffer names. Power to the people.

In all seriousness, this has greatly helped improve the buffer list with similar-named buffers across many progects (e.g. `README`) but since this changes some core machinery, I thought I'd gather some feedback. (If it's actually not too controversial, then it's ready to be merged)