### PR TITLE
fix(lib): reset font size before setting big font mode

### DIFF
--- a/lisp/lib/fonts.el
+++ b/lisp/lib/fonts.el
@@ -177,4 +177,5 @@ Also resizees `doom-variable-pitch-font' and `doom-serif-font'."
          (font-get (doom-normalize-font doom-big-font) :size))
        t `((doom-font . ,doom-big-font)))
     ;; Resize the current font
+    (doom-adjust-font-size nil)
     (doom-adjust-font-size (if doom-big-font-mode doom-big-font-increment))))


### PR DESCRIPTION
Calling `(doom-adjust-font-size 1)` repeatedly would keep increase the font size because an increment is passed.

When loading themes, the `doom-big-font-mode` minor mode gets loaded again therefore it causes the font to get increased.

Fix: #7845

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
