### PR TITLE
fix(go): remove bind to deprecated function

### DIFF
--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -25,8 +25,7 @@
         (:prefix ("h" . "help")
           "." #'godoc-at-point)    ; Lookup in godoc
         (:prefix ("ri" . "imports")
-          "a" #'go-import-add
-          "r" #'go-remove-unused-imports)
+          "a" #'go-import-add)
         (:prefix ("b" . "build")
           :desc "go run ." "r" (cmd! (compile "go run ."))
           :desc "go build" "b" (cmd! (compile "go build"))


### PR DESCRIPTION
Trying to execute `go-remove-unused-imports` renders this error message in the minibuffer:

    ‘go-remove-unused-imports’ is an obsolete command (as of 1.7.0); set ‘gofmt-command’ to goimports instead, or use LSP and gopls’s "Organize Imports" code action.

Ref: dominikh/go-mode.el@166dfb1e0902

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
- [x] Even though I'm no Mark Watney, I know a martian gopher when I see one.
