### PR TITLE
Don't overwrite M-/ in web-mode

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -142,7 +142,7 @@
             "p" #'web-mode-tag-previous
             "s" #'web-mode-tag-select))
 
-        :g  "M-/" #'web-mode-comment-or-uncomment
+        :g  "M-;" #'web-mode-comment-or-uncomment
         :i  "SPC" #'self-insert-command
         :n  "za"  #'web-mode-fold-or-unfold
         :nv "]a"  #'web-mode-attribute-next


### PR DESCRIPTION
The M-/ is a default shortcut for dabbrev-expand, and having one mode where it does something else is confusing. I propose to remove this custom binding and use the default M-; that's used for comment/uncomment  in most other mode

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
