### PR TITLE
fix(lib): doom-packages-ensure: fix local packages always built

### DIFF
--- a/lisp/cli/packages.el
+++ b/lisp/cli/packages.el
@@ -301,7 +301,7 @@ list remains lean."
                          (setq want-native-compile nil))
                        (and (or want-byte-compile want-native-compile)
                             (or (file-newer-than-file-p repo-dir build-dir)
-                                (file-exists-p (straight--modified-dir (or local-repo package)))
+                                (file-exists-p (straight--modified-dir package))
                                 (cl-loop with outdated = nil
                                          for file in (doom-files-in build-dir :match "\\.el$" :full t)
                                          if (or (if want-byte-compile   (doom-packages--elc-file-outdated-p file))


### PR DESCRIPTION
If the package is local, the local-repo has absolute local file path, and straight-modified-dir will return as it is, which always exists.

Fix it by passing package only to straight-modified-dir.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
