### PR TITLE
fix(tabs): speed up tabs by making it patient

### DIFF
--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -20,7 +20,26 @@
     (defun +tabs-disable-centaur-tabs-mode-maybe-h ()
       "Disable `centaur-tabs-mode' in current buffer."
       (when (centaur-tabs-mode-on-p)
-        (centaur-tabs-local-mode)))))
+        (centaur-tabs-local-mode))))
+
+  ;; HACK: The function centaur-tabs-buffer-update-groups gets called way too
+  ;; frequently leading to performance degredation.
+  ;; There is really no reason to call it more than 10 times a second,
+  ;; as buffers do not change groups more frequently than that.
+  (defvar centaur-tabs-buffer-groups-patience 0.1
+    "The amount of time (in seconds) to wait before recalculating groups.")
+  (setq centaur-tabs--buffers-time (float-time))
+  (defadvice! centaur-tabs-buffer-update-groups--patience (fn)
+    "Add patience to centaur-tabs-buffer-update-groups"
+    :around #'centaur-tabs-buffer-update-groups
+    (if (and (< (time-to-seconds)
+                (+ centaur-tabs-buffer-groups-patience
+                   centaur-tabs--buffers-time))
+             centaur-tabs--buffers
+             (assq (current-buffer) centaur-tabs--buffers))
+        (car (nth 2 (assq (current-buffer) centaur-tabs--buffers)))
+      (setq centaur-tabs--buffers-time (float-time))
+      (funcall fn))))
 
 
 ;; TODO tab-bar-mode (emacs 27)


### PR DESCRIPTION
Limit the number of times that `centaur-tabs-buffer-update-groups` gets called per second.

<!-- ⚠️ Please do not ignore this template! -->

Centaur-tabs leads to performance degradation as noted by Henrik on this [discourse page](https://discourse.doomemacs.org/t/why-is-emacs-doom-slow/83) and this Issue in the centaur-tabs repo: ema2159/centaur-tabs#222. In my experience, the contributing factors are:

1. Large number of total open buffers (> 200).
2. Large number of buffers in certain groups (> 10).
3. Multiple window splits each displaying different buffers.
4. Actions that redisplay a lot, e.g. `pixel-scroll-interpolate-up`, `scroll-other-window`

The main culprit is the function `centaur-tabs-buffer-update-groups`, which walks every buffer to determine the group it belongs in. This function can be called a lot of times (I have clocked it at 1,000 times per second in certain conditions), as it is called on every redisplay (it is indirectly attached to `tab-line-format`).

This PR adds a hack to fix most (all?) centaur-tabs performance issues. It limits the number of times that `centaur-tabs-buffer-update-groups` is called per second to 10.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
