### PR TITLE
feat(go): Update flycheck-golangci-lint package to support renamed option

### DIFF
--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -13,4 +13,4 @@
 
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))
-  (package! flycheck-golangci-lint :pin "9def093e416e9a6ddd3cae8590dbb7ff6314925a"))
+  (package! flycheck-golangci-lint :pin "91c59b128aa6f719069cfb3e5df77588691a3e14"))


### PR DESCRIPTION
This commit updates flycheck-golangci-lint package to support renamed option(--deadline to --timeout) of golangci-lint linter. Link to commit https://github.com/weijiangan/flycheck-golangci-lint/commit/91c59b128aa6f719069cfb3e5df77588691a3e14
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
