### PR TITLE
feat(nav-flash): blink on workspace change

### DIFF
--- a/modules/ui/nav-flash/config.el
+++ b/modules/ui/nav-flash/config.el
@@ -31,6 +31,10 @@
   ;; `org'
   (add-hook 'org-follow-link-hook #'+nav-flash-delayed-blink-cursor-h)
 
+  ;; `persp-mode'
+  (after! persp-mode
+    (add-hook 'persp-activated-functions #'+nav-flash-delayed-blink-cursor-h))
+
   ;; `saveplace'
   (advice-add #'save-place-find-file-hook :after #'+nav-flash-blink-cursor-a)
 


### PR DESCRIPTION
Changing workspace is big motion so we should blink the cursor. We can not use `+nav-flash-blink-cursor-maybe-h` as the point is not yet in the correct buffer when the hook is triggered.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
