### PR TITLE
docs(org): Remove org-yt custom link type

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -235,7 +235,6 @@ They are (with examples):
 - ~wolfram:sin(x^3)~
 - ~wikipedia:Emacs~
 - ~youtube:P196hEuA_Xc~ (link only)
-- ~yt:P196hEuA_Xc~ (like =youtube=, but includes an inline preview of the video)
 
 ** evil-mode keybindings
 For =evil-mode= users, an overview of org-mode keybindings is provided [[https://github.com/Somelauw/evil-org-mode/blob/master/README.org#keybindings][here]].


### PR DESCRIPTION
The org-yt package has been removed via commit 321f2d2249a5a933e4a4a3ef684e30ce0a7a74cf therefore the custom link type `yt:...` is no longer supported.
Let's update the docs to no longer include it either 😊 

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

