### PR TITLE
bump: :syntax flycheck & minor flycheck fixes

### DIFF
--- a/modules/checkers/syntax/config.el
+++ b/modules/checkers/syntax/config.el
@@ -74,7 +74,7 @@
   (if (modulep! +icons)
       (setq flycheck-posframe-warning-prefix "⚠ "
             flycheck-posframe-info-prefix "ⓘ "
-            flycheck-posframe-error-prefix "⚠ ")
+            flycheck-posframe-error-prefix "⮾ ")
     (setq flycheck-posframe-warning-prefix "[?] "
           flycheck-posframe-info-prefix "[i] "
           flycheck-posframe-error-prefix "[!] "))

--- a/modules/checkers/syntax/packages.el
+++ b/modules/checkers/syntax/packages.el
@@ -2,7 +2,7 @@
 ;;; checkers/syntax/packages.el
 
 (unless (modulep! +flymake)
-  (package! flycheck :pin "02148c6ce7edb0fd0986460db327cc9463939747")
+  (package! flycheck :pin "e8d1472aeab6ac4e19c8339e6be93e91e878f819")
   (package! flycheck-popup-tip :pin "ef86aad907f27ca076859d8d9416f4f7727619c6")
   (when (modulep! +childframe)
     (package! flycheck-posframe :pin "19896b922c76a0f460bf3fe8d8ebc2f9ac9028d8")))


### PR DESCRIPTION
https://github.com/flycheck/flycheck/commit/02148c6ce7edb0fd0986460db327cc9463939747 -> https://github.com/flycheck/flycheck/commit/e8d1472aeab6ac4e19c8339e6be93e91e878f819

---

[tweak(syntax): use close-circle-outline icon for errors](https://github.com/doomemacs/doomemacs/pull/7942/commits/a7a618786435eacbed966c8a6697bb09dd560787)

The same is used by [doom-modeline][1] to show flycheck errors.

[1]: https://github.com/seagle0128/doom-modeline/blob/1505c13564b83e44d3187611e326a48b742cad3a/doom-modeline-segments.el#L818

