### PR TITLE
fix(corfu): indent and completion with TAB

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -46,7 +46,7 @@
                       #'company-indent-or-complete-common
                       (and (bound-and-true-p corfu-mode)
                            (modulep! :completion corfu))
-                      #'completion-at-point)
+                      #'indent-for-tab-command)
       :m [tab] (cmds! (and (modulep! :editor snippets)
                            (evil-visual-state-p)
                            (or (eq evil-visual-selection 'line)


### PR DESCRIPTION
Perform indentation or completion when pressing <kbd>TAB</kbd> when one uses `corfu` instead of `company`.

With `company`, <kbd>TAB</kbd> did `company-indent-or-complete`, so let's have the same behavior for `corfu`.


-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.