### PR TITLE
feat(common-lisp): make quicklisp directory configurable

### DIFF
--- a/modules/lang/common-lisp/autoload/common-lisp.el
+++ b/modules/lang/common-lisp/autoload/common-lisp.el
@@ -37,4 +37,4 @@
 (defun +lisp/find-file-in-quicklisp ()
   "Find a file belonging to a library downloaded by Quicklisp."
   (interactive)
-  (doom-project-find-file "~/.quicklisp/dists/"))
+  (doom-project-find-file (file-name-concat +lisp-quicklisp-directory "dists/")))

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -179,3 +179,9 @@
   :defer t
   :init
   (add-to-list 'sly-contribs 'sly-stepper))
+
+(defvar +lisp-quicklisp-directory
+  (if (file-exists-p "~/.quicklisp")
+      "~/.quicklisp"
+    "~/quicklisp")
+  "Quicklisp install directory")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Previously, `+lisp/find-file-in-quicklisp` used a hard-coded directory aimed at a nonstandard Quicklisp install location, `~/.quicklisp`. The default install location is `~/quicklisp`, without the dot. This commit makes the user's Quicklisp directory configurable through the variable `+lisp-quicklisp-directory`, which will default to `~/.quicklisp` if it exists or to `~/quicklisp` otherwise. `+lisp/find-file-in-quicklisp` has been updated to respect this variable.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
