### PR TITLE
fix(ansible): update emacs-ansible to fetch from the new repo on gitlab

### DIFF
--- a/modules/tools/ansible/packages.el
+++ b/modules/tools/ansible/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/ansible/packages.el
 
-(package! ansible :recipe (:nonrecursive t) :pin "b4dca00f89334392d770a7a67fffc935ec7354aa")
+(package! ansible :recipe (:nonrecursive t) :pin "eebb2fb49d3c0a0586d1e4ead9ba618c7d003cae")
 (package! ansible-doc :pin "86083a7bb2ed0468ca64e52076b06441a2f8e9e0")
 (package! jinja2-mode :pin "03e5430a7efe1d163a16beaf3c82c5fd2c2caee1")
 (package! yaml-mode :pin "7b5ce294fb15c2c8926fa476d7218aa415550a2a")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
As per emacs-ansible old repo's README https://github.com/k1LoW/emacs-ansible the package moved into gitlab
so I just updated `:pin` in `packages.el` to read from the new source https://gitlab.com/emacs-ansible/emacs-ansible

Before:
<img width="1074" alt="Screenshot 2024-07-09 at 12 57 21 AM" src="https://github.com/doomemacs/doomemacs/assets/10425180/2c17e8d3-102c-4160-afcd-b516bd2f163b">

After:
<img width="1017" alt="Screenshot 2024-07-09 at 12 57 40 AM" src="https://github.com/doomemacs/doomemacs/assets/10425180/0f1f31b7-66c5-4265-8b39-6c431be6fbf1">



-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
