### PR TITLE
Add binding for find-file-at-point

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -79,6 +79,7 @@
        :desc "Browse emacs.d"              "E"   #'doom/browse-in-emacsd
        :desc "Find file"                   "f"   #'find-file
        :desc "Find file from here"         "F"   #'+default/find-file-under-here
+       :desc "Find file under cursor"      "h"   #'find-file-at-point
        :desc "Locate file"                 "l"   #'locate
        :desc "Rename/move this file"       "m"   #'doom/move-this-file
        :desc "Find file in private config" "p"   #'doom/find-file-in-private-config


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This is a very simple PR to bind 'SPC f h' to `find-file-at-point`. This is immensely useful in terminal emulators. 'h' is a mnemonic for 'here'. 'c' and 'C' (for 'cursor') were already taken.

Fix: N/A
Ref: N/A
Close: N/A

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
