### PR TITLE
fix(eval): fix results overlay position

### DIFF
--- a/modules/tools/eval/autoload/eval.el
+++ b/modules/tools/eval/autoload/eval.el
@@ -40,9 +40,10 @@
          (pad (if next-line?
                   (+ (window-hscroll) prefixlen)
                 0))
-         (where (if next-line?
-                    (line-beginning-position 2)
-                  (line-end-position)))
+         (where (with-current-buffer (or source-buffer (current-buffer))
+                  (if next-line?
+                      (line-beginning-position 2)
+                    (line-end-position))))
          eros-eval-result-prefix
          eros-overlays-use-font-lock)
     (with-current-buffer (or source-buffer (current-buffer))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

what you've changed: change the parameter `:where` calculation in function `+eval-display-results-in-overlay`

and why: the overlay position calculation is base on the `*quickrun*` buffer, which is wrong. We should calculate it base on our evaluating buffer

Fix: #7732

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
