### PR TITLE
bump: :tools magit forge

### DIFF
--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,9 +1,9 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "ea0f07e54967197ac0b072a69ba314314a4080c1")
+(when (package! magit :pin "9d1f8db507e080e032943a3ed1445bd8d9aaa9fc")
   (when (modulep! +forge)
-    (package! forge :pin "4adb94d23c8f28ea3b15757936c2203b3376586a")
+    (package! forge :pin "0102834bb7c872c8a3f77cabf5221e8199346c43")
     (package! code-review
       :recipe (:host github
                :repo "doomelpa/code-review"


### PR DESCRIPTION
magit/forge@4adb94d23c8f -> magit/forge@0102834bb7c8 magit/magit@ea0f07e54967 -> magit/magit@9d1f8db507e0

Bump magit-forge and magit; closql has changed its interface, and forge needed to update, so here we are. I've run with this bump and it's all working fine.

/cc https://github.com/magit/forge/commit/fb272bd93bf1793606728d39f1dbf59b64cc002b

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

