### PR TITLE
Fix typo in local variable name

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -106,7 +106,7 @@ the buffer is visible, then set another timer and try again later."
                   (param (if (memq side '(left right))
                              'window-width
                            'window-height)))
-        (setq list (assq-delete-all 'size alist))
+        (setq alist (assq-delete-all 'size alist))
         (setf (alist-get param alist) size))
       (setf (alist-get 'window-parameters alist)
             parameters)


### PR DESCRIPTION
This caused a global variable `list` to be bound  

---------
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/git-conventionspr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

