### PR TITLE
Parinfer bump, take 2

### DIFF
--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -17,7 +17,8 @@
                ((featurep :system 'linux)   "parinfer-rust-linux.so")
                ((featurep :system 'windows) "parinfer-rust-windows.dll")
                ((featurep :system 'bsd)     "libparinfer_rust.so")))
-        parinfer-rust-auto-download (not (featurep :system 'bsd)))
+        parinfer-rust-auto-download (not (featurep :system 'bsd))
+        parinfer-rust-disable-troublesome-modes t)
   :config
   (map! :map parinfer-rust-mode-map
         :localleader

--- a/modules/editor/parinfer/packages.el
+++ b/modules/editor/parinfer/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/parinfer/packages.el
 
-(package! parinfer-rust-mode :pin "8df117a3b54d9e01266a3905b132a1d082944702")
+(package! parinfer-rust-mode :pin "e9a23e136b8c5f1fb718af93c19cd6ed22d8c98c")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Ok, this time my commits conform to convention, the upstream maintainer has confirmed I was overzealous closing the last one, and there's even a new version out. Same caveats from last time apply: this now breaks Intel macOS, but fixes Apple Silicon, and Arm anything else still doesn't work. Perhaps we could provide some auto-compile for upstream-unpackaged platforms but that's out of my wheelhouse.

Next step is to enable for other sexp-based modes, like `dune-project` and `wat`. Maybe I'll get onto that at some point.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
