### PR TITLE
refactor(corfu): consolidate +orderless logic without vertico

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -55,8 +55,10 @@ use the minibuffer such as `query-replace'.")
         corfu-count 16
         corfu-max-width 120
         corfu-on-exact-match nil
-        corfu-quit-at-boundary (if (modulep! +orderless) 'separator t)
-        corfu-quit-no-match (if (modulep! +orderless) 'separator t)
+        corfu-quit-at-boundary (if (or (modulep! :completion vertico)
+                                       (modulep! +orderless))
+                                   'separator t)
+        corfu-quit-no-match corfu-quit-at-boundary
         tab-always-indent 'complete)
   (add-to-list 'completion-category-overrides `(lsp-capf (styles ,@completion-styles)))
   (add-to-list 'corfu-auto-commands #'lispy-colon)

--- a/modules/completion/corfu/packages.el
+++ b/modules/completion/corfu/packages.el
@@ -5,8 +5,12 @@
 (package! cape :pin "a397a0c92de38277b7f835fa999fac400a764908")
 (when (modulep! +icons)
   (package! nerd-icons-corfu :pin "7077bb76fefc15aed967476406a19dc5c2500b3c"))
-(when (modulep! +orderless)
-  (package! orderless :pin "b24748093b00b37c3a572c4909f61c08fa27504f"))
+(when (and (not (modulep! :completion vertico))
+           (modulep! +orderless))
+  ;; enabling +orderless without vertico should be fairly niche enough that to
+  ;; save contributor headaches we should only pin vertico's orderless and leave
+  ;; this one unpinned
+  (package! orderless))
 (when (modulep! :os tty)
   (package! corfu-terminal :pin "501548c3d51f926c687e8cd838c5865ec45d03cc"))
 (when (modulep! :editor snippets)


### PR DESCRIPTION
This tidy ups the corfu module to use the logic when a user enables
corfu +orderless without enabling vertico. Since that's probably a niche
situation, we only specify commit to pin to orderless in the vertico
module so that contributors aren't tripped up with trying to remember to
update orderless in two different code locations. Of course, if this
turns out to be a more popular use-case we can re-evaluate this logic.