### PR TITLE
tweak(markdown): fontify code blocks natively

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -23,6 +23,7 @@ capture, the end position, and the output buffer.")
         markdown-gfm-additional-languages '("sh")
         markdown-make-gfm-checkboxes-buttons t
         markdown-fontify-whole-heading-line t
+        markdown-fontify-code-blocks-natively t
 
         ;; `+markdown-compile' offers support for many transpilers (see
         ;; `+markdown-compile-functions'), which it tries until one succeeds.


### PR DESCRIPTION
That's a neat feature if you have code blocks in Markdown. I've been using this for a while and I haven't encountered any drawbacks.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
