### PR TITLE
fix(fold): avoid Hideshow-not-supported error

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -9,8 +9,16 @@
 ;;; Helpers
 
 (defun +fold--ensure-hideshow-mode ()
-  (unless (bound-and-true-p hs-minor-mode)
-    (hs-minor-mode +1)))
+  "Enable `hs-minor-mode' if not already enabled.
+
+Return non-nil if successful in doing so."
+  (if (not (bound-and-true-p hs-minor-mode))
+      ;; `hs-grok-mode-type' applies this test; if it fails, it produces an
+      ;; error indicating that `hs-minor-mode' is not supported here.
+      (when (and (bound-and-true-p comment-start)
+                 (bound-and-true-p comment-end))
+        (hs-minor-mode +1))
+    t))
 
 (defun +fold--vimish-fold-p ()
   (and (featurep 'vimish-fold)
@@ -23,14 +31,14 @@
        (outline-on-heading-p)))
 
 (defun +fold--hideshow-fold-p ()
-  (+fold--ensure-hideshow-mode)
-  (save-excursion
-    (ignore-errors
-      (or (hs-looking-at-block-start-p)
-          (hs-find-block-beginning)
-          (unless (eolp)
-            (end-of-line)
-            (+fold--hideshow-fold-p))))))
+  (when (+fold--ensure-hideshow-mode)
+    (save-excursion
+      (ignore-errors
+        (or (hs-looking-at-block-start-p)
+            (hs-find-block-beginning)
+            (unless (eolp)
+              (end-of-line)
+              (+fold--hideshow-fold-p)))))))
 
 ;; NOTE: does this need more?
 (defun +fold--ts-fold-p ()
@@ -186,13 +194,13 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
         ((and (featurep 'vimish-fold) (+fold--vimish-fold-p))
          (vimish-fold-unfold-all))
         ((save-excursion
-           (+fold--ensure-hideshow-mode)
+           (when (+fold--ensure-hideshow-mode)
+             (hs-life-goes-on
+              (if (integerp level)
+                  (hs-hide-level-recursive level (point-min) (point-max))
+                (hs-show-all))))
            (if (integerp level)
-               (progn
-                 (outline-hide-sublevels (max 1 level))
-                 (hs-life-goes-on
-                  (hs-hide-level-recursive level (point-min) (point-max))))
-             (hs-show-all)
+               (outline-hide-sublevels (max 1 level))
              (when (fboundp 'outline-show-all)
                (outline-show-all)))))))
 
@@ -207,15 +215,15 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
       (progn
         (when (featurep 'vimish-fold)
           (vimish-fold-refold-all))
-        (+fold--ensure-hideshow-mode)
-        (hs-life-goes-on
-         (if (integerp level)
-             (progn
-               (outline--show-headings-up-to-level level)
-               (hs-hide-level-recursive level (point-min) (point-max)))
-           (hs-hide-all)
-           (when (fboundp 'outline-hide-sublevels)
-             (outline-show-only-headings))))))))
+        (when (+fold--ensure-hideshow-mode)
+          (hs-life-goes-on
+           (if (integerp level)
+               (hs-hide-level-recursive level (point-min) (point-max))
+             (hs-hide-all))))
+        (if (integerp level)
+            (outline--show-headings-up-to-level level)
+          (when (fboundp 'outline-hide-sublevels)
+            (outline-show-only-headings)))))))
 
 ;;;###autoload
 (defun +fold/next (count)

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -56,8 +56,7 @@ this."
   (defadvice! +fold--hideshow-ensure-mode-a (&rest _)
     "Ensure `hs-minor-mode' is enabled when we need it, no sooner or later."
     :before '(hs-toggle-hiding hs-hide-block hs-hide-level hs-show-all hs-hide-all)
-    (unless (bound-and-true-p hs-minor-mode)
-      (hs-minor-mode +1)))
+    (+fold--ensure-hideshow-mode))
 
   ;; extra folding support for more languages
   (unless (assq 't hs-special-modes-alist)


### PR DESCRIPTION
Some modes are not supported by `hs-minor-mode`, but can still support some of the `+fold/` commands. For example, `pdf-outline-minor-mode` recognizes the same commands as `outline-minor-mode`, but `hs-minor-mode` is not applicable. In cases like these, we shouldn't try to enable `hs-minor-mode`, as this will produce an error that will terminate the command.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
