### PR TITLE
fix(fold): properly support outline-minor-mode

### DIFF
--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -6,7 +6,7 @@
     [remap evil-toggle-fold]   #'+fold/toggle
     [remap evil-close-fold]    #'+fold/close
     [remap evil-open-fold]     #'+fold/open
-    [remap evil-open-fold-rec] #'+fold/open
+    [remap evil-open-fold-rec] #'+fold/open-rec
     [remap evil-close-folds]   #'+fold/close-all
     [remap evil-open-folds]    #'+fold/open-all)
   (after! evil


### PR DESCRIPTION
- Make `+fold/close-all` work for outline-minor-mode.

- Distinguish between `zo` and `zO` for outline-minor-mode alone, by binding `zO` to a new function `+fold/open-rec`. `zO` will now trigger `outline-show-subtree` in outline-minor-mode, while `zo` will only trigger `outline-show-branches`, keeping the subheadings folded. This matches the behavior in org-mode.

- Fix a bug in `+fold/open-all`, introduced in 7b9d00d6616d67cbc92765bb9da0dd0d2d9e9581, that makes it only operate on vimish-fold folds.

Similar fixes were PRed in #5724, but it looks like the author proceeded to use that branch as their main branch, resulting in hundreds of commits from master being added to the PR, before giving up and closing it.

Note that I have not enabled outline-minor-mode anywhere it's not already on. So the concerns raised in #5724 about outline-minor-mode replacing other kinds of folds should not apply here. Users who are aware of outline-minor-mode and enable it explicitly will probably understand if turning on something that's off-by-default doesn't work perfectly. This PR is only intended to ensure that the existing support works as intended.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
