### PR TITLE
fix(cli) update `comp-async-runnings` to `comp--async-runnings` for emacs 30

### DIFF
--- a/lisp/cli/packages.el
+++ b/lisp/cli/packages.el
@@ -208,7 +208,7 @@ list remains lean."
   (cl-loop with previous = 0
            with timeout = 30
            with timer = 0
-           for pending = (+ (length comp-files-queue) (comp-async-runnings))
+           for pending = (+ (length comp-files-queue) (comp--async-runnings))
            while (not (zerop pending))
            if (/= previous pending) do
            (print! (start "\033[KNatively compiling %d files...\033[1A" pending))


### PR DESCRIPTION
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
Following the upstream Emacs 30 change: https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=fd61cf3976c1c24b5a58923f6520f88db060cacd.
