### PR TITLE
fix(lib): doom-project-find-file: use transient project

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -152,11 +152,12 @@ If DIR is not a project, it will be indexed (but not cached)."
           ((and (bound-and-true-p ivy-mode)
                 (fboundp 'counsel-file-jump))
            (call-interactively #'counsel-file-jump))
-          ((when-let ((pr (project-current nil dir)))
-             (project-find-file-in nil nil pr)))
           ((and (bound-and-true-p helm-mode)
                 (fboundp 'helm-find-files))
            (call-interactively #'helm-find-files))
+          ((when-let ((project-current-directory-override t)
+                      (pr (project-current t dir)))
+             (project-find-file-in nil nil pr)))
           ((call-interactively #'find-file)))))
 
 ;;;###autoload


### PR DESCRIPTION
If DIR is not a project and does not have root markers, create a transient project instead. This ensures that `project-find-file-in`, and by extension Vertico, is still used in non-project directories instead of falling back to `find-file`

`+vertico/consult-fd-or-find` was removed from `doom-project-find-file` in 1b0af3bfc747, with the intention that Vertico users would instead use Vertico's integration with `project-find-file-in`. However, `project-current` returns `nil` for folders that are not projects and do not have any root markers. This causes `doom-project-find-file` to fallback to `find-file` for commands which use `doom-project-find-file` on directories which aren't necessarily projects, such as `doom/find-file-in-private-config`, `+default/find-in-notes`, and especially `+default/find-file-under-here`. This means that each of these commands ends up having the same behavior as their `browse` counterparts rather than recursively searching through the target directory.

I moved the `project-find-file-in` clause below the `helm-find-files` clause, since the transient project would always take priority over `helm-find-files`, rather than only taking priority when a project exists in that directory as before. If this approach isn't ideal, perhaps there could be two blocks for `project-find-file-in`, one before `helm-find-files` which does not set `project-current-directory-override`, and one after `helm-find-files` which does.

Ref: 1b0af3bfc747

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
