### PR TITLE
feat(corfu): update dabbrev-ignore-buffer-modes

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -125,10 +125,12 @@ use the minibuffer such as `query-replace'.")
     (after! dabbrev
       (setq dabbrev-friend-buffer-function #'+dabbrev-friend-buffer-p
             dabbrev-ignored-buffer-regexps
-            '("^ "
+            '("\\` "
               "\\(TAGS\\|tags\\|ETAGS\\|etags\\|GTAGS\\|GRTAGS\\|GPATH\\)\\(<[0-9]+>\\)?")
             dabbrev-upcase-means-case-search t)
-      (add-to-list 'dabbrev-ignored-buffer-modes 'pdf-view-mode)))
+      (add-to-list 'dabbrev-ignored-buffer-modes 'pdf-view-mode)
+      (add-to-list 'dabbrev-ignored-buffer-modes 'doc-view-mode)
+      (add-to-list 'dabbrev-ignored-buffer-modes 'tags-table-mode)))
 
   ;; Make these capfs composable.
   (advice-add #'lsp-completion-at-point :around #'cape-wrap-noninterruptible)


### PR DESCRIPTION
The Corfu documentation has been updated to suggest more modes to ignore with `dabbrev-ignore-buffer-modes`. This commit updates the list of modes to ignore in `cape-dabbrev` to match the documentation.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
