### PR TITLE
fix(lsp): lsp-terraform removal condition

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -85,7 +85,7 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
     :type-definition #'lsp-find-type-definition)
 
   ;; HACK: See emacs-lsp/lsp-mode#3577
-  (unless (modulep! :lang terraform)
+  (unless (modulep! :tools terraform)
     (setq lsp-client-packages (delete 'lsp-terraform lsp-client-packages)))
 
   (defadvice! +lsp--respect-user-defined-checkers-a (fn &rest args)


### PR DESCRIPTION
Current workaround for https://github.com/emacs-lsp/lsp-mode/issues/3577 is disabling terraform lsp even for terraform users, because of incorrect section.

Ref: #7713

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.