### PR TITLE
fix: obey the comp namespace change

### DIFF
--- a/lisp/cli/packages.el
+++ b/lisp/cli/packages.el
@@ -208,7 +208,10 @@ list remains lean."
   (cl-loop with previous = 0
            with timeout = 30
            with timer = 0
-           for pending = (+ (length comp-files-queue) (comp-async-runnings))
+           for pending = (+ (length comp-files-queue)
+                            (if (functionp 'comp--async-runnings)
+                                (comp--async-runnings)
+                              (comp-async-runnings)))
            while (not (zerop pending))
            if (/= previous pending) do
            (print! (start "\033[KNatively compiling %d files...\033[1A" pending))


### PR DESCRIPTION
Some of the comp functions were declared private.

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.