### PR TITLE
fix(cli): Replace sxhash with safe-hash to ensure persistence

### DIFF
--- a/lisp/cli/sync.el
+++ b/lisp/cli/sync.el
@@ -113,7 +113,11 @@ OPTIONS:
 ;;; Helpers
 
 (defun doom-sync--system-hash ()
-  (sxhash (list doom-local-dir system-type system-configuration-features)))
+  (secure-hash 'md5 (concat doom-local-dir
+                            (symbol-name system-type)
+                            (mapconcat 'identity (split-string
+                                                  system-configuration-features
+                                                  "")))))
 
 (defun doom-sync--abort-warning-h ()
   (print! (warn "Script was abruptly aborted, leaving Doom in an incomplete state!"))


### PR DESCRIPTION
This is to fix a problem where the hash values returned by `sxhash` was changing for every `doom sync` I would run. 
Doom's cli would then bug me about rebuilding all my packages because of the difference.

In the documentation of `sxhash` it does mention that the values obtained may change per session:
> Hash codes are not guaranteed to be preserved across Emacs sessions.

My `sync` file would contain a different hash value every time it synced, so for example:

> 1st sync
> -1610799279532103343
>2nd sync
> -1610671656264054447
> 3rd sync
> -1610672328830977711

I'm not very good at Elisp so I would be grateful for any feedback, thanks


-----
- [x ] I searched the issue tracker and this hasn't been PRed before.
- [x ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

