### PR TITLE
fix(gdscript): replace removed functions with new binding

### DIFF
--- a/modules/lang/gdscript/config.el
+++ b/modules/lang/gdscript/config.el
@@ -28,9 +28,8 @@
          :desc "Run current scene" "s" #'gdscript-godot-run-current-scene)
 
         (:prefix ("d" . "debug")
-         :desc "Add breakpoint" "a"  #'gdscript-debug-add-breakpoint
+         :desc "Toggle breakpoint" "d" #'gdscript-debug-toggle-breakpoint
          :desc "Display breakpoint buffer" "b" #'gdscript-debug-display-breakpoint-buffer
-         :desc "Remove breakpoint" "d" #'gdscript-debug-remove-breakpoint
          :desc "Continue execution" "c" #'gdscript-debug-continue
          :desc "Next" "n" #'gdscript-debug-next
          :desc "Step" "s" #'gdscript-debug-step)


### PR DESCRIPTION
This commit removes the keybinds to add and remove a breakpoint in a gdscript buffer, which were removed from gdscript-mode long ago, and replaces them with one binding to toggle a breakpoint.

<!-- ⚠️ Please do not ignore this template! -->
Fix: #7254

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
