### PR TITLE
refactor(irc): Remove obsolete workaround for tls.el, it's obsolete

### DIFF
--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -141,10 +141,10 @@ playback.")
 
 
 (use-package! circe-color-nicks
-  :hook (circe-channel-mode . enable-circe-color-nicks)
   :config
   (setq circe-color-nicks-min-constrast-ratio 4.5
-        circe-color-nicks-everywhere t))
+        circe-color-nicks-everywhere t)
+  (enable-circe-color-nicks))
 
 
 (use-package! circe-new-day-notifier

--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -220,6 +220,9 @@ Courtesy of esh-mode.el"
   ;; enable a horizontal line marking the last read message
   (add-hook 'lui-mode-hook #'enable-lui-track-bar)
 
+  ;; Make modes like Circe who use Lui understand IRC colors
+  (enable-lui-irc-colors)
+
   (add-hook! 'lui-mode-hook
     (defun +irc-init-lui-margins-h ()
       (setq lui-time-stamp-position 'right-margin

--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -94,24 +94,6 @@ playback.")
   (add-hook 'circe-mode-hook #'+irc--add-circe-buffer-to-persp-h)
   (add-hook 'circe-mode-hook #'turn-off-smartparens-mode)
 
-  ;; HACK Fix #1862: circe hangs on TLS connections when using OpenSSL versions
-  ;;      > 1.1.0, where tls.el does not correctly determine the end of the info
-  ;;      block. This fixes proposed in jorgenschaefer/circe#340
-  (setq-hook! 'circe-mode-hook
-    tls-end-of-info
-    (concat "\\("
-            ;; `openssl s_client' regexp. See ssl/ssl_txt.c lines 219-220.
-            ;; According to apps/s_client.c line 1515 `---' is always the last
-            ;; line that is printed by s_client before the real data.
-            "^    Verify return code: .+\n\\(\\|^    Extended master secret: .+\n\\)\\(\\|^    Max Early Data: .+\n\\)---\n\\|"
-            ;; `gnutls' regexp. See src/cli.c lines 721-.
-            "^- Simple Client Mode:\n"
-            "\\(\n\\|"                           ; ignore blank lines
-            ;; According to GnuTLS v2.1.5 src/cli.c lines 640-650 and 705-715 in
-            ;; `main' the handshake will start after this message. If the
-            ;; handshake fails, the programs will abort.
-            "^\\*\\*\\* Starting TLS handshake\n\\)*"
-            "\\)"))
 
   (defadvice! +irc--circe-run-disconnect-hook-a (&rest _)
     "Runs `+irc-disconnect-hook' after circe disconnects."

--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -237,4 +237,5 @@ Courtesy of esh-mode.el"
 
 
 (use-package! lui-autopaste
-  :hook (circe-channel-mode . enable-lui-autopaste))
+              :config
+              (enable-lui-autopaste))


### PR DESCRIPTION
tls.el is obsolete in Emacs 26.1 or later, it's no longer used in Circe.
The workaround is no longer required.
See also:
emacs-circe/circe#340
emacs-circe/circe#377
doomemacs/doomemacs#1862