### PR TITLE
tweak(ligatures): fallback to derived mode

### DIFF
--- a/modules/ui/ligatures/config.el
+++ b/modules/ui/ligatures/config.el
@@ -133,7 +133,9 @@ and cannot run in."
           (setq +ligatures--init-font-hook nil)))
       (when in-mode-extras-p
         (prependq! prettify-symbols-alist
-                   (alist-get major-mode +ligatures-extra-alist)))
+                   (if-let ((major-mode-ligatures (alist-get major-mode +ligatures-extra-alist)))
+                       major-mode-ligatures
+                     (cdr (seq-find (lambda (mode) (derived-mode-p (car mode))) +ligatures-extra-alist)))))
       (when (and (or in-mode-p in-mode-extras-p)
                  prettify-symbols-alist)
         (when prettify-symbols-mode


### PR DESCRIPTION
Ligatures now can fall back to derived mode
ligatures if they are not available for the
current mode. This has lower precedence than
ligatures directly defined for the current
mode.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
