### PR TITLE
tweak(flycheck): prettify default settings

### DIFF
--- a/modules/checkers/syntax/README.org
+++ b/modules/checkers/syntax/README.org
@@ -16,12 +16,14 @@ This module provides syntax checking and error highlighting, powered by
   *Requires GUI Emacs.*
 - +flymake :: Leverages the inbuilt [[doom-package:flymake]] for error and
   diagnostics highlighting.
+- +icons :: Uses unicode icons instead of ASCII characters to prefix tooltips
+  or flycheck frames (depending on the value of doom-module:+childframe)
 
 ** Packages
 - [[doom-package:flycheck]]
 - [[doom-package:flycheck-popup-tip]]
 - [[doom-package:flycheck-posframe]] if [[doom-module:+childframe]]
-
+        
 ** Hacks
 - If ~lsp-ui-mode~ is active, most of the aesthetic functionality of this module
   is turned off, as they show the same information.

--- a/modules/checkers/syntax/config.el
+++ b/modules/checkers/syntax/config.el
@@ -50,8 +50,9 @@
   :commands flycheck-popup-tip-show-popup flycheck-popup-tip-delete-popup
   :hook (flycheck-mode . +syntax-init-popups-h)
   :config
-  (setq flycheck-popup-tip-error-prefix "X ")
-
+  (setq flycheck-popup-tip-error-prefix (if (modulep! +icons)
+                                            "❌ "
+                                          "X "))
   ;; HACK: Only display the flycheck popup if we're in normal mode (for evil
   ;;   users) or if no selection or completion is active. This popup can
   ;;   interfere with the active evil mode, clear active regions, and other
@@ -71,9 +72,16 @@
   :unless (modulep! +flymake)
   :hook (flycheck-mode . +syntax-init-popups-h)
   :config
-  (setq flycheck-posframe-warning-prefix "! "
-        flycheck-posframe-info-prefix "··· "
-        flycheck-posframe-error-prefix "X ")
+  (set-face-attribute 'flycheck-posframe-info-face nil :inherit 'font-lock-variable-name-face)
+  (set-face-attribute 'flycheck-posframe-warning-face nil :inherit 'warning)
+  (set-face-attribute 'flycheck-posframe-error-face nil :inherit 'error)
+  (if (modulep! +icons)
+      (setq flycheck-posframe-warning-prefix "⚠ "
+            flycheck-posframe-error-prefix "❌ "
+            flycheck-posframe-info-prefix "ⓘ ")
+    (setq flycheck-posframe-warning-prefix "! "
+          flycheck-posframe-error-prefix "X "
+          flycheck-posframe-info-prefix "··· "))
   (after! company
     ;; Don't display popups if company is open
     (add-hook 'flycheck-posframe-inhibit-functions #'company--active-p))


### PR DESCRIPTION
Makes the default settings of flycheck a
bit prettier in child frame mode, using
faces from the default "pretty config" in
`flycheck-posframe`. Additionally, unicode
characters can be optionally enabled as
prefixes for flycheck messages.

I'm not sure if +icons should be enabled be default, is it a reasonable to assume that users will have fonts that support unicode icons?

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

Before:
![20240411_22h50m08s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/7276baab-5b58-43b4-a0cf-3619467c4364)

After (with +childframe and +icons)
![20240411_22h53m13s_grim](https://github.com/doomemacs/doomemacs/assets/49997896/da606d46-52cb-43ab-a850-c312a1554a39)


