### PR TITLE
fix: 'doom sync' generates autoload files for symbolic link files

### DIFF
--- a/lisp/doom-modules.el
+++ b/lisp/doom-modules.el
@@ -351,9 +351,9 @@ If ENABLED-ONLY, return nil if the containing module isn't enabled."
                (and (or (null enabled-only)
                         (doom-module-p category module))
                     (cons category module))))
-            ((file-in-directory-p path doom-core-dir)
+            ((string-match (concat "^" (regexp-quote doom-core-dir)) path)
              (cons :core nil))
-            ((file-in-directory-p path doom-user-dir)
+            ((string-match (concat "^" (regexp-quote doom-user-dir)) path)
              (cons :user nil))))))
 
 (defun doom-module-load-path (&optional module-load-path)

--- a/lisp/lib/autoloads.el
+++ b/lisp/lib/autoloads.el
@@ -169,7 +169,6 @@ non-nil, treat FILES as pre-generated autoload files instead."
       (when (and (not (seq-find (doom-rpartial #'string-match-p file) exclude))
                  (file-readable-p file))
         (doom-log "loaddefs:scan: %s" file)
-        (setq file (file-truename file))
         (with-temp-buffer
           (if literal
               (insert-file-contents file)


### PR DESCRIPTION
* lisp/lib/autoloads.el(doom-autoloads--scan) Remove invoke `file-truename` of file, keeping symbolic from being converted to a real path.
* lisp/doom-modules.el(doom-module-from-path) Replace `file-in-directory-p` with `string-match` to determine the module to which the file belongs.

Fix: #7821

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
