### PR TITLE
fix(format): apheleia doesn't invoke lsp formatter

### DIFF
--- a/modules/editor/format/autoload/lsp.el
+++ b/modules/editor/format/autoload/lsp.el
@@ -44,9 +44,9 @@ mode unconditionally, call `+format-with-lsp-mode' instead."
 ;;; Apheleia formatters
 
 ;;;###autoload
-(cl-defun +format-lsp-buffer (&rest plist &key callback &allow-other-keys)
+(cl-defun +format-lsp-buffer (&rest plist &key buffer callback &allow-other-keys)
   "Format the current buffer with any available lsp-mode or eglot formatter."
-  (if-let* ((fn (+format--lsp-fn))
+  (if-let* ((fn (with-current-buffer buffer (+format--lsp-fn)))
             ((apply fn plist)))
       (funcall callback)
     (funcall callback "LSP server doesn't support formatting")))


### PR DESCRIPTION
apheleia runs `+format-lsp-buffer` in a scratch buffer (where lsp is disabled) so checking for an active lsp mode to invoke the right formatter fails. Change `+format--lsp-fn` to run `+format--lsp-fn` in context of main buffer rather than apheleia's scratch buffer so that the lsp mode can be discovered.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).