### PR TITLE
Bump Parinfer to v0.9.0, make use of some niceties

### DIFF
--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -17,7 +17,8 @@
                ((featurep :system 'linux)   "parinfer-rust-linux.so")
                ((featurep :system 'windows) "parinfer-rust-windows.dll")
                ((featurep :system 'bsd)     "libparinfer_rust.so")))
-        parinfer-rust-auto-download (not (featurep :system 'bsd)))
+        parinfer-rust-auto-download (not (featurep :system 'bsd))
+        parinfer-rust-disable-troublesome-modes t)
   :config
   (map! :map parinfer-rust-mode-map
         :localleader

--- a/modules/editor/parinfer/packages.el
+++ b/modules/editor/parinfer/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/parinfer/packages.el
 
-(package! parinfer-rust-mode :pin "8df117a3b54d9e01266a3905b132a1d082944702")
+(package! parinfer-rust-mode :pin "d3bfb2745cc0858e2741dc2a2f00a86f456656ec")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

parinfer-rust-mode came out with version 0.9 last week, the headline feature of which is using their own fork of parinfer-rust with better Emacs integration. Notably, the nominated macOS binary is now built for arm64e rather than x86_64, which will break some setups; this is inevitable without a complex workaround (as vanilla parinfer-rust is no longer supported, and the fork doesn't provide an x86_64 binary), and it makes just as many setups now work when they previously did not.

I also enabled the option parinfer-rust-disable-troublesome-modes, which is behind a prompt by default. I was unsure about this but I believe it is in line with the existing decision to enable auto-download and the DOOM philosophy in general: reduce the amount of hassle the user goes through to get things working together.

(Apologies about the commits; I discovered the guidelines when opening this PR. If I have to redo them I will.)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
