### PR TITLE
refactor(lib): use ripgrep instead of `git grep`

### DIFF
--- a/lisp/lib/help.el
+++ b/lisp/lib/help.el
@@ -468,14 +468,12 @@ will open with point on that line."
 
 (defun doom--help-package-configs (package)
   (let ((default-directory doom-emacs-dir))
-    ;; TODO Use ripgrep instead
     (split-string
      (cdr (doom-call-process
-           "git" "grep" "--no-break" "--no-heading" "--line-number"
-           (format "%s %s\\($\\| \\)"
-                   "\\(^;;;###package\\|(after!\\|(use-package!\\)"
-                   package)
-           ":(exclude)*.org"))
+           "rg" "--no-heading" "--line-number" "--iglob" "!*.org"
+           (format "%s %s($| )"
+                   "(^;;;###package|\\(after!|\\(use-package!)"
+                   package)))
      "\n" t)))
 
 (defvar doom--help-packages-list nil)


### PR DESCRIPTION
Although this is a refactor for normal users of Doom, it is a bugfix for one (I assume) unsupported configuration: when Doom is not running from a git checkout. In that case, `doom--help-package-configs` currently returns Git's error messages. This breaks `doom/help-packages` because it expects each returned line to contain at least one `:` character, so it errors out with `Wrong number of arguments: (file line _match &rest), 2`.

Using ripgrep here should be equivalent for normal users as long as they have not added untracked files not covered by Doom's .gitignore.

<!-- ⚠️ Please do not ignore this template! -->

Assuming Doom outside of a git checkout is indeed unsupported, please close this PR if you don't want to spend time on it: when I saw the TODO in that function I figured I'd send this in, but it shouldn't be too hard to work around locally.

(I'm running into this running Doom from the Nix store. So far, this is the only issue I've encountered doing so. I've tested this change with that setup and with a more normal Doom install.)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
