### PR TITLE
fix(dired): require needed for `dirvish-side'

### DIFF
--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -22,6 +22,7 @@ If dirvish is already open, remotely jump to the file in Dirvish.
 If given the prefix ARG, then prompt for a directory (replaces existing Dirvish
 sidebars)."
   (interactive "P")
+  (require 'dirvish-side)
   (save-selected-window
     (let ((win (dirvish-side--session-visible-p)))
       (when (and win arg)


### PR DESCRIPTION
This prevents getting load errors when calling the command `+dired/dirvish-side-and-follow` before `dirvish` has been loaded.

The errors occur when calling `dirvish-side--session-visible-p`:
>let: Symbol’s function definition is void: dirvish-side--session-visible-p



----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

