### PR TITLE
fix(format): avoid `+javascript-npm-conf` definition void error

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -102,5 +102,6 @@ This is controlled by `+format-on-save-disabled-modes'."
                                                 ".prettierrc.toml")
                                            if (locate-dominating-file default-directory file)
                                            return t)
-                                  (assq 'prettier (+javascript-npm-conf)))
+                                  (and (modulep! :lang javascript)
+                                       (assq 'prettier (+javascript-npm-conf))))
                         (apheleia-formatters-indent "--use-tabs" "--tab-width"))))))))


### PR DESCRIPTION
`+javascript-npm-conf` is defined in modules/lang/javascript/autoload.el, so c0a1b9ef broke formatting JSON files when the javascript module isn't enabled in init.el. Gate the call to the function behind a `modulep` check.