### PR TITLE
fix: emacs-flymake-popon not fetching

### DIFF
--- a/modules/checkers/syntax/packages.el
+++ b/modules/checkers/syntax/packages.el
@@ -8,4 +8,5 @@
     (package! flycheck-posframe :pin "19896b922c76a0f460bf3fe8d8ebc2f9ac9028d8")))
 
 (when (modulep! +flymake)
-  (package! flymake-popon :recipe (:repo "https://codeberg.org/akib/emacs-flymake-popon")))
+  (package! popon :recipe (:host codeberg :repo "akib/emacs-popon"))
+  (package! flymake-popon :recipe (:host codeberg :repo "akib/emacs-flymake-popon")))


### PR DESCRIPTION
fix: emacs-flymake-popon not fetching

straight.el added support for codeberg in the past. it now requires `:host codeberg` to be added to the :recipe to work otherwise, it assumes github and can't find the repo
also, had to readd the popon recipe because straight was still looking on github for that

Ref: radian-software/straight.el#992
Ref: #6660
Fix: #8035

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.