### PR TITLE
fix(flycheck): make child frame disappear instantly

### DIFF
--- a/modules/checkers/syntax/README.org
+++ b/modules/checkers/syntax/README.org
@@ -25,6 +25,9 @@ This module provides syntax checking and error highlighting, powered by
 ** Hacks
 - If ~lsp-ui-mode~ is active, most of the aesthetic functionality of this module
   is turned off, as they show the same information.
+- If child frames are enabled, a post command hook has to be added to ensure
+  that the flycheck frame goes away instantly, or else it will linger for a
+  couple of seconds.
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.

--- a/modules/checkers/syntax/config.el
+++ b/modules/checkers/syntax/config.el
@@ -69,6 +69,19 @@
 (use-package! flycheck-posframe
   :when (modulep! +childframe)
   :unless (modulep! +flymake)
+  :preface
+  ;; Fix bug where the child frame doesn't disappear immediately.
+  ;; See #6416
+  ;; Thanks to jadestrong for the fix:
+  ;; https://github.com/doomemacs/doomemacs/issues/6416#issuecomment-1156164346
+  (defun +flycheck-posframe-monitor-post-command ()
+    (unless (flycheck-posframe-check-position)
+      (posframe-hide flycheck-posframe-buffer)))
+  (defun +fix-flycheck-posframe-not-hide-immediately ()
+    (if flycheck-posframe-mode
+        (add-hook! post-command :local #'+flycheck-posframe-monitor-post-command)
+      (remove-hook! post-command :local #'+flycheck-posframe-monitor-post-command t)))
+  :hook (flycheck-posframe-mode . +fix-flycheck-posframe-not-hide-immediately)
   :hook (flycheck-mode . +syntax-init-popups-h)
   :config
   (setq flycheck-posframe-warning-prefix "! "


### PR DESCRIPTION
Currently, if the +childframe flag is on, the frame will linger for a few seconds before disappearing
after leaving the highlighted error. A post command hook needs to be added to fix this, courtesy of
[jadestrong](https://github.com/doomemacs/doomemacs/issues/6416#issuecomment-1156164346).

Fix: #6416
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
