### PR TITLE
Fix rust ts mode priority

### DIFF
--- a/modules/lang/rust/README.org
+++ b/modules/lang/rust/README.org
@@ -32,6 +32,11 @@ e.g. ~cargo~.
 - rustic has been modified /not/ to automatically install lsp-mode or eglot if
   they're missing. Doom expects you to have enabled the [[doom-module::tools lsp]] module
   yourself.
+- If doom-package:rust-ts-mode is loaded, it'll add itself as the default major mode for rust
+  with higher priority than doom-package:rustic-mode. This package disables doom-package:rust-ts-mode
+  setting itself as the default major mode when it loads, so do not depend on
+  this behaviour. Instead, set ~rust-mode-treesitter-derive~ to have this module use
+  the tree-sitter mode as the "base mode" automatically.
 
 ** TODO Changelog
 # This section will be machine generated. Don't edit it by hand.

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -20,6 +20,11 @@
     (remove-hook 'rustic-mode-hook #'flymake-mode-off)
     (remove-hook 'flycheck-mode-hook #'rustic-flycheck-setup))
   :init
+  ;; HACK if `rust-ts-mode' is used as the base of `rust-mode'
+  ;; it will set itself as a higher priority major mode for
+  ;; rust files.
+  (after! rust-ts-mode
+    (setq auto-mode-alist (delete '("\\.rs\\'" . rust-ts-mode) auto-mode-alist)))
   ;; HACK Certainly, `rustic-babel' does this, but the package (and many other
   ;;   rustic packages) must be loaded in order for them to take effect. To lazy
   ;;   load it all, we must do it early:


### PR DESCRIPTION
If `rust-ts-mode` is used as the base of `rust-mode`
then it will [automatically add itself](https://github.com/emacsmirror/emacs/blob/2fc7e21f5e75ea6b00d6f7344335f44f5663d955/lisp/progmodes/rust-ts-mode.el#L557) to `auto-mode-alist`
before `rustic-mode`, causing every file other than
the first to be opened to default to `rust-ts-mode`
instead. This can be fixed by removing the treesitter
mode from the list after it gets set when the package
loads. This will change behaviour if:

1) both this module and the tree sitter mode are enabled
2) the user loads the `rust-ts-mode` package in some way
3) the user intends for `rust-ts-mode` to be prioritized
over the doom module.

However, this is unlikely to be the case.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
