### PR TITLE
fix(latex): reorder viewers w.r.t +latex-viewers

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -12,6 +12,7 @@
           (and (featurep :system 'macos)
                (file-exists-p! (or "/Applications/Skim.app"
                                    "~/Applications/Skim.app"))))
+       (delete '(output-pdf "Skim") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "Skim"))
        (add-to-list 'TeX-view-program-list
                     (list "Skim" (format "%s/Contents/SharedSupport/displayline -r -b %%n %%o %%b"
@@ -20,6 +21,7 @@
     (`sumatrapdf
      (when (and (featurep :system 'windows)
                 (executable-find "SumatraPDF"))
+       (delete '(output-pdf "SumatraPDF") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "SumatraPDF"))))
 
     (`okular
@@ -27,18 +29,22 @@
        ;; Configure Okular as viewer. Including a bug fix
        ;; (https://bugs.kde.org/show_bug.cgi?id=373855).
        (add-to-list 'TeX-view-program-list '("Okular" ("okular --noraise --unique file:%o" (mode-io-correlate "#src:%n%a"))))
+       (delete '(output-pdf "Okular") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "Okular"))))
 
     (`zathura
      (when (executable-find "zathura")
+       (delete '(output-pdf "Zathura") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "Zathura"))))
 
     (`evince
      (when (executable-find "evince")
+       (delete '(output-pdf "Evince") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "Evince"))))
 
     (`pdf-tools
      (when (modulep! :tools pdf)
+       (delete '(output-pdf "PDF Tools") TeX-view-program-selection)
        (add-to-list 'TeX-view-program-selection '(output-pdf "PDF Tools"))
        (when (featurep :system 'macos)
          ;; PDF Tools isn't in `TeX-view-program-list-builtin' on macs.


### PR DESCRIPTION
After `latex` module is loaded, the value of `TeX-view-program-selection` does not reflect the order set in `+latex-viewers`. This is because if a viewer already exists in `TeX-view-program-selection`, loading `+viewer.el` does not change its order as `add-to-list` does nothing when the item is already in the list.

Fix: #5275

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.