### PR TITLE
Fix "File mode specification error: (void-function ansible)"

### DIFF
--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -31,5 +31,5 @@
 
 (def-project-mode! +ansible-yaml-mode
   :modes '(yaml-mode)
-  :add-hooks '(ansible ansible-auto-decrypt-encrypt ansible-doc-mode)
+  :add-hooks '(ansible-mode ansible-auto-decrypt-encrypt ansible-doc-mode)
   :files (or "roles/" "tasks/main.yml" "tasks/main.yaml"))


### PR DESCRIPTION
During the last update to anisble mode ( commit
af2b1a62dcb55c6c2f4b823a1f5c2926548ab97d ) the `ansible` function got renamed to ansible-mode and, when opening ansible files, multiple things would fail. This commit reflects the change done in commit eebb2fb49d3c0a0586d1e4ead9ba618c7d003cae in the repo gitlab.com/emacs-ansible/emacs-ansible.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
