### PR TITLE
tweak(chinese): lazy load liberime

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -30,6 +30,7 @@
 
 (use-package! liberime
   :when (modulep! +rime)
+  :after pyim
   :init
   (setq liberime-auto-build t
         liberime-user-data-dir (file-name-concat doom-cache-dir "rime")))
@@ -37,7 +38,7 @@
 
 (use-package! pyim-liberime
   :when (modulep! +rime)
-  :after liberime
+  :after (pyim liberime)
   :config
   (setq pyim-default-scheme 'rime))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

right now when +rime enabled, pyim-liberime and liberime is loaded immediately which will load pyim as dependency and slows down the startup by ~300ms-~500ms.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
