### PR TITLE
feat(plantuml): support fallback to system jar

### DIFF
--- a/modules/lang/plantuml/config.el
+++ b/modules/lang/plantuml/config.el
@@ -5,8 +5,27 @@
   :init
   (setq plantuml-jar-path (concat doom-data-dir "plantuml.jar")
         org-plantuml-jar-path plantuml-jar-path)
+  (let ((doom-jar-path (concat doom-data-dir "plantuml.jar"))
+        (system-jar-path "/usr/share/plantuml/plantuml.jar"))
+    (setq plantuml-jar-path
+          (cond ((file-exists-p doom-jar-path) doom-jar-path)
+                ((file-exists-p system-jar-path) system-jar-path)
+                (t doom-jar-path)))
+    (setq org-plantuml-jar-path plantuml-jar-path))
+
   :config
   (set-popup-rule! "^\\*PLANTUML" :size 0.4 :select nil :ttl 0)
+  (advice-add 'plantuml-download-jar :around
+              (lambda (orig-fun &rest args)
+                (let ((plantuml-jar-path (concat doom-data-dir "plantuml.jar")))
+                  (apply orig-fun args)
+                  (let ((doom-jar-path (concat doom-data-dir "plantuml.jar"))
+                        (system-jar-path "/usr/share/plantuml/plantuml.jar"))
+                    (setq plantuml-jar-path
+                          (cond ((file-exists-p doom-jar-path) doom-jar-path)
+                                ((file-exists-p system-jar-path) system-jar-path)
+                                (t doom-jar-path)))
+                    (setq org-plantuml-jar-path plantuml-jar-path)))))
 
   (setq plantuml-default-exec-mode
         (cond ((file-exists-p plantuml-jar-path) 'jar)


### PR DESCRIPTION
If plantuml.jar does not exist in doom-data-dir, but system plantuml.jar exists, fallback to system plantuml.jar. Advice plantuml-donwload-jar function to download to doom-data-dir, instead of attempting to overwrite system plantuml.jar.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
