### PR TITLE
Emacs bug 70914 dont lookup file uri with file exists p on windows

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -502,6 +502,10 @@ relative to `org-directory', unless it is an absolute path."
   (org-link-set-parameters
    "file" :face (lambda (path)
                   (if (or
+                       ;; file uris is not a valid path on windows
+                       ;; ref https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-05/threads.html#00729
+                       ;; emacs <= 29 crashes for (file-exists-p "file://whatever")
+                       (if (featurep :system 'windows) (string-prefix-p "//" path))
                        (file-remote-p path)
                        ;; filter out network shares on windows (slow)
                        (if (featurep :system 'windows) (string-prefix-p "\\\\" path))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -501,10 +501,11 @@ relative to `org-directory', unless it is an absolute path."
   ;; Modify default file: links to colorize broken file links red
   (org-link-set-parameters
    "file" :face (lambda (path)
-                  (if (or (file-remote-p path)
-                          ;; filter out network shares on windows (slow)
-                          (if (featurep :system 'windows) (string-prefix-p "\\\\" path))
-                          (file-exists-p path))
+                  (if (or
+                       (file-remote-p path)
+                       ;; filter out network shares on windows (slow)
+                       (if (featurep :system 'windows) (string-prefix-p "\\\\" path))
+                       (file-exists-p path))
                       'org-link
                     '(warning org-link))))
 


### PR DESCRIPTION
fix(org): avoid `(file-exists-p "file://")` on Windows

Emacs bug#70914 handles `file://whatever` incorrectly, potentially
crashing emacs.

Fixed in emacs commit 350ae75f5c1c47a03560e43e8699781c04c9078a:
```
Avoid crashes on MS-Windows due to invalid UNC file names

* src/w32.c (parse_root): Avoid crashes due to invalid (too short)
UNC names, such as "\\".  (Bug#70914)
```

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


