### PR TITLE
fix(cli): auto-generated script error

### DIFF
--- a/lisp/doom-cli.el
+++ b/lisp/doom-cli.el
@@ -1350,7 +1350,7 @@ ARGS are options passed to less. If DOOMPAGER is set, ARGS are ignored."
            (doom-cli--exit 0 context))
 
           ((let ((tmpfile (doom-cli--output-file 'output context))
-                 (coding-system-for-write 'utf-8-auto))
+                 (coding-system-for-write 'utf-8))
              (with-file-modes #o700
                (make-directory (file-name-directory tmpfile) t))
              (with-file-modes #o600


### PR DESCRIPTION
The auto-generated script has bom characters on my mac. if bin/doom
exits with code 254, it gives me the below error:
`.../doom.123.0.sh: line 1: #!/usr/bin/env: No such file or directory`


<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
