### PR TITLE
fix(ligatures): use `alist-get` instead of `assq`

### DIFF
--- a/modules/ui/ligatures/config.el
+++ b/modules/ui/ligatures/config.el
@@ -112,7 +112,7 @@ isn't disabled in `+ligatures-extras-in-modes'."
         (((+ligatures--enable-p +ligatures-extras-in-modes))
          (symbols
           (if-let ((symbols (assq major-mode +ligatures-extra-alist)))
-              symbols
+              (cdr symbols)
             (cl-loop for (mode . symbols) in +ligatures-extra-alist
                      if (derived-mode-p mode)
                      return symbols))))


### PR DESCRIPTION
Otherwise, `prettify-symbols-alist` will be set to a list whose first element is the mode name, a symbol. That makes `prettify-symbols-alist` an invalid alist, so when `prettify-symbols-mode` is enabled, there's a type error in `prettify-symbols--make-keywords`.

Amend: c07f359d648a

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
