### PR TITLE
bump: :completion vertico (consult only)

### DIFF
--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -5,7 +5,7 @@
 
 (package! orderless :pin "ac4aeb66f331f4c4a430d5556071e33177304c37")
 
-(package! consult :pin "c87b0bf06de0c3cb60bc8d257c770cb981ddcd19")
+(package! consult :pin "6eba1a3fa8e13681091a30b2490a03bdce5f243a")
 (package! consult-dir :pin "3f5f4b71ebe819392cb090cda71bd39a93bd830a")
 (when (and (modulep! :checkers syntax)
            (not (modulep! :checkers syntax +flymake)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Issue found with LSP `+lookup/definition`.
relates to https://github.com/minad/consult/issues/1015
the fix itself is in this commit https://github.com/minad/consult/commit/22d759c1335fae314a751d4b9f42c89f3d8848ef

Fix: #7863 

bumping just the `consult` dependency to the latest tag.

<details>
<summary>debug catch</summary>

```
Debugger entered--Lisp error: (wrong-number-of-arguments #<subr xref--group-name-for-display> 2)
  xref--group-name-for-display("/[redacted]/packages/functions/src/gateway/types.ts" "/[redacted]/")
  #f(compiled-function (xref) #<bytecode -0x684767c19857f5f>)(#s(xref-item :summary #("export const getGwsSch = z.object({" 13 22 (face xref-match)) :location #s(xref-file-location :file "/[redacted]ccxc-g..." :line 12 :column 13)))
  consult-xref--candidates()
  consult-xref(#f(compiled-function (&rest _) #<bytecode 0x6bdb2b8a7787d24>) ((window . #<window 3 on get.ts>) (display-action) (auto-jump)))
  lsp-show-xrefs((#s(xref-item :summary #("export const getGwsSch = z.object({" 13 22 (face xref-match)) :location #s(xref-file-location :file "/[redacted]ccxc-g..." :line 12 :column 13))) nil nil)
  (progn (lsp-show-xrefs (lsp--locations-to-xref-items loc) nil nil) 'deferred)
  (if loc (progn (lsp-show-xrefs (lsp--locations-to-xref-items loc) nil nil) 'deferred) nil)
  (let* ((loc (and t (lsp-request "textDocument/definition" (lsp--text-document-position-params))))) (if loc (progn (lsp-show-xrefs (lsp--locations-to-xref-items loc) nil nil) 'deferred) nil))
  +lsp-lookup-definition-handler()
  funcall-interactively(+lsp-lookup-definition-handler)
  call-interactively(+lsp-lookup-definition-handler)
  (if (commandp handler) (call-interactively handler) (funcall handler identifier))
  +lookup--run-handler(+lsp-lookup-definition-handler #("getGwsSch" 0 9 (identifier-at-point t fontified t)))
  (condition-case e (+lookup--run-handler handler identifier) ((debug error) (if doom-inhibit-log nil (doom--log "Lookup handler %S threw an error: %s" handler e)) 'fail))
  (let ((wconf (current-window-configuration)) (result (condition-case e (+lookup--run-handler handler identifier) ((debug error) (if doom-inhibit-log nil (doom--log "Lookup handler %S threw an error: %s" handler e)) 'fail)))) (cond ((eq result 'fail) (set-window-configuration wconf) nil) ((or (get handler '+lookup-async) (eq result 'deferred))) ((or result (null origin) (/= (point-marker) origin)) (prog1 (point-marker) (set-window-configuration wconf)))))
  (condition-case e (let ((wconf (current-window-configuration)) (result (condition-case e (+lookup--run-handler handler identifier) ((debug error) (if doom-inhibit-log nil (doom--log "Lookup handler %S threw an error: %s" handler e)) 'fail)))) (cond ((eq result 'fail) (set-window-configuration wconf) nil) ((or (get handler '+lookup-async) (eq result 'deferred))) ((or result (null origin) (/= (point-marker) origin)) (prog1 (point-marker) (set-window-configuration wconf))))) ((debug error user-error) (message "Lookup handler %S: %s" handler e) nil))
  +lookup--run-handlers(+lsp-lookup-definition-handler #("getGwsSch" 0 9 (identifier-at-point t fontified t)) #<marker at 273 in get.ts>)
  run-hook-wrapped(+lookup--run-handlers +lsp-lookup-definition-handler #("getGwsSch" 0 9 (identifier-at-point t fontified t)) #<marker at 273 in get.ts>)
  (if arg (let* ((handler (and t (intern-soft (completing-read "Select lookup handler: " (delete-dups ...) nil t))))) (if handler (+lookup--run-handlers handler identifier origin) (user-error "No lookup handler selected"))) (run-hook-wrapped handlers #'+lookup--run-handlers identifier origin))
  (let* ((origin (point-marker)) (handlers (plist-get (list :definition '+lookup-definition-functions :implementations '+lookup-implementations-functions :type-definition '+lookup-type-definition-functions :references '+lookup-references-functions :documentation '+lookup-documentation-functions :file '+lookup-file-functions) prop)) (result (if arg (let* ((handler (and t ...))) (if handler (+lookup--run-handlers handler identifier origin) (user-error "No lookup handler selected"))) (run-hook-wrapped handlers #'+lookup--run-handlers identifier origin)))) (unwind-protect (if (cond ((null result) (message "No lookup handler could find %S" identifier) nil) ((markerp result) (funcall (or display-fn #'switch-to-buffer) (marker-buffer result)) (goto-char result) result) (result)) (progn (save-current-buffer (set-buffer (marker-buffer origin)) (better-jumper-set-jump (marker-position origin))) result)) (set-marker origin nil)))
  +lookup--jump-to(:definition #("getGwsSch" 0 9 (identifier-at-point t fontified t)) nil nil)
  (cond ((null identifier) (user-error "Nothing under point")) ((+lookup--jump-to :definition identifier nil arg)) ((user-error "Couldn't find the definition of %S" (substring-no-properties identifier))))
  +lookup/definition(#("getGwsSch" 0 9 (identifier-at-point t fontified t)) nil)
  funcall-interactively(+lookup/definition #("getGwsSch" 0 9 (identifier-at-point t fontified t)) nil)
  command-execute(+lookup/definition)
```
</details>

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

