### PR TITLE
fix(vertico): missing command error in consult 

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -160,13 +160,16 @@ orderless."
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep
    consult-bookmark consult-recent-file
-   +default/search-project +default/search-other-project
-   +default/search-project-for-symbol-at-point
-   +default/search-cwd +default/search-other-cwd
-   +default/search-notes-for-symbol-at-point
-   +default/search-emacsd
    consult--source-recent-file consult--source-project-recent-file consult--source-bookmark
    :preview-key "C-SPC")
+  (when (modulep! :config default)
+    (consult-customize
+     +default/search-project +default/search-other-project
+     +default/search-project-for-symbol-at-point
+     +default/search-cwd +default/search-other-cwd
+     +default/search-notes-for-symbol-at-point
+     +default/search-emacsd
+     :preview-key "C-SPC"))
   (consult-customize
    consult-theme
    :preview-key (list "C-SPC" :debounce 0.5 'any))


### PR DESCRIPTION
Although it is rare for a user to not enable the :config default module,
enabling/disabling modules one-by-one is common practice for debugging
Doom Emacs. This PR fixes an error that occurs when you have :completion
vertico enabled without enabling :config default.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.