### PR TITLE
fix: display flutter buffer as popup

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -37,7 +37,9 @@
           "f" #'flutter-run
           "q" #'flutter-quit
           "r" #'flutter-hot-reload
-          "R" #'flutter-hot-restart)))
+          "R" #'flutter-hot-restart))
+  :config
+  (set-popup-rule! "\\*Flutter\\*"))
 
 
 (use-package! lsp-dart


### PR DESCRIPTION
Hi!

The flutter console is not displayed as a popup buffer but it should be. This fix addresses it.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
