### PR TITLE
fix(dired): typo in command name

### DIFF
--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -15,7 +15,7 @@
        (dired-git-info-mode 1)))
 
 ;;;###autoload
-(defun +dired/dirvish-side-or-follow (&optional arg)
+(defun +dired/dirvish-side-and-follow (&optional arg)
   "Open `dirvish-side' then find the currently focused file.
 
 If dirvish is already open, remotely jump to the file in Dirvish.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

`<leader> o p` is bound to `+dired/dirvish-side-and-follow`, but the command was previously called `+dired/dirvish-side-or-follow` instead.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
