### PR TITLE
feat(fold): unify doom's usage of eliding text

### DIFF
--- a/modules/editor/fold/autoload/hideshow.el
+++ b/modules/editor/fold/autoload/hideshow.el
@@ -30,7 +30,7 @@
                          'empty-line
                          'vimish-fold-fringe))))
     (overlay-put
-     ov 'display (propertize "  [...]  " 'face '+fold-hideshow-folded-face))))
+     ov 'display (propertize +fold-elide-string 'face '+fold-hideshow-folded-face))))
 
 
 ;;

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -1,5 +1,13 @@
 ;;; editor/fold/config.el -*- lexical-binding: t; -*-
 
+(defvar +fold-elide-string
+  (format " [%s]" (if (char-displayable-p ?…) "…" "..."))
+  "String to represent folded elided text, e.g. […].
+
+This differs from `doom-elide-string' because folded text often
+implies multiple lines and some users might want this to be, for
+example, \"[...]\" or might even prefer a fancy downwards arrow.")
+
 (when (modulep! :editor evil)
   ;; Add vimish-fold, outline-mode & hideshow support to folding commands
   (define-key! 'global
@@ -96,5 +104,5 @@
                                                 :box nil
                                                 :inherit font-lock-comment-face
                                                 :weight light))
-  (setq ts-fold-replacement "  [...]  ")
+  (setq ts-fold-replacement +fold-elide-string)
   (ts-fold-mode +1))


### PR DESCRIPTION
~~Currently, shortening text is hardcoded as variations of "..." throughout the code. This PR adds two variables to control the short elision of one-line / inline type of text (e.g. 222dc4706…) along with an inherited variable to customize the string used in more traditional folding scenarios of coding and whatnot.~~

Previously, eliding strings was hardcoded to " [...] " which isn't customizable 😬 so `ts-fold-replacement` could become mismatched with `hideshow`.

This variable defaults to " […]" if unicode is displayable, otherwise it falls back to " [...]".