### PR TITLE
fix(latex): update latex module to new AUCTeX naming conventions

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -100,7 +100,8 @@ If no viewer is found, `latex-preview-pane-mode' is used.")
   ;; Hook LSP, if enabled.
   (when (modulep! +lsp)
     (add-hook! '(tex-mode-local-vars-hook
-                 latex-mode-local-vars-hook)
+                 latex-mode-local-vars-hook
+                 LaTeX-mode-local-vars-hook)
                :append #'lsp!))
   ;; Define a function to compile the project.
   (defun +latex/compile ()


### PR DESCRIPTION
enable `lsp` with `LaTeX-mode` (new AUCTeX (version >= 14) naming conventions).
See AUCTeX changes here: https://github.com/emacs-straight/auctex/blob/master/NEWS.org#1401---2024-02-08

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
