### PR TITLE
Fix deft keybind

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -608,7 +608,8 @@
 
        :desc "Toggle last org-clock"        "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"     "C" #'org-clock-cancel
-       :desc "Open deft"                    "d" #'deft
+       (:when (modulep! :ui deft)
+         :desc "Open deft"                    "d" #'deft)
        (:when (modulep! :lang org +noter)
         :desc "Org noter"                  "e" #'org-noter)
 


### PR DESCRIPTION
- **feat(corfu): update smart tab completion**
- **bump: :editor evil**
- **bump: :editor snippets**
- **bump: :tools debugger lsp**
- **bump: :lang scala**
- **bump: :tools magit :emacs vc**
- **bump: :completion**
- **bump: :tools**
- **bump: :term eshell**
- **fix(org): org-download: remove unneeded advice**
- **fix(cli): doom upgrade: void-variable num**
- **refactor: startup optimizations**
- **release(modules): 24.04.0-dev**
- **fix(lib): find-subling-file-search: wrong-number-of-args error**
- **fix(cc): make *.c(c|pp) siblings of *.h(h|pp) files**
- **fix(web): make *.((s[ac]|le)ss|styl) siblings of *.css**
- **fix(lib): sudo-{find,this}-file: disable auto-save**
- **refactor: doom--last-frame: remove unused symbol**
- **bump: :tools pdf**
- **fix(julia): duplicate popup rules**
- **docs(julia): reformat & fix package/flag links**
- **refactor(corfu): use hook symbols in add-hook! calls**
- **refactor: remove redundant auto-mode-alist entries**
- **fix(mu4e): void-function mu4e-clear-caches error**
- **fix(rust): lsp-mode: produce better hover info**
- **feat(lib): sudo-{find,this}-file: invoke save-place**
- **refactor(eval): avoid seq-uniq & cl-{first,second}**
- **fix(factor): repl handler**
- **fix(factor): package association for lookup handlers & keybinds**
- **fix(factor): handle fuel popups**
- **bump: :lang factor**
- **fix(vc): *vc-{diff,change-log}* popup rules**
- **fix(corfu): prevent void-variable error**
- **fix(vertico): missing command error in consult**
- **perf(tabs): rate limit centaur-tabs-buffer-update-groups**
- **bump: :editor evil**
- **fix(lib): remove-recent-file: improve completion UI**
- **fix(workspaces): dual *Warnings* windows at startup**
- **bump: :lang scala**
- **bump: :app everywhere**
- **bump: :editor snippets**
- **bump: :ui doom**
- **fix(syntax): flycheck popups clearing active region**
- **tweak(corfu): update dabbrev-ignore-buffer-modes**
- **fix(eval): warnings after eval error**
- **fix(helm): helm-descbinds-disable-which-key = nil**
- **tweak(helm): helm-always-two-windows = t**
- **fix: doom-init-fonts-h: don't run more than needed**
- **refactor: menu-bar (re)initialization on MacOS**
- **nit: reformat+revise comments**
- **fix: doom-run-hook-on: check context & chain hooks unconditionally**
- **fix(spell): spell-fu: remove unneeded advice**
- **revert: org**
- **doc(corfu): update troubleshooting section**
- **fix: doom-initialize-core-packages: extract plist from alist**
- **fix(cli): doom-packages-ensure: ensure local packages are built**
- **fix(direnv): fix void function error in emacs30**
- **bump: :lang go**
- **tweak(default): remove +vc/gutter-hydra keybind**
- **tweak(default): ensure '<leader> g S' is silent**
- **fix(evil): ]f/[f opening broken symlinks**
- **fix(config): fix corfu smart tab behavior**
- **fix: obey the comp namespace change**
- **fix(magit): forge-browse-dwim -> forge-browse**
- **fix(gdscript): replace removed functions with new binding**
- **feat(debugger): add gdscript dap-mode support**
- **fix(evil): bind git time machine without vc-gutter**
- **refactor(lib): use ripgrep instead of `git grep`**
- **fix(cli): auto-generated script error**
- **nit(org): reformat or block**
- **fix(org): avoid `(file-exists-p "file://")` on Windows**
- **fix: suppress lexical-binding warnings on 30+**
- **perf(cli): bin/doom startup**
- **perf(chinese): lazy load liberime**
- **tweak(web): remove M-/ keybind**
- **bump: :lang emacs-lisp scheme web zig**
- **bump: :editor parinfer**
- **bump: :tools magit :emacs vc**
- **bump: :tools debugger lsp**
- **bump: :core**
- **fix(word-wrap): choose first element if indent-var is list**
- **fix(ligatures): set-font-ligatures! reset on nil**
- **tweak(wanderlust): hide more technical headers**
- **tweak(wanderlust): switch to use UTF-8 as default charset**
- **bump: :email wanderlust**
- **bump: :completion**
- **feat(lookup): +lookup/file: search file tree for relative paths**
- **bump: :lang javascript**
- **docs: update supported Emacs version in version check**
- **refactor(cli): bin/doomscript: simplify redirs, update commment**
- **fix(tabs): workaround for ema2159/centaur-tabs#231**
- **fix(tabs): defer centaur-tabs-mode in daemon sessions**
- **fix(tabs): reload centaur-tabs when changing themes**
- **docs(dired): update flags & package listing**
- **bump: :core**
- **bump: :emacs undo**
- **bump: :tools tree-sitter**
- **release(modules): 24.07.0-dev**
- **fix: 'doom sync' generates autoload files for symbolic link files**
- **fix(ocaml): fix incorrect package name in README**
- **feat(ocaml): switch to using opam-switch-mode**
- **bump: :ui tabs**
- **bump: :tools**
- **bump: :ui**
- **bump: :tools tree-sitter**
- **bump: :lang org**
- **refactor!(vc-gutter): drop git-gutter for diff-hl**
- **bump: :editor**
- **refactor(lib): tweak user-error messages**
- **feat(lib): doom-print: allow lexical redirection**
- **fix(lib): print!: don't resolve printed symlinks**
- **fix(lib): doom/bumpify-diff: ignore malformed package! statements**
- **bump: :lang org**
- **fix(dired): update dirvish keybindings**
- **feat(dired): add subtree bindings to dirvish**
- **fix(god): cursor color change**
- **bump: ws-butler**
- **refactor!(ophints): replace volatile-highlights w/ goggles**
- **docs(mu4e): instructions for SMTP setup**
- **bump: :lang clojure**
- **fix(fold): only enable ts-fold-mode in tree-sitter buffers**
- **feat(sh): assoc zsh compdef files with sh-mode**
- **bump: :editor fold**
- **fix(fold): don't expect evil-vimish-fold**
- **fix(fold): properly handle recursive folds**
- **fix(lookup): project search backend no-op**
- **bump: :lang**
- **fix(lib): don't kill buffers visible in another frame**
- **fix(fold): fold-levels off-by-one**
- **fix(fold): +fold/next: actually support outlines**
- **fix(org): attachment image inline preview**
- **bump: :ui tabs**
- **fix(cli): suppress secondary prompts from straight on -!/--force**
- **docs: fix badges & update 29.3->29.4**
- **refactor: avoid needless macro calls**
- **fix(org): serve evil-org-mode from @doomelpa**
- **fix(org): revise org-crypt init**
- **tweak(org): org-effort-property = EFFORT**
- **fix(lsp): revert refactor of map! call**
- **refactor(org): remove unneeded advice**
- **bump: :app**
- **bump: :os tty :input chinese**
- **bump: :term**
- **fix(python): ensure anaconda-mode and +lsp are mutually exclusive**
- **refactor(lsp): remove lsp-racket fix**
- **feat(common-lisp): make quicklisp directory configurable**
- **tweak(syntax): hide posframe on next user input**
- **release(modules): 24.08.0-dev**
- **module: remove :tools rgb**
- **module: remove :app twitter**
- **module: remove :tools taskrunner**
- **dev: update CODEOWNERS**
- **refactor(evil): remove unneeded advice**
- **dev: format CODEOWNERS with more whitespace**
- **fix(python): wrong-number-of-args error for eglot users**
- **tweak(treemacs): use treemacs-add-and-display-current-project-exclusively**
- **refactor!: remove pcre2el package**
- **refactor!(org): remove org-yt**
- **refactor(org): remove redundant org-catch-invisible-edits setting**
- **fix(spell): initialize ispell fully**
- **bump: :ui doom modeline**
- **module: remove :ui hydra**
- **refactor(php): remove php-cs-fixer**
- **refactor!(org): remove ob-ipython**
- **refactor!(python): remove lsp-python-ms**
- **refactor(workspaces): +workspace/delete: rename to +workspace/kill**
- **fix(default): replace void function +yas-active-p**
- **fix(lib): reset font size before setting big font mode**
- **fix(lib): don't call doom-adjust-font-size twice**
- **refactor(evil): +evil--window-swap: no-op if on edge**
- **fix(zig): update zls download URL**
- **fix(org): reload org-mode in half-loaded capture buffers**
- **refactor(format): redesign module**
- **feat(org): add +org/reformat-at-point command**
- **refactor(org): remove unused hooks**
- **fix(cli): wrong-number-of-args error on choosing 'abort'**
- **tweak(lib): doom-project-find-file: use transient project**
- **feat(literate): add +literate/find-heading command**
- **tweak(org): use consult-outline instead of imenu**
- **fix(format): add lsp functions**
- **fix(format): eglot-managed{,-mode}-hook hook**
- **fix(mu4e): remove stray +workspace-delete invokation**
- **bump: :tools magit**
- **tweak(beancount): +beancount/balance w/ prefix arg**
- **fix(format): LSP formatters before Apheleia is loaded**
- **refactor(format): use eglot-server-capable**
- **feat(format): add +format-inhibit alias**
- **tweak(default): bind '<leader> g U' to magit-unstage-buffer-file**
- **docs(format): revise docstrings and comments**
- **tweak(format): doom-debug-variables: add apheleia-log-debug-info**
- **refactor!(format): simplify & gate lsp/eglot impl behind +lsp**
- **docs(format): revise README.org**
- **refactor(format): +format/org-block: make arg optional**
- **fix(python): missing labels for keybind prefixes**
- **fix(format): void function +format-with-lsp-maybe-h error**
- **docs(format): hacks: mention save-buffer advice**
- **bump!: :lang latex**
- **bump: :tools ansible**
- **fix(format): apheleia doesn't invoke lsp formatter**
- **perf(vc-gutter): diff-hl-update-async = t**
- **fix(latex): auctex: build tex-site.el**
- **fix(lib): doom-plist-merge causing side-effects**
- **refactor(org): remove +org--recenter-after-follow-link-a**
- **refactor(lib): don't use smartparens' API**
- **perf: suppress local-vars hooks in temp buffers**
- **refactor(org): org-src-lang-modes: move md alias**
- **tweak: unbind SPC in y-or-n-p prompts**
- **fix(evil): q/Q keybinds in view-mode**
- **fix(org): restart org in all optimized buffers**
- **nit(org): update outdated comment**
- **fix(lib): avoid writing customized faces to custom.el**
- **tweak(markdown): fontify code blocks natively**
- **perf(vc-gutter): optimize bitmaps**
- **refactor(vc-gutter): simplify & DRY**
- **fix(ivy): counsel-rg dying on non-zero exit code**
- **fix(ivy): +counsel-rg-suppress-error-code-a**
- **fix(lib): avoid writing customized faces to custom.el (take 2)**
- **fix(lib): avoid writing customized faces to custom.el (take 3)**
- **fix(lib): autoload doom--run-customize-theme-hook**
- **fix(deft): only bind open deft if the module is enabled**

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
