### PR TITLE
Adding a single character so other workspaces could persist automatically

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -118,7 +118,7 @@ Returns t on success, nil otherwise."
   (unless (+workspace-exists-p name)
     (error "'%s' is an invalid workspace" name))
   (let ((fname (expand-file-name +workspaces-data-file persp-save-dir)))
-    (persp-save-to-file-by-names fname *persp-hash* (list name))
+    (persp-save-to-file-by-names fname *persp-hash* (list name) t)
     (and (member name (persp-list-persp-names-in-file fname))
          t)))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

It seems that `persp-save-to-file-by-names` has an optional `keep-others` argument which I believe is the default behaviour

Fix: #0000
Ref: #0000
Close: #0000

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
