### PR TITLE
feat(corfu): vim-like C-n / C-p completion

### DIFF
--- a/modules/completion/corfu/autoload.el
+++ b/modules/completion/corfu/autoload.el
@@ -37,3 +37,21 @@
          (save-excursion (backward-char 1)
                          (insert-char ?\\)))
         (t (call-interactively #'corfu-insert-separator))))
+
+;;;###autoload
+(defun +corfu-popup-and-first ()
+  "Trigger corfu popup and select the first candidate."
+  (interactive)
+  (let ((corfu-auto-prefix 1))
+    (when (completion-at-point)
+      (corfu--exhibit)
+      (corfu--goto 0))))
+
+;;;###autoload
+(defun +corfu-popup-and-last ()
+  "Trigger corfu popup and select the last candidate."
+  (interactive)
+  (let ((corfu-auto-prefix 1))
+    (when (completion-at-point)
+      (corfu--exhibit)
+      (corfu-last))))

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -163,6 +163,8 @@
        (:after corfu
         (:map corfu-mode-map
          :i "C-SPC" #'completion-at-point
+         :i "C-n" #'+corfu-popup-and-first
+         :i "C-p" #'+corfu-popup-and-last
          :n "C-SPC" (cmd! (call-interactively #'evil-insert-state)
                           (call-interactively #'completion-at-point))
          :v "C-SPC" (cmd! (call-interactively #'evil-change)


### PR DESCRIPTION
Adds insert-mode bindings to make C-n and C-p trigger the Corfu popup, with the first or last candidate selected, respectively.

Care has been taken that no candidate is actually inserted, even if there is only one candidate - only the popup will be shown with the candidate selected. Whether the candidate is previewed or not depends on `corfu-preview-current`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
