### PR TITLE
tweak(ocaml): add more extra ligatures

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -17,6 +17,24 @@
   (set-ligatures! 'tuareg-mode :alist
     (append tuareg-prettify-symbols-basic-alist
             tuareg-prettify-symbols-extra-alist))
+  ;; some extra ligatures
+  ;; unfortunately, ocaml does not have many keywords
+  ;; that can't be used as identifiers, so in theory
+  ;; some user defined variables could be prettified.
+  ;; However, naming your function "string" is probably
+  ;; as confusing with and without ligatures.
+  (set-ligatures! 'tuareg-mode :alist
+    :true "true"
+    :false "false"
+    :null "[]"
+    :int "int"
+    :float "float"
+    :str "string"
+    :bool "bool"
+    :list "list"
+    :pipe "|>"
+    :tuple ", "
+    :dot "*")
   ;; harmless if `prettify-symbols-mode' isn't active
   (setq tuareg-prettify-symbols-full t)
 


### PR DESCRIPTION
Tuareg mode (for ocaml) current uses
its own ligatures. This extends that
with some extra, non-conflicting ones
using the `:ui ligatures` module's
pre-defined ligatures.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

Before:
![20240410_21h33m24s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/a95f9742-35d2-4225-9c8b-154c37034cc6)


After:
![20240410_21h32m05s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/20642719-bfa0-435b-928e-6bd5fdc7427d)


I'm using the dot instead of the cartesian product sign for the tuple type because it uses the * character, which is also used for multiplication. One way to resolve this is to add the cross product symbol to the default `+ligatures-extra-symbols` plist as a compromise between X for multiplication and X for cartesian product. I'm not sure if this is optimal, though, should this be done?

I added the tuple symbol just for the screenshot, but I might remove it because of how hacky it is (matches on ", " to avoid it being lopsided, but then tuples not in that format won't work + there are no spaces on each side).