### PR TITLE
fix(corfu): prevent void-variable error

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -28,7 +28,8 @@ use the minibuffer such as `query-replace'.")
               ('aggressive
                (not (or (bound-and-true-p mct--active)
                         (bound-and-true-p vertico--input)
-                        (eq (current-local-map) read-passwd-map)
+                        (and (featurep 'auth-source)
+                             (eq (current-local-map) read-passwd-map))
                         (and (featurep 'helm-core) (helm--alive-p))
                         (and (featurep 'ido) (ido-active))
                         (where-is-internal 'minibuffer-complete


### PR DESCRIPTION
Although this error will not be triggered by most people, since auth-source is loaded by a lot of packages, it can still happen if you are debugging your configuration (e.g. enabling/disabling modules one-by-one).

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.