### PR TITLE
fix(dired): update dirvish keybindings

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -151,6 +151,9 @@ we have to clean it up ourselves."
         :n "F" #'dirvish-layout-toggle
         :n "l" #'dired-find-file
         :n "h" #'dired-up-directory
+        :n "TAB" #'dirvish-subtree-toggle
+        :n "gh" #'dirvish-subtree-up
+        :n "gl" #'dirvish-subtree-down
         :localleader
         "h" #'dired-omit-mode))
 

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -145,10 +145,10 @@ we have to clean it up ourselves."
   (when (modulep! +icons)
     (push +dired-dirvish-icon-provider dirvish-attributes))
   (map! :map dirvish-mode-map
-        :n "b" #'dirvish-goto-bookmark
-        :n "z" #'dirvish-show-history
+        :n "b" #'dirvish-quick-access
+        :n "z" #'dirvish-history-jump
         :n "f" #'dirvish-file-info-menu
-        :n "F" #'dirvish-toggle-fullscreen
+        :n "F" #'dirvish-layout-toggle
         :n "l" #'dired-find-file
         :n "h" #'dired-up-directory
         :localleader


### PR DESCRIPTION
This is another temporary fix to buy us more time until https://github.com/doomemacs/doomemacs/pull/6760
lands.

It also adds dirvish's `sub-tree` keybindings, mirroring `dired`'s.

Ref: #6760 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).