### PR TITLE
Add `+hybrid` flag to `:editor evil`? Maybe?

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -15,6 +15,8 @@ This holy module brings the Vim editing model to Emacs.
 - +everywhere ::
   Enable evilified keybinds everywhere possible. Uses the [[https://github.com/emacs-evil/evil-collection][evil-collection]] plugin
   as a foundation.
+- +hybrid ::
+  Enable nearly full use of vanilla emacs bindings in ~evil-insert-state~.
 
 ** Packages
 - [[doom-package:evil]]

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -53,6 +53,7 @@ directives. By default, this only recognizes C directives.")
         ;; It's infuriating that innocuous "beginning of line" or "end of line"
         ;; errors will abort macros, so suppress them:
         evil-kbd-macro-suppress-motion-error t
+        evil-disable-insert-state-bindings (modulep! :editor evil +hybrid)
         evil-undo-system
         (cond ((modulep! :emacs undo +tree) 'undo-tree)
               ((modulep! :emacs undo) 'undo-fu)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -1208,18 +1208,31 @@ between the two."
             :ni [C-return]   #'+org/insert-item-below
             :ni [C-S-return] #'+org/insert-item-above
             ;; navigate table cells (from insert-mode)
-            :i Cright (cmds! (org-at-table-p) #'org-table-next-field
-                             #'org-end-of-line)
-            :i Cleft  (cmds! (org-at-table-p) #'org-table-previous-field
-                             #'org-beginning-of-line)
-            :i Cup    (cmds! (org-at-table-p) #'+org/table-previous-row
-                             #'org-up-element)
-            :i Cdown  (cmds! (org-at-table-p) #'org-table-next-row
-                             #'org-down-element)
-            :ni CSright   #'org-shiftright
-            :ni CSleft    #'org-shiftleft
-            :ni CSup      #'org-shiftup
-            :ni CSdown    #'org-shiftdown
+            (:unless (modulep! :editor evil +hybrid)
+              :i Cright (cmds! (org-at-table-p) #'org-table-next-field #'org-end-of-line))
+            (:unless (modulep! :editor evil +hybrid)
+              :i Cleft  (cmds! (org-at-table-p) #'org-table-previous-field #'org-beginning-of-line))
+            (:unless (modulep! :editor evil +hybrid)
+              :i Cup    (cmds! (org-at-table-p) #'+org/table-previous-row #'org-up-element))
+            (:unless (modulep! :editor evil +hybrid)
+              :i Cdown  (cmds! (org-at-table-p) #'org-table-next-row #'org-down-element))
+            (:unless (modulep! :editor evil +hybrid)
+              :ni CSright   #'org-shiftright)
+            (:when (modulep! :editor evil +hybrid)
+              :n CSright   #'org-shiftright)
+            (:unless (modulep! :editor evil +hybrid)
+              :ni CSleft   #'org-shiftleft)
+            (:when (modulep! :editor evil +hybrid)
+              :n CSleft   #'org-shiftleft)
+            (:unless (modulep! :editor evil +hybrid)
+              :ni CSup   #'org-shiftup)
+            (:when (modulep! :editor evil +hybrid)
+              :n CSup   #'org-shiftup)
+            (:unless (modulep! :editor evil +hybrid)
+              :ni CSdown   #'org-shiftdown)
+            (:when (modulep! :editor evil +hybrid)
+              :n CSdown   #'org-shiftdown)
+
             ;; more intuitive RET keybinds
             :n [return]   #'+org/dwim-at-point
             :n "RET"      #'+org/dwim-at-point


### PR DESCRIPTION
This adds a `+hybrid` flag to the `:editor evil` module. The configuration associated with the flag is trivial (just sets `evil-disable-insert-state-bindings`), but ~the real value of the flag is providing a hook for conditionally disabling `evil{, +everywhere}` bindings that clobber important vanilla emacs bindings~ see note below 😅.

Note below: while rebasing my branch to create this PR, I stumbled across the existence of https://github.com/doomemacs/doomemacs/commit/122e3732f70f21ff9bd6f5e263642fd1793e08b1, which dropped one of my (now missing) commits in favor of a shorter, more readable alternative. Now I'm less convinced that this flag is needed—it does significantly improve the discoverability of this configuration, which isn't nothing, but perhaps it's not enough to justify the flag. I have no problem with reducing the PR to a similar patch on `modules/lang/org/config.el`.

Ref: #107 

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
  Well, it does edit a module readme, but only trivially; that's not the core change.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
- [X] This a draft PR; I need more time to ~finish it~ discuss whether it makes sense to merge in its current form.