### PR TITLE
Switch to using opam-switch-mode for :lang ocaml

### DIFF
--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -14,6 +14,7 @@ This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by
 - Auto-indentation ([[doom-package:ocp-indent]])
 - Code formatting ([[doom-package:ocamlformat]])
 - Dune file format ([[doom-package:dune]])
+- Opam switch selection ([[doom-package:opam-switch-mode]])
 
 ** Maintainers
 *This module needs a maintainer.* [[doom-contrib-maintainer:][Become a maintainer?]]
@@ -31,6 +32,7 @@ This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by
 - [[doom-package:ocamlformat]] if [[doom-module::editor format]]
 - [[doom-package:ocp-indent]]
 - [[doom-package:tuareg]]
+- [[doom-package:opam-switch-mode]]
 - [[doom-package:utop]] if [[doom-module::tools eval]]
 - unless [[doom-module:+lsp]]
   - [[doom-package:flycheck-ocaml]] if [[doom-module::checkers syntax]]
@@ -42,7 +44,7 @@ This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by
 - ~set-ligatures!~ is called with the full tuareg prettify symbol list, this can
   cause columns to change as certain keywords are shortened (e.g. =fun= becomes
   \lambda).
-- ~tuareg-opam-update-env~ is called the first time [[doom-package:tuareg]] is loaded
+- ~opam-switch-set-switch~ is called the first time [[doom-package:tuareg]] and subsequently [[doom-package:opam-switch-mode]] are loaded
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.
@@ -80,6 +82,7 @@ This module requires the following packages available through [[http://opam.ocam
 | ~merlin-iedit-occurrences~   | [[kbd:][v R]]             | visual refactor identifier under point (multiple cursors) |
 | ~utop~                       | [[kbd:][SPC o r]]         | open =utop= as REPL                                       |
 | ~utop-eval-region~           | [[kbd:][SPC c e]]         | evaluate selected region in =utop=                        |
+| ~opam-switch-set-switch~     | [[kbd:][<localleader> w]] | evaluate selected region in =utop=                        |
 
 * TODO Configuration
 #+begin_quote

--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -4,7 +4,7 @@
 #+since:    2.0.4 (#128)
 
 * Description :unfold:
-This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:tuareg-mode]].
+This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by [[doom-package:tuareg]].
 
 - Code completion, documentation look-up, code navigation and refactoring
   ([[doom-package:merlin]])

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -20,10 +20,6 @@
   ;; harmless if `prettify-symbols-mode' isn't active
   (setq tuareg-prettify-symbols-full t)
 
-  ;; Use opam to set environment
-  (setq tuareg-opam-insinuate t)
-  (tuareg-opam-update-env (tuareg-opam-current-compiler))
-
   (setq-hook! 'tuareg-mode-hook
     comment-line-break-function #'+ocaml/comment-indent-new-line)
 
@@ -122,6 +118,22 @@
                 ((equal ext ".eliomi")
                  (setq-local ocamlformat-file-kind 'interface)))))
       (setq-local +format-with 'ocamlformat))))
+
+(use-package! opam-switch-mode
+  :hook (tuareg-mode-local-vars . +ocaml-init-opam-switch-h)
+  :init
+  (map! :localleader
+        :map tuareg-mode-map
+        "w" #'opam-switch-set-switch)
+
+  (defun +ocaml-init-opam-switch-h ()
+    "Activate `opam-switch-mode' if the opam executable exists."
+    (when (executable-find "opam")
+      (opam-switch-mode)))
+  :config
+  ;; Use opam to set environment
+  (setq tuareg-opam-insinuate t)
+  (opam-switch-set-switch (tuareg-opam-current-compiler)))
 
 ;; Tree sitter
 (eval-when! (modulep! +tree-sitter)

--- a/modules/lang/ocaml/packages.el
+++ b/modules/lang/ocaml/packages.el
@@ -3,6 +3,8 @@
 
 (package! tuareg :pin "1d53723e39f22ab4ab76d31f2b188a2879305092")
 
+(package! opam-switch-mode :pin "1069e56a662f23ea09d4e05611bdedeb99257012")
+
 (unless (modulep! +lsp)
   (package! merlin :pin "8404f96693727f7b0edc0d0b14db57843d79e27b")
   (package! merlin-eldoc :pin "bf8edc63d85b35e4def352fa7ce4ea39f43e1fd8")


### PR DESCRIPTION
The PR adds configuration to install `opam-switch-mode` to manage OCaml's opam switches, instead of using a deprecated method in the `tuareg` package. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

I'm not sure if the DNP on modules is still in place, since there's been no activity on the modules repository since the last comment on the DNP list.