### PR TITLE
feat(corfu): `both` option for RET behavior

### DIFF
--- a/modules/completion/corfu/README.org
+++ b/modules/completion/corfu/README.org
@@ -193,9 +193,13 @@ A few variables may be set to change behavior of this module:
 - [[var:corfu-preview-current]] ::
   Configures current candidate preview.
 - [[var:+corfu-want-ret-to-confirm]] ::
-  Enables commiting with [[RET]] when the popup is visible. Default is ~t~, may be set to
-  ~'minibuffer~ if you want to commit both the completion and the minibuffer when
-  active. When ~nil~, it is always passed-through.
+  Controls the behavior of [[kbd:][RET]] when the popup is visible - whether it confirms
+  the selected candidate, and whether [[kbd:][RET]] is passed through (ie. the normal
+  behavior of [[kbd:][RET]] is performed). The default value of ~t~ enables confirmation
+  and disables pass-through. Other variations are ~nil~ for pass-through and no
+  confirmation and ~both~ for confirmation followed by pass-through. Finally,
+  the value of ~minibuffer~ will both confirm and pass-through (like ~both~)
+  when in the minibuffer, and only confirm (like ~t~) otherwise.
 - [[var:+corfu-buffer-scanning-size-limit]]  ::
   Sets the maximum buffer size to be scanned by ~cape-dabbrev~. Defaults to 1 MB.
   Set this if you are having performance problems using the CAPF.

--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -4,9 +4,9 @@
   "Configure how the user expects RET to behave.
 Possible values are:
 - t (default): Insert candidate if one is selected, pass-through otherwise;
-- `minibuffer': Insert candidate if one is selected, pass-through otherwise,
-              and immediatelly exit if in the minibuffer;
-- nil: Pass-through without inserting.")
+- nil: Pass-through without inserting;
+- `both': Insert candidate if one is selected, then pass-through;
+- `minibuffer': Behaves like `both` in the minibuffer and `t` otherwise.")
 
 (defvar +corfu-buffer-scanning-size-limit (* 1 1024 1024) ; 1 MB
   "Size limit for a buffer to be scanned by `cape-dabbrev'.")

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -482,16 +482,23 @@ Continues comments if executed from a commented line. Consults
                         (cond ((null +corfu-want-ret-to-confirm)
                                (corfu-quit)
                                nil)
-                              ((eq +corfu-want-ret-to-confirm 'minibuffer)
+                              ((eq +corfu-want-ret-to-confirm t)
+                                 (if (>= corfu--index 0)
+                                     cmd
+                                   nil))
+                              ((eq +corfu-want-ret-to-confirm 'both)
                                (funcall-interactively cmd)
                                nil)
-                              ((and (or (not (minibufferp nil t))
-                                        (eq +corfu-want-ret-to-confirm t))
-                                    (>= corfu--index 0))
-                               cmd)
-                              ((or (not (minibufferp nil t))
-                                   (eq +corfu-want-ret-to-confirm t))
-                               nil)
+                              ((eq +corfu-want-ret-to-confirm 'minibuffer)
+                               (if (minibufferp nil t)
+                                   ;; 'both' behavior
+                                   (progn
+                                     (funcall-interactively cmd)
+                                     nil)
+                                 ;; 't' behavior
+                                 (if (>= corfu--index 0)
+                                     cmd
+                                   nil)))
                               (t cmd))))))
     (map! :when (modulep! :completion corfu)
           :map corfu-map


### PR DESCRIPTION
Adds a new value of `+corfu-want-ret-to-confirm` to cover the case where the user wants to select the candidate as well as perform the normal behavior of RET.

Also, the logic for RET behavior has been refactored for clarity, and the variable's documentation has been clarified a little.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
