### PR TITLE
Due to change in Cargo, update elisp-tree-sitter

### DIFF
--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/tree-sitter/packages.el
 
-(package! tree-sitter :pin "3cfab8a0e945db9b3df84437f27945746a43cc71")
+(package! tree-sitter :pin "e0ce25406706e0a164bd565a391f5bb8f54f995f")
 (package! tree-sitter-langs :pin "b7895ca759563f3c7c3b928eb4f816bb4099d866")
 (package! tree-sitter-indent :pin "4ef246db3e4ff99f672fe5e4b416c890f885c09e")
 


### PR DESCRIPTION
The current pinned commit is around 2 years old.

This PR updates the commit to the one matching https://github.com/emacs-tree-sitter/elisp-tree-sitter/pull/249

That change is backards-compatible with old Cargo behavior, so it should be safe.