### PR TITLE
fix(god): fix cursor color

### DIFF
--- a/modules/editor/god/autoload.el
+++ b/modules/editor/god/autoload.el
@@ -26,7 +26,7 @@
           (cond (buffer-read-only +god-read-only-mode-color)
                 (is-fill-overflow +god-fill-overflow-color)
                 (overwrite-mode +god-overwrite-mode-color)
-                (t previous-cursor-color))))
+                (t (face-background 'highlight)))))
     (setq cursor-type next-cursor-type)
     (unless (eq previous-cursor-color next-cursor-and-modeline-color)
       (set-cursor-color next-cursor-and-modeline-color))


### PR DESCRIPTION
This was broken in aa079b0e3ccc0548a677907a08cd12c5b878e44c (#7049).

When the cursor changes from color A to color B, it doesn't ever change back to color A, as `(face 'cursor)` will now return color B.
Since the default cursor in the Doom theme uses the `highlight` background color, we can use that when setting the cursor color when this module is enabled.

### Screenshots

For example, when the `:editor god` module is enabled, change the cursor color by moving to the end of a long line, and then move to the beginning of the line so that the default cursor color should be shown.

#### Before
![image](https://github.com/doomemacs/doomemacs/assets/1171466/e1106d15-f83f-411e-bf97-c2aedc50776b)

#### After
![image](https://github.com/doomemacs/doomemacs/assets/1171466/c43fad52-2de5-4d40-a51b-e211d4ecebad)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
