### PR TITLE
fix(emacs-lisp): always try Helpful for doc lookup

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -117,8 +117,9 @@ if it's callable, `apropos' otherwise."
                  (org-show-hidden-entry))))
            'deferred))
         (thing
-         (funcall (or (command-remapping #'describe-symbol)
-                      #'describe-symbol)
+         (funcall (if (fboundp #'helpful-symbol)
+                      #'helpful-symbol
+                    #'describe-symbol)
                   (intern thing)))
         ((call-interactively
           (if (fboundp #'helpful-at-point)


### PR DESCRIPTION
As per the description in 6671adc68, this module should always use Helpful's functions as long as Helpful is available (ie. not explicitly disabled by the user in packages.el). The remapping of `describe-symbol` is irrelevant here - the user might prefer to rebind `C-h C-o` to `describe-symbol` (as `helpful-symbol` cannot look up types), but that doesn't necessarily mean they want this module not to use it.

<!-- ⚠️ Please do not ignore this template! -->

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
