### PR TITLE
fix(corfu): do not use corfu's minibuffer setup

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -56,6 +56,7 @@ TAB/S-TAB.")
   (setq corfu-auto t
         corfu-auto-delay 0.18
         corfu-auto-prefix 2
+        global-corfu-minibuffer nil
         global-corfu-modes '((not erc-mode
                                   circe-mode
                                   help-mode


### PR DESCRIPTION
This PR prevents Corfu minibuffer completion from being activated always, even in Vertico after a future bump.

Upstream, Corfu has added minibuffer completion by default so this PR disables it since we already have our own hook & code that is working better for our purposes, i.e. our solution is tuned to work in tandem with vertico, helm, etc. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.