### PR TITLE
Bump (non-tree-sitter) typescript-mode to get support for the satisifies keyword

### DIFF
--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -3,7 +3,7 @@
 
 ;; Major modes
 (package! rjsx-mode :pin "b697fe4d92cc84fa99a7bcb476f815935ea0d919")
-(package! typescript-mode :pin "4fcb4594819caf472ae42ea068a1c7795cf07f46")
+(package! typescript-mode :pin "1cf78d7ef8e0a1684a2cf265539c54ccff4068c0")
 
 ;; Tools
 (package! js2-refactor :pin "a0977c4ce1918cc266db9d6cd7a2ab63f3a76b9a")


### PR DESCRIPTION
Bump emacs-typescript/typescript.el@4fcb4594 -> emacs-typescript/typescript.el@1cf78d7e

<!-- ⚠️ Please do not ignore this template! -->

typescript-mode got support for the `satisfies` keyword in https://github.com/emacs-typescript/typescript.el/pull/189, for those of us who haven't moved to tree-sitter for one reason or another. This PR bumps the pin to that version.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->