### PR TITLE
fix: correct path for doom config files

### DIFF
--- a/lisp/cli/install.el
+++ b/lisp/cli/install.el
@@ -65,8 +65,8 @@ Change `$DOOMDIR' with the `--doomdir' option, e.g.
                 (cl-destructuring-bind (filename . template) file
                   (if (file-exists-p! filename doom-user-dir)
                       (print! (item "Skipping %s (already exists)")
-                              (path filename))
-                    (print! (item "Creating %s%s") (relpath doom-user-dir) filename)
+                              (relpath (doom-path doom-user-dir filename)))
+                    (print! (item "Creating %s") (relpath (doom-path doom-user-dir filename)))
                     (with-temp-file (doom-path doom-user-dir filename)
                       (insert-file-contents template))
                     (print! (success "Done!")))))


### PR DESCRIPTION
Fix the path when printing message about skipping or creating config. Now uses same style throughout.

Previously:
```
Installing Doom Emacs!

- Skipping ~/.config/doom/ (already exists)
  - Skipping ~/.config/emacs/init.el (already exists)
  - Skipping ~/.config/emacs/config.el (already exists)
  - Skipping ~/.config/emacs/packages.el (already exists)
```

Now:
```
kll@ThinkYoga:~/.config/doom$ ~/.config/emacs/bin/doom install 
Installing Doom Emacs!

- Skipping ~/.config/doom/ (already exists)
  - Skipping ~/.config/doom/init.el (already exists)
  - Skipping ~/.config/doom/config.el (already exists)
  - Skipping ~/.config/doom/packages.el (already exists)
```

- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
  - My change does appear to violate the second rule about less than 3 trivial fixes, but I don't quite understand why. I can open an issue instead but isn't it better I send a PR with this simple fix?
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
  - not screenshots but text diff