### PR TITLE
feat(ophints): add goggles for non-evil users

### DIFF
--- a/modules/ui/ophints/README.org
+++ b/modules/ui/ophints/README.org
@@ -16,11 +16,13 @@ Uses [[doom-package:evil-goggles]] for evil users and [[doom-package:volatile-hi
 [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-/This module has no flags./
+- +goggles ::
+  Use doom-package:goggles instead of doom-package:volatile-highlights. Only works when [[doom-module::editor evil]] is off.
 
 ** Packages
 - [[doom-package:evil-goggles]] if [[doom-module::editor evil]]
-- [[doom-package:volatile-highlights]] unless [[doom-module::editor evil]]
+- [[doom-package:volatile-highlights]] unless [[doom-module::editor evil]] or [[doom-module:+goggles]]
+- doom-package:goggles if doom-module:+goggles unless [[doom-module::editor evil]]
 
 ** Hacks
 /No hacks documented for this module./

--- a/modules/ui/ophints/README.org
+++ b/modules/ui/ophints/README.org
@@ -8,22 +8,20 @@ This module provides op-hints (operation hinting), i.e. visual feedback for
 certain operations. It highlights regions of text that the last operation (like
 yank) acted on.
 
-Uses [[doom-package:evil-goggles]] for evil users and [[doom-package:volatile-highlights]] otherwise.
+Uses [[doom-package:evil-goggles]] for evil users and [[doom-package:goggles]] otherwise.
 
 ** Maintainers
 - [[doom-user:][@hlissner]]
 
 [[doom-contrib-maintainer:][Become a maintainer?]]
-
+        
 ** Module flags
-- +goggles ::
-  Use doom-package:goggles instead of doom-package:volatile-highlights. Only works when [[doom-module::editor evil]] is off.
-
+-/This module has no flags./
+        
 ** Packages
 - [[doom-package:evil-goggles]] if [[doom-module::editor evil]]
-- [[doom-package:volatile-highlights]] unless [[doom-module::editor evil]] or [[doom-module:+goggles]]
-- doom-package:goggles if doom-module:+goggles unless [[doom-module::editor evil]]
-
+- doom-package:goggles unless [[doom-module::editor evil]]
+  
 ** Hacks
 /No hacks documented for this module./
 

--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -65,7 +65,11 @@
 
 (use-package! goggles
   :if (and (modulep! +goggles) (not (modulep! :editor evil)))
-  :hook ((prog-mode text-mode) . goggles-mode))
+  :hook ((prog-mode text-mode) . goggles-mode)
+  :config
+  (goggles-define goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
+  (goggles-define goggles-register-paste insert-register)
+  (goggles-define goggles-kill-word backward-kill-word kill-word))
 
 (use-package! volatile-highlights
   :unless (or (modulep! :editor evil) (modulep! +goggles))

--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -69,4 +69,5 @@
   :config
   (goggles-define goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
   (goggles-define goggles-register-paste insert-register)
-  (goggles-define goggles-kill-word backward-kill-word kill-word))
+  (goggles-define goggles-kill-word backward-kill-word kill-word)
+  (goggles-define goggles-undo-fu undo-fu-only-undo undo-fu-only-redo))

--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -63,9 +63,12 @@
                 :switch evil-goggles-enable-join
                 :advice evil-goggles--join-advice))))
 
+(use-package! goggles
+  :if (and (modulep! +goggles) (not (modulep! :editor evil)))
+  :hook ((prog-mode text-mode) . goggles-mode))
 
 (use-package! volatile-highlights
-  :unless (modulep! :editor evil)
+  :unless (or (modulep! :editor evil) (modulep! +goggles))
   :hook (doom-first-input . volatile-highlights-mode)
   :config
   (after! undo-fu

--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -64,17 +64,9 @@
                 :advice evil-goggles--join-advice))))
 
 (use-package! goggles
-  :if (and (modulep! +goggles) (not (modulep! :editor evil)))
+  :if (not (modulep! :editor evil))
   :hook ((prog-mode text-mode) . goggles-mode)
   :config
   (goggles-define goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
   (goggles-define goggles-register-paste insert-register)
   (goggles-define goggles-kill-word backward-kill-word kill-word))
-
-(use-package! volatile-highlights
-  :unless (or (modulep! :editor evil) (modulep! +goggles))
-  :hook (doom-first-input . volatile-highlights-mode)
-  :config
-  (after! undo-fu
-    (vhl/define-extension 'undo-fu 'undo-fu-only-undo 'undo-fu-only-redo)
-    (vhl/install-extension 'undo-fu)))

--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -67,7 +67,7 @@
   :if (not (modulep! :editor evil))
   :hook ((prog-mode text-mode) . goggles-mode)
   :config
-  (goggles-define goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
-  (goggles-define goggles-register-paste insert-register)
-  (goggles-define goggles-kill-word backward-kill-word kill-word)
-  (goggles-define goggles-undo-fu undo-fu-only-undo undo-fu-only-redo))
+  (goggles-define +goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
+  (goggles-define +goggles-register-paste insert-register)
+  (goggles-define +goggles-kill-word backward-kill-word kill-word)
+  (goggles-define +goggles-undo-fu undo-fu-only-undo undo-fu-only-redo))

--- a/modules/ui/ophints/packages.el
+++ b/modules/ui/ophints/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/ophints/packages.el
 
-(if (modulep! :editor evil)
-    (package! evil-goggles :pin "34ca276a85f615d2b45e714c9f8b5875bcb676f3")
-  (package! volatile-highlights :pin "fcf6e2778454ce514c189a7d1fe70e03ad81c325"))
+(cond ((modulep! :editor evil) (package! evil-goggles :pin "34ca276a85f615d2b45e714c9f8b5875bcb676f3"))
+      ((modulep! +goggles) (package! goggles :pin "41d3669d7ae7b73bd39d298e5373ece48b656ce3"))
+      (t (package! volatile-highlights :pin "fcf6e2778454ce514c189a7d1fe70e03ad81c325")))


### PR DESCRIPTION
This adds the goggles package as a module flag
to use goggles instead of volatile-highlights-mode as a non-evil user.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
