### PR TITLE
refactor!(go): remove go-guru

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -13,7 +13,6 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
 - REPL (~gore~)
 - Syntax-checking (~flycheck~)
 - Auto-formatting on save (~gofmt~) (requires [[doom-module::editor format +onsave]])
-- Code navigation & refactoring (~go-guru~)
 - [[../../editor/file-templates/templates/go-mode][File templates]]
 - [[https://github.com/hlissner/doom-snippets/tree/master/go-mode][Snippets]]
 - Generate testing code (~go-gen-test~)
@@ -36,7 +35,6 @@ This module adds [[https://golang.org][Go]] support, with optional (but recommen
 - [[doom-package:flycheck-golangci-lint]] if [[doom-module::checkers syntax]]
 - [[doom-package:go-eldoc]]
 - [[doom-package:go-gen-test]]
-- [[doom-package:go-guru]]
 - [[doom-package:go-mode]]
 - [[doom-package:gorepl-mode]]
 - [[doom-package:go-tag]]
@@ -64,7 +62,6 @@ below.
 - ~godoc~ (for documentation lookup)
 - ~gorename~ (for extra refactoring commands)
 - ~gore~ (for the REPL)
-- ~guru~ (for code navigation & refactoring commands)
 - ~goimports~ (/optional/: for auto-formatting code on save & fixing imports)
 - ~gotests~ (for generate test code)
 - ~gomodifytags~ (for manipulating tags)
@@ -77,7 +74,6 @@ go install github.com/stamblerre/gocode@latest
 go install golang.org/x/tools/cmd/godoc@latest
 go install golang.org/x/tools/cmd/goimports@latest
 go install golang.org/x/tools/cmd/gorename@latest
-go install golang.org/x/tools/cmd/guru@latest
 go install github.com/cweill/gotests/gotests@latest
 go install github.com/fatih/gomodifytags@latest
 #+end_src
@@ -102,16 +98,6 @@ go install github.com/fatih/gomodifytags@latest
 | [[kbd:][<localleader> b b]]   | run ~$ go build~                                      |
 | [[kbd:][<localleader> b r]]   | run ~$ go run .~                                      |
 | [[kbd:][<localleader> h .]]   | lookup symbol at point in godoc                       |
-| [[kbd:][<localleader> h d]]   | describe symbol at point                              |
-| [[kbd:][<localleader> h v]]   | list free variables                                   |
-| [[kbd:][<localleader> h i]]   | list implements relations for package types           |
-| [[kbd:][<localleader> h p]]   | list peers for channel                                |
-| [[kbd:][<localleader> h P]]   | "what does this point to"                             |
-| [[kbd:][<localleader> h r]]   | list references to object                             |
-| [[kbd:][<localleader> h e]]   | which errors                                          |
-| [[kbd:][<localleader> h w]]   | what query                                            |
-| [[kbd:][<localleader> h c]]   | show callers of function at point                     |
-| [[kbd:][<localleader> h C]]   | show callees of function at point                     |
 | [[kbd:][<localleader> t t]]   | rerun last test                                       |
 | [[kbd:][<localleader> t a]]   | run all tests in project                              |
 | [[kbd:][<localleader> t f]]   | run all tests in current file                         |

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -7,8 +7,6 @@
   (set-docsets! 'go-mode "Go")
   (set-repl-handler! 'go-mode #'gorepl-run)
   (set-lookup-handlers! 'go-mode
-    :definition #'go-guru-definition
-    :references #'go-guru-referrers
     :documentation #'godoc-at-point)
 
   (if (modulep! +lsp)
@@ -25,17 +23,7 @@
         "e" #'+go/play-buffer-or-region
         "i" #'go-goto-imports      ; Go to imports
         (:prefix ("h" . "help")
-          "." #'godoc-at-point     ; Lookup in godoc
-          "d" #'go-guru-describe   ; Describe this
-          "v" #'go-guru-freevars   ; List free variables
-          "i" #'go-guru-implements ; Implements relations for package types
-          "p" #'go-guru-peers      ; List peers for channel
-          "P" #'go-guru-pointsto   ; What does this point to
-          "r" #'go-guru-referrers  ; List references to object
-          "e" #'go-guru-whicherrs  ; Which errors
-          "w" #'go-guru-what       ; What query
-          "c" #'go-guru-callers    ; Show callers of this function
-          "C" #'go-guru-callees)   ; Show callees of this function
+          "." #'godoc-at-point)    ; Lookup in godoc
         (:prefix ("ri" . "imports")
           "a" #'go-import-add
           "r" #'go-remove-unused-imports)

--- a/modules/lang/go/doctor.el
+++ b/modules/lang/go/doctor.el
@@ -9,9 +9,6 @@
              (modulep! :tools tree-sitter))
          "This module requires (:tools tree-sitter)")
 
-(unless (executable-find "guru")
-  (warn! "Couldn't find guru. Refactoring commands (go-guru-*) won't work"))
-
 (unless (executable-find "gore")
   (warn! "Couldn't find gore. REPL will not work"))
 

--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -2,7 +2,6 @@
 ;;; lang/go/packages.el
 
 (package! go-eldoc :pin "cbbd2ea1e94a36004432a9ac61414cb5a95a39bd")
-(package! go-guru :pin "636d36e37a0d2b6adb2e12d802ff4794ccbba336")
 (package! go-mode :pin "636d36e37a0d2b6adb2e12d802ff4794ccbba336")
 (package! gorepl-mode :pin "6a73bf352e8d893f89cad36c958c4db2b5e35e07")
 (package! go-tag :pin "33f2059551d5298ca228d90f525b99d1a8d70364")


### PR DESCRIPTION
BREAKING CHANGE: Removes go-guru from the Go module. It has been deprecated upstream in favor of gopls, the official Go LSP server.

Close: #7995
Ref: golang/go/issues/65880

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

**Note**: I have discarded the [bump](https://github.com/doomemacs/doomemacs/issues/7995#issuecomment-2299971269) to `go-mode.el` because that introduces a [deprecation](https://github.com/dominikh/go-mode.el/commit/166dfb1e090233c4609a50c2ec9f57f113c1da72) that requires more updates to the Go module.
I'll be happy to tackle those, as well as other issues I've recently noticed, once this PR is accepted.
Being my first non-trivial contribution, I didn't want to mix too much stuff, for the sake of clarity.