### PR TITLE
feat(format): format on save only in certain directories

### DIFF
--- a/modules/editor/format/README.org
+++ b/modules/editor/format/README.org
@@ -26,7 +26,8 @@ be formatted and returned to the buffer using
 - +onsave ::
   Enable reformatting of a buffer when it is saved. See
   [[var:+format-on-save-disabled-modes]] to disable format on save for certain
-  major modes.
+  major modes and var:+format-on-save-enabled-files-directories to only
+  format on save for specific files/directories.
 
 ** Packages
 - [[doom-package:apheleia]]
@@ -102,7 +103,9 @@ If you want to save more than a handful of time, you can set
 [[var:apheleia-inhibit]] to disable even if =apheleia-global-mode= is on.
 
 *** Onsave only
-This behaviour is controlled via [[var:+format-on-save-disabled-modes]] thus;
+This behaviour is controlled via two variables:
+- [[var:+format-on-save-disabled-modes]]
+- var:+format-on-save-enabled-files-directories
 
 #+begin_src emacs-lisp
 (setq +format-on-save-disabled-modes
@@ -115,6 +118,18 @@ This behaviour is controlled via [[var:+format-on-save-disabled-modes]] thus;
 In this case, =emacs-lisp-mode=, =sql-mode=, =tex-mode= and =latex-mode= will not be
 formatted on save, but can still be formatted by manually invoking the commands
 =+format/buffer= or =apheleia-format-buffer=.
+
+#+begin_src emacs-lisp
+(setq +format-on-save-enabled-files-directories
+      '("/usr/share/emacs/29.3/lisp/"
+        "~/my-dotfiles/"
+        "~/.config/doom/config.el"))
+#+end_src
+
+This will make the files in the =/usr/share/emacs/29.3/lisp/= and =~/my-dotfiles= folders
+format on save, as well as the =config.el= file; turning this on makes auto format disable
+on every other file. By default, the value of this is ~t~ which will format all files on save.
+Setting this option still requires the doom-module:+onsave flag to work.
 
 ** Disabling the LSP formatter
 If you are in a buffer with ~lsp-mode~ enabled and a server that supports

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -61,11 +61,13 @@ This is controlled by `+format-on-save-disabled-modes' and
       (string-blank-p (buffer-name))
       (eq +format-on-save-disabled-modes t)
       (not (null (memq major-mode +format-on-save-disabled-modes)))
-      (cl-some
-       (lambda (f) (or
-               (file-in-directory-p buffer-file-truename f)
-               (file-equal-p buffer-file-truename f)))
-       +format-on-save-enabled-directories)))
+      (not (or
+            +format-on-save-enabled-files-directories
+            (cl-some
+             (lambda (f) (or
+                     (file-in-directory-p buffer-file-truename f)
+                     (file-equal-p buffer-file-truename f)))
+             +format-on-save-enabled-files-directories)))))
 
 
 (after! apheleia

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -11,6 +11,13 @@ If it is t, it is disabled in all modes, the same as if the +onsave flag
 If nil, formatting is enabled in all modes.
 Irrelevant if you do not have the +onsave flag enabled for this module.")
 
+(defvar +format-on-save-enabled-files-directories t
+  "A list of files or directories in which to reformat the buffer upon saving.
+Accepts both filenames and directories. The tilde (~) can be used to specify the
+current user's home directory
+If t, formatting is enabled in all directories.
+Irrelevant if you do not have the +onsave flag enabled for this module.")
+
 (defvar +format-preserve-indentation t
   "If non-nil, the leading indentation is preserved when formatting the whole
 buffer. This is particularly useful for partials.
@@ -48,11 +55,17 @@ including Apheleia itself.")
 
 (defun +format-maybe-inhibit-h ()
   "Check if formatting should be disabled for current buffer.
-This is controlled by `+format-on-save-disabled-modes'."
+This is controlled by `+format-on-save-disabled-modes' and
+`+format-on-save-enabled-files-directories'."
   (or (eq major-mode 'fundamental-mode)
       (string-blank-p (buffer-name))
       (eq +format-on-save-disabled-modes t)
-      (not (null (memq major-mode +format-on-save-disabled-modes)))))
+      (not (null (memq major-mode +format-on-save-disabled-modes)))
+      (cl-some
+       (lambda (f) (or
+               (file-in-directory-p buffer-file-truename f)
+               (file-equal-p buffer-file-truename f)))
+       +format-on-save-enabled-directories)))
 
 
 (after! apheleia


### PR DESCRIPTION
Adds support for formatting on save in certain
directories/files only, with a new list variable
`+format-on-save-enabled-directories`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
