### PR TITLE
fix(window-select): load winum earlier

### DIFF
--- a/modules/ui/window-select/config.el
+++ b/modules/ui/window-select/config.el
@@ -23,12 +23,9 @@
 
 (use-package! winum
   :when (modulep! +numbers)
-  :after-call doom-switch-window-hook
+  :hook (doom-after-init . winum-mode)
   :config
-  ;; winum modifies `mode-line-format' in a destructive manner. I'd rather leave
-  ;; it to modeline plugins (or the user) to add this if they want it.
   (setq winum-auto-setup-mode-line nil)
-  (winum-mode +1)
   (map! :map evil-window-map
         "0" #'winum-select-window-0-or-10
         "1" #'winum-select-window-1


### PR DESCRIPTION
This is so that a user can use `winum-auto-setup-mode-line` with value `t`. Since that modifies the default mode line, the entire package needs to be loaded very early for that option to be available to a user.

This is cheaper and better than mapping over every buffer and modifying their buffer-local value for mode-line-format.

Also, I disagree with that comment in the sense that modifying `mode-line-format` is not important at all since it is done correctly. The issue to me is that since it modifies the default value of `mode-line-format`, the package should be loaded early for all buffers to have that mode-line segment.