### PR TITLE
feat(debugger): add gdscript dap-mode support

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -20,6 +20,7 @@
   `(((:lang cc +lsp)         :after ccls        :require (dap-lldb dap-gdb-lldb))
     ((:lang elixir +lsp)     :after elixir-mode :require dap-elixir)
     ((:lang go +lsp)         :after go-mode     :require dap-dlv-go)
+    ((:lang gdscript +lsp)   :after gdscript-mode :require dap-gdscript)
     ((:lang java +lsp)       :after java-mode   :require lsp-java)
     ((:lang php +lsp)        :after php-mode    :require dap-php)
     ((:lang python +lsp)     :after python      :require dap-python)


### PR DESCRIPTION
This commit adds gdscript support to `:tool debugger +lsp`, which has been available in dap-mode since a year ago.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
