### PR TITLE
fix(word-wrap): choose first element if indent-var is list

### DIFF
--- a/modules/editor/word-wrap/autoload.el
+++ b/modules/editor/word-wrap/autoload.el
@@ -66,7 +66,10 @@ wrapped at `fill-column' by configuring `+word-wrap-fill-style'."
         (unless +word-wrap--major-mode-is-visual
           (require 'dtrt-indent) ; for dtrt-indent--search-hook-mapping
           (setq-local +word-wrap--major-mode-indent-var
-                      (caddr (dtrt-indent--search-hook-mapping major-mode)))
+                      (let ((indent-var (caddr (dtrt-indent--search-hook-mapping major-mode))))
+                        (if (listp indent-var)
+                            (car indent-var)
+                          indent-var)))
 
           (advice-add #'adaptive-wrap-fill-context-prefix :around #'+word-wrap--adjust-extra-indent-a))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

There is an edge case where `+word-wrap--major-mode-indent-var` becomes list, not symbol, which is the expected type.

Hence, this PR accounts for that edge case.

Concrete error:
```
(wrong-type-argument symbolp (yaml-indent-offset tab-width))
```
when adjust indenting in yaml file.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
