### PR TITLE
bump: evil-textobj-tree-sitter

### DIFF
--- a/modules/tools/tree-sitter/packages.el
+++ b/modules/tools/tree-sitter/packages.el
@@ -7,4 +7,4 @@
 
 (when (modulep! :editor evil +everywhere)
   (package! evil-textobj-tree-sitter
-    :pin "a19ab9d89a00f4a04420f9b5d61b66f04fea5261"))
+    :pin "041fcb9fbb00deac92a4e58b5fca03f7dc0a32e8"))


### PR DESCRIPTION
Bump  evil-textobj-tree-sitter to latest

⚠️ ~~Beware that while this fixes Typescript grammar, **it will break haskell, php and r textobj queries**~~
~~See https://github.com/meain/evil-textobj-tree-sitter/issues/117#issuecomment-2302112038~~

=> All good now

Fix: #8006 

-----
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
