### PR TITLE
add support for relative path for gf

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -469,7 +469,7 @@ directives. By default, this only recognizes C directives.")
        :nv "K"   #'+lookup/documentation
        :nv "gd"  #'+lookup/definition
        :nv "gD"  #'+lookup/references
-       :nv "gf"  #'+lookup/file
+       :nv "gf"  #'+lookup/open-file-under-cursor
        :nv "gI"  #'+lookup/implementations
        :nv "gA"  #'+lookup/assignments)
       (:when (modulep! :tools eval)

--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -399,6 +399,30 @@ Otherwise, falls back on `find-file-at-point'."
 
         ((user-error "Couldn't find any files here"))))
 
+;;;###autoload
+(defun +lookup/open-file-under-cursor ()
+  "Open the file under cursor and go to position if present.
+
+Supports both relative path and absolute path. If path is relative,
+ then find common ancestor of path and current buffer file. If path is
+ absolute path, go to the file directly. Otherwise, fallback to +lookup/file."
+  (interactive)
+  (let* ((file-path (thing-at-point 'filename t)))
+    (if (file-name-absolute-p file-path)
+        (find-file file-path)
+      (let* ((parts (split-string (buffer-file-name) "/"))
+             (target-filename "")
+             (target-exists nil))
+
+        (dolist (n (number-sequence 1 (length parts)) target-filename)
+          (let* ((new-filename (string-join (append (-take n parts) (list file-path)) "/")))
+            (if (file-exists-p new-filename)
+                (setq target-filename new-filename
+                      target-exists t))))
+
+        (if target-exists
+            (find-file target-filename)
+          (+lookup/file))))))
 
 ;;
 ;;; Dictionary


### PR DESCRIPTION
In evil mode, `gf` doest work when path under cursor has common ancstor with current buffer file. This seems to be a common situation. For example, suppose I have the following files:

```
project
└── src
    ├── a
    │   └── a.h
    └── b
        └── b.h
```
and in b.h, the file `a/a.h` is included:

```
// b/b.h
#include "a/a.h"
```
The `gf` command was mapped to `+lookup/file`. If I want to open `a/a.h` file using `gf` in `b.h` file, it doest not work. `+lookup/file` seems to lookup files in some predefined directories.

To solve this problem, I add a new function `+lookup/open-file-under-cursor`:
1. Find path under cursor.
2. If the path is absolute path, then try opening the file using `find-file`.
3. If the path is a relative path, find directory of current buffer file, then try every combination of sub directory and path under cursor. If any of them exists, then we found the target, try opening the file.
4. Otherwise, fallback to `+lookup/file` as the origin logic.

And also I changed the `gf` key mapping in `modules/editor/evil/config.el`:
```
:nv "gf"  #'+lookup/open-file-under-cursor
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
