### PR TITLE
tweak(cli): rebuild silently if --rebuild is set

### DIFF
--- a/lisp/cli/sync.el
+++ b/lisp/cli/sync.el
@@ -73,7 +73,7 @@ OPTIONS:
           (when (and old-host (not (equal old-host (system-name))))
             (print! (warn "Your system has changed since last sync"))
             (setq to-rebuild t))
-          (when (and to-rebuild (not (doom-cli-context-suppress-prompts-p context)))
+          (when (and to-rebuild (not rebuild?) (not (doom-cli-context-suppress-prompts-p context)))
             (cond (nobuild?
                    (print! (warn "Packages must be rebuilt, but -B has prevented it. Skipping...")))
                   ((doom-cli-context-get context 'upgrading)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

When running `doom sync --rebuild` after emacs upgrade the user is prompted with "Installed packages must be rebuilt. Do so now?", even though doom was explicitly instructed to rebuild. This PR removes this prompt when the `--rebuild` option is provided


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
