### PR TITLE
fix(fold): don't expect evil-vimish-fold

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -169,8 +169,9 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
                     (lambda ()
                       (when (featurep 'vimish-fold)
                         (if (> count 0)
-                            (evil-vimish-fold/next-fold count)
-                          (evil-vimish-fold/previous-fold (- count))))
+                            (dotimes (_ count) (vimish-fold-next-fold))
+                          (dotimes (_ count)
+                            (vimish-fold-previous-fold (- count)))))
                       (if (/= (point) orig-pt) (point)))
                     (lambda ()
                       ;; ts-fold does not define movement functions so we need to do it ourselves


### PR DESCRIPTION
This module is also used by non-Evil users. Also,
`evil-vimish-fold/next-fold` and friends just wrap the corresponding vimish-fold functions in `dotimes`, anyway.