### PR TITLE
fix(vertico): orderless filtering

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -74,30 +74,23 @@ orderless."
           (completion-styles +vertico-company-completion-styles))
       (apply fn args)))
 
+  (setq orderless-affix-dispatch-alist
+        `((?! . ,#'orderless-without-literal)
+          (?& . ,#'orderless-annotation)
+          (?% . ,#'char-fold-to-regexp)
+          (?` . ,#'orderless-initialism)
+          (?= . ,#'orderless-literal)
+          (?^ . ,#'orderless-literal-prefix)
+          (?~ . ,#'orderless-flex)))
+
   (defun +vertico-orderless-dispatch (pattern _index _total)
     (cond
      ;; Ensure $ works with Consult commands, which add disambiguation suffixes
      ((string-suffix-p "$" pattern)
-      `(orderless-regexp . ,(concat (substring pattern 0 -1) "[\x200000-\x300000]*$")))
-     ;; Ignore single !
-     ((string= "!" pattern) `(orderless-literal . ""))
-     ;; Without literal
-     ((string-prefix-p "!" pattern) `(orderless-without-literal . ,(substring pattern 1)))
-     ;; Annotation
-     ((string-prefix-p "&" pattern) `(orderless-annotation . ,(substring pattern 1)))
-     ((string-suffix-p "&" pattern) `(orderless-annotation . ,(substring pattern 0 -1)))
-     ;; Character folding
-     ((string-prefix-p "%" pattern) `(char-fold-to-regexp . ,(substring pattern 1)))
-     ((string-suffix-p "%" pattern) `(char-fold-to-regexp . ,(substring pattern 0 -1)))
-     ;; Initialism matching
-     ((string-prefix-p "`" pattern) `(orderless-initialism . ,(substring pattern 1)))
-     ((string-suffix-p "`" pattern) `(orderless-initialism . ,(substring pattern 0 -1)))
-     ;; Literal matching
-     ((string-prefix-p "=" pattern) `(orderless-literal . ,(substring pattern 1)))
-     ((string-suffix-p "=" pattern) `(orderless-literal . ,(substring pattern 0 -1)))
-     ;; Flex matching
-     ((string-prefix-p "~" pattern) `(orderless-flex . ,(substring pattern 1)))
-     ((string-suffix-p "~" pattern) `(orderless-flex . ,(substring pattern 0 -1)))))
+      `(orderless-regexp . ,(concat (substring pattern 0 -1) "[\x200000-\x300000]*$")))))
+
+  (add-to-list 'orderless-style-dispatchers '+vertico-orderless-dispatch)
+
   (add-to-list
    'completion-styles-alist
    '(+vertico-basic-remote
@@ -109,7 +102,6 @@ orderless."
         ;; note that despite override in the name orderless can still be used in
         ;; find-file etc.
         completion-category-overrides '((file (styles +vertico-basic-remote orderless partial-completion)))
-        orderless-style-dispatchers '(+vertico-orderless-dispatch)
         orderless-component-separator #'orderless-escapable-split-on-space)
   ;; ...otherwise find-file gets different highlighting than other commands
   (set-face-attribute 'completions-first-difference nil :inherit nil))


### PR DESCRIPTION
The original implementation of `+vertico-orderless-dispatch` match pattern by prefix and suffix in pairs. In that case, '=&&' will go for branch `(string-suffix-p "&" pattern)`, not `(string-prefix-p "=" pattern)`, which fail to filter literal '&&'.

We probably should match all prefixes first, then all suffixes. Just like orderless does.

Ref: https://github.com/oantolin/orderless/blob/178b0c55f2cb49f27cd972f731ea45e5d3aea262/orderless.el#L159

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
