### PR TITLE
fix(lib): doom-initialize-core-packages: correct filtering

### DIFF
--- a/lisp/doom-packages.el
+++ b/lisp/doom-packages.el
@@ -256,7 +256,7 @@ uses a straight or package.el command directly).")
           (alist-get 'straight packages)
         (doom--ensure-straight recipe pin))
       (doom--ensure-core-packages
-       (seq-filter (fn! (eq (plist-get % :type) 'core))
+       (seq-filter (fn! (eq (plist-get (cdr %) :type) 'core))
                    packages)))))
 
 (defun doom-initialize-packages (&optional force-p)


### PR DESCRIPTION
The doom-package-list is a list of (module :key value ...). To get the plist,  apply cdr first.

<!-- ⚠️ Please do not ignore this template! -->

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
