### PR TITLE
fix(lib): avoid writing custom faces to custom.el

### DIFF
--- a/lisp/lib/themes.el
+++ b/lisp/lib/themes.el
@@ -31,9 +31,16 @@ all themes. It will apply to all themes once they are loaded."
            (dolist (theme (ensure-list (or ,theme 'user)))
              (when (or (eq theme 'user)
                        (custom-theme-enabled-p theme))
-               (apply #'custom-theme-set-faces theme
-                      (mapcan #'doom--custom-theme-set-face
-                              (list ,@specs)))))))
+               ;; Skip the 'saved-face(-comment) properties to avoid that the
+               ;; customizations are written to custom.el when saving other
+               ;; customized settings such as variables (e.g., triggered by
+               ;; lisp code calling customize-save-variable).
+               (letf! (defun put (sym prop val)
+                        (unless (memq prop (list 'saved-face 'saved-face-comment))
+                          (funcall put sym prop val)))
+                 (apply #'custom-theme-set-faces theme
+                        (mapcan #'doom--custom-theme-set-face
+                                (list ,@specs))))))))
        ;; Apply the changes immediately if the user is using the default theme
        ;; or the theme has already loaded. This allows you to evaluate these
        ;; macros on the fly and customize your faces iteratively.


### PR DESCRIPTION
custom-theme-set-faces! calls custom-theme-set-faces, which will mark the customizations for saving to custom.el. But custom-theme-set-faces! is not intended for permanent customizations. Fix this by intercepting the relevant put call.

The actual saving is performed by custom-save-all, which will be triggered whenever anything else writes to custom.el, e.g., when lisp code uses customize-save-variable.

----

I've seen this issue in my config, and it has also been reported here:
https://discourse.doomemacs.org/t/how-to-best-change-face-settings-custom-set-faces-or-set-face-attribute/2721/3
And I had fixed a very similar bug when I was still using spacemacs:
https://github.com/syl20bnr/spacemacs/issues/5353#issuecomment-1693211609

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.


