### PR TITLE
docs(magit): remove magit-todos from the README

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -21,7 +21,6 @@ This module provides Magit, an interface to the Git version control system.
 - [[doom-package:forge]] if [[doom-module:+forge]]
 - [[doom-package:code-review]] if [[doom-module:+forge]]
 - [[doom-package:magit]]
-- [[doom-package:magit-todos]]
 
 ** Hacks
 - [[doom-package:magit]] has been modified to recognize =$XDG_CACHE_HOME/git/credential/socket=.


### PR DESCRIPTION
0893edefae1fe548c7e1112038c6e50b9e35bd26 removed magit-todos from the default magit module configuration. Users are expected to install it by themselves, if they wish to use the package, given it's simple config.


- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).