### PR TITLE
fix(vc-gutter): check 'diff-hl-disable-on-remote is bound

### DIFF
--- a/modules/ui/vc-gutter/config.el
+++ b/modules/ui/vc-gutter/config.el
@@ -69,7 +69,7 @@
     (defun +vc-gutter-enable-maybe-h ()
       "Conditionally enable `diff-hl-dired-mode' in dired buffers.
 Respects `diff-hl-disable-on-remote'."
-      (unless (and diff-hl-disable-on-remote
+      (unless (and (bound-and-true-p diff-hl-disable-on-remote)
                    (file-remote-p default-directory))
         (diff-hl-dired-mode +1))))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This is a trivial bug fix for an issue that I believed appeared in 7c5d8641a141777dd48ba52bc1406a534959c724.

I was getting this message on startup: "Symbol’s value as variable is void: diff-hl-disable-on-remote".

I believe it's as simple as checking whether the variable is bound, and considering unbound equivalent to false.

I hope you don't mind that I didn't create an issue to track this -- it felt like a lot of overhead for a tiny fix.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
