### PR TITLE
refactor(mu4e): drop support for 1.8

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -20,9 +20,6 @@ OPTIONAL:
 DEFAULT-P is a boolean. If non-nil, it marks that email account as the
 default/fallback account."
   (after! mu4e
-    (when (version< mu4e-mu-version "1.4")
-      (when-let (address (cdr (assq 'user-mail-address letvars)))
-        (add-to-list 'mu4e-user-mail-address-list address)))
     ;; remove existing context with same label
     (setq mu4e-contexts
           (cl-loop for context in mu4e-contexts
@@ -380,20 +377,13 @@ preferred alias"
                           (mu4e-personal-addresses))))
     (setq user-mail-address
           (if mu4e-compose-parent-message
-              (if (version<= "1.8" mu4e-mu-version)
-                  (let ((to (mu4e-message-field mu4e-compose-parent-message :to))
-                        (cc (mu4e-message-field mu4e-compose-parent-message :cc))
-                        (from (mu4e-message-field mu4e-compose-parent-message :from)))
-                    (or (car (cl-intersection
-                              (mapcar (lambda (adr) (plist-get adr :email))
-                                      (append to from cc))
-                              addresses
-                              :test #'equal))
-                        (completing-read "From: " addresses)))
-                (let ((to (mapcar #'cdr (mu4e-message-field mu4e-compose-parent-message :to)))
-                      (cc (mapcar #'cdr (mu4e-message-field mu4e-compose-parent-message :cc)))
-                      (from (mapcar #'cdr (mu4e-message-field mu4e-compose-parent-message :from))))
-                  (or (car (cl-intersection (append to from cc) addresses
-                                            :test #'equal))
-                      (completing-read "From: " addresses))))
+              (let ((to (mu4e-message-field mu4e-compose-parent-message :to))
+                    (cc (mu4e-message-field mu4e-compose-parent-message :cc))
+                    (from (mu4e-message-field mu4e-compose-parent-message :from)))
+                (or (car (cl-intersection
+                          (mapcar (lambda (adr) (plist-get adr :email))
+                                  (append to from cc))
+                          addresses
+                          :test #'equal))
+                    (completing-read "From: " addresses)))
             (completing-read "From: " addresses)))))

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -14,59 +14,10 @@
   :commands mu4e mu4e-compose-new
   :init
   (provide 'html2text) ; disable obsolete package
-  (when (or (not (or (require 'mu4e-config nil t)
-                     (require 'mu4e-meta nil t)))
-            (version< mu4e-mu-version "1.4"))
-    (setq mu4e-maildir "~/.mail"
-          mu4e-user-mail-address-list nil))
   (setq mu4e-attachment-dir
         (lambda (&rest _)
           (expand-file-name ".attachments" (mu4e-root-maildir))))
   :config
-  (when (version< mu4e-mu-version "1.8")
-    ;; Define aliases to maintain backwards compatibility. The list of suffixes
-    ;; were obtained by comparing mu4e~ and mu4e-- functions in `obarray'.
-    (dolist (transferable-suffix
-             '("check-requirements" "contains-line-matching" "context-ask-user"
-               "context-autoswitch" "default-handler" "get-folder" "get-log-buffer"
-               "get-mail-process-filter" "guess-maildir" "key-val"
-               "longest-of-maildirs-and-bookmarks" "maildirs-with-query"
-               "main-action-str" "main-bookmarks" "main-maildirs" "main-menu"
-               "main-queue-size" "main-redraw-buffer"
-               "main-toggle-mail-sending-mode" "main-view" "main-view-queue"
-               "main-view-real" "main-view-real-1" "mark-ask-target"
-               "mark-check-target" "mark-clear" "mark-find-headers-buffer"
-               "mark-get-dyn-target" "mark-get-markpair" "mark-get-move-target"
-               "mark-in-context" "mark-initialize" "org-store-link-message"
-               "org-store-link-query" "pong-handler" "read-char-choice"
-               "read-patch-directory" "replace-first-line-matching"
-               "request-contacts-maybe" "rfc822-phrase-type" "start" "stop"
-               "temp-window" "update-contacts" "update-mail-and-index-real"
-               "update-mail-mode" "update-sentinel-func" "view-gather-mime-parts"
-               "view-open-file" "view-mime-part-to-temp-file"))
-      (defalias (intern (concat "mu4e--" transferable-suffix))
-        (intern (concat "mu4e~" transferable-suffix))
-        "Alias to provide the API of mu4e 1.8 (mu4e~ ⟶ mu4e--).")
-      (dolist (transferable-proc-suffixes
-               '("add" "compose" "contacts" "eat-sexp-from-buf" "filter"
-                 "find" "index" "kill" "mkdir" "move" "ping" "remove"
-                 "sent" "sentinel" "start" "view"))
-        (defalias (intern (concat "mu4e--server-" transferable-proc-suffixes))
-          (intern (concat "mu4e~proc-" transferable-proc-suffixes))
-          "Alias to provide the API of mu4e 1.8 (mu4e~proc ⟶ mu4e--server)."))
-      (defalias 'mu4e-search-rerun #'mu4e-headers-rerun-search
-        "Alias to provide the API of mu4e 1.8.")
-      (defun mu4e (&optional background)
-        "If mu4e is not running yet, start it.
-Then, show the main window, unless BACKGROUND (prefix-argument)
-is non-nil."
-        (interactive "P")
-        (mu4e--start (and (not background) #'mu4e--main-view))))
-    (setq mu4e-view-show-addresses t
-          mu4e-view-show-images t
-          mu4e-view-image-max-width 800
-          mu4e-view-use-gnus t))
-
   (pcase +mu4e-backend
     (`mbsync
      (setq mu4e-get-mail-command "mbsync -a"
@@ -268,73 +219,71 @@ is non-nil."
   (map! :map mu4e-headers-mode-map
         :vne "l" #'+mu4e/capture-msg-to-agenda)
 
-  ;; Functionality otherwise obscured in mu4e 1.6
-  (when (version<= "1.6" mu4e-mu-version)
-    (defun +mu4e-view-select-attachment ()
-      "Use completing-read to select a single attachment.
+  (defun +mu4e-view-select-attachment ()
+    "Use completing-read to select a single attachment.
 Acts like a singular `mu4e-view-save-attachments', without the saving."
-      (if-let ((parts (delq nil (mapcar
-                                 (lambda (part)
-                                   (when (assoc "attachment" (cdr part))
-                                     part))
-                                 (mu4e--view-gather-mime-parts))))
-               (files (+mu4e-part-selectors parts)))
-          (cdr (assoc (completing-read "Select attachment: " (mapcar #'car files)) files))
-        (user-error (mu4e-format "No attached files found"))))
+    (if-let ((parts (delq nil (mapcar
+                               (lambda (part)
+                                 (when (assoc "attachment" (cdr part))
+                                   part))
+                               (mu4e--view-gather-mime-parts))))
+             (files (+mu4e-part-selectors parts)))
+        (cdr (assoc (completing-read "Select attachment: " (mapcar #'car files)) files))
+      (user-error (mu4e-format "No attached files found"))))
 
-    (defun +mu4e-view-open-attachment ()
-      "Select an attachment, and open it."
-      (interactive)
-      (mu4e--view-open-file
-       (mu4e--view-mime-part-to-temp-file (cdr (+mu4e-view-select-attachment)))))
+  (defun +mu4e-view-open-attachment ()
+    "Select an attachment, and open it."
+    (interactive)
+    (mu4e--view-open-file
+     (mu4e--view-mime-part-to-temp-file (cdr (+mu4e-view-select-attachment)))))
 
-    (defun +mu4e-view-select-mime-part-action ()
-      "Select a MIME part, and perform an action on it."
-      (interactive)
-      (let ((labeledparts (+mu4e-part-selectors (mu4e--view-gather-mime-parts))))
-        (if labeledparts
-            (mu4e-view-mime-part-action
-             (cadr (assoc (completing-read "Select part: " (mapcar #'car labeledparts))
-                          labeledparts)))
-          (user-error (mu4e-format "No parts found")))))
+  (defun +mu4e-view-select-mime-part-action ()
+    "Select a MIME part, and perform an action on it."
+    (interactive)
+    (let ((labeledparts (+mu4e-part-selectors (mu4e--view-gather-mime-parts))))
+      (if labeledparts
+          (mu4e-view-mime-part-action
+           (cadr (assoc (completing-read "Select part: " (mapcar #'car labeledparts))
+                        labeledparts)))
+        (user-error (mu4e-format "No parts found")))))
 
-    (map! :map mu4e-view-mode-map
-          :ne "A" #'+mu4e-view-select-mime-part-action
-          :ne "p" #'mu4e-view-save-attachments
-          :ne "o" #'+mu4e-view-open-attachment)
+  (map! :map mu4e-view-mode-map
+        :ne "A" #'+mu4e-view-select-mime-part-action
+        :ne "p" #'mu4e-view-save-attachments
+        :ne "o" #'+mu4e-view-open-attachment)
 
-    (defun +mu4e-part-selectors (parts)
-      "Generate selection strings for PARTS."
-      (if parts
-          (let (partinfo labeledparts maxfnamelen fnamefmt maxsizelen sizefmt)
-            (dolist (part parts)
-              (push (list :index (car part)
-                          :mimetype (if (and (string= "text/plain" (caaddr part))
-                                             (alist-get 'charset (cdaddr part)))
-                                        (format "%s (%s)"
-                                                (caaddr part)
-                                                (alist-get 'charset (cdaddr part)))
-                                      (caaddr part))
-                          :type (car (nth 5 part))
-                          :filename (cdr (assoc 'filename (assoc "attachment" (cdr part))))
-                          :size (file-size-human-readable (with-current-buffer (cadr part) (buffer-size)))
-                          :part part)
-                    partinfo))
-            (setq maxfnamelen (apply #'max 7 (mapcar (lambda (i) (length (plist-get i :filename))) partinfo))
-                  fnamefmt (format " %%-%ds  " maxfnamelen)
-                  maxsizelen (apply #'max (mapcar (lambda (i) (length (plist-get i :size))) partinfo))
-                  sizefmt (format "%%-%ds " maxsizelen))
-            (dolist (pinfo partinfo)
-              (push (cons (concat (propertize (format "%-2s " (plist-get pinfo :index)) 'face '(bold font-lock-type-face))
-                                  (when (featurep 'nerd-icons)
-                                    (nerd-icons-icon-for-file (or (plist-get pinfo :filename) "")))
-                                  (format fnamefmt (or (plist-get pinfo :filename)
-                                                       (propertize (plist-get pinfo :type) 'face '(italic font-lock-doc-face))))
-                                  (format sizefmt (propertize (plist-get pinfo :size) 'face 'font-lock-builtin-face))
-                                  (propertize (plist-get pinfo :mimetype) 'face 'font-lock-constant-face))
-                          (plist-get pinfo :part))
-                    labeledparts))
-            labeledparts))))
+  (defun +mu4e-part-selectors (parts)
+    "Generate selection strings for PARTS."
+    (if parts
+        (let (partinfo labeledparts maxfnamelen fnamefmt maxsizelen sizefmt)
+          (dolist (part parts)
+            (push (list :index (car part)
+                        :mimetype (if (and (string= "text/plain" (caaddr part))
+                                           (alist-get 'charset (cdaddr part)))
+                                      (format "%s (%s)"
+                                              (caaddr part)
+                                              (alist-get 'charset (cdaddr part)))
+                                    (caaddr part))
+                        :type (car (nth 5 part))
+                        :filename (cdr (assoc 'filename (assoc "attachment" (cdr part))))
+                        :size (file-size-human-readable (with-current-buffer (cadr part) (buffer-size)))
+                        :part part)
+                  partinfo))
+          (setq maxfnamelen (apply #'max 7 (mapcar (lambda (i) (length (plist-get i :filename))) partinfo))
+                fnamefmt (format " %%-%ds  " maxfnamelen)
+                maxsizelen (apply #'max (mapcar (lambda (i) (length (plist-get i :size))) partinfo))
+                sizefmt (format "%%-%ds " maxsizelen))
+          (dolist (pinfo partinfo)
+            (push (cons (concat (propertize (format "%-2s " (plist-get pinfo :index)) 'face '(bold font-lock-type-face))
+                                (when (featurep 'nerd-icons)
+                                  (nerd-icons-icon-for-file (or (plist-get pinfo :filename) "")))
+                                (format fnamefmt (or (plist-get pinfo :filename)
+                                                     (propertize (plist-get pinfo :type) 'face '(italic font-lock-doc-face))))
+                                (format sizefmt (propertize (plist-get pinfo :size) 'face 'font-lock-builtin-face))
+                                (propertize (plist-get pinfo :mimetype) 'face 'font-lock-constant-face))
+                        (plist-get pinfo :part))
+                  labeledparts))
+          labeledparts)))
 
   (map! :localleader
         :map mu4e-compose-mode-map


### PR DESCRIPTION
mu4e support code and third-party packages are getting difficult to maintain due to pre-1.10 having a wild time with lisp code. Starting with 1.10, mu has a better policy for lisp practices and has even implemented most of the third-party functionality.

By dropping support for 1.8, we can simplify the mu4e module and maintenance burden for doom. For reference, mu 1.12 was just released.

Again, this might be too big a change for now so I labeled this as RFC. If it turns out that it's ok, then it's ready to be merged.