### PR TITLE
fix(mu4e): org-msg: toggle behavior

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -442,14 +442,14 @@ This should already be the case yet it does not always seem to be."
       (org-msg-set-prop "attachment" (nconc files (list file)))))
 
   ;; HACK: Toggle `org-msg' where sensible.
-  (defvar +mu4e--compose-org-msg-toggle-next t)
+  (defvar +mu4e-compose-org-msg-toggle-next t)
   (defadvice! +mu4e-maybe-toggle-org-msg-a (&rest _)
     :before #'+mu4e/attach-files
     :before #'mu4e-compose-new
     :before #'mu4e-compose-reply
     :before #'mu4e-compose-forward
     :before #'mu4e-compose-resend
-    (when (xor (/= 1 (if (integerp current-prefix-arg) current-prefix-arg 0))
+    (when (xor (/= 1 (prefix-numeric-value current-prefix-arg))
                +mu4e-compose-org-msg-toggle-next)
       (org-msg-mode (if org-msg-mode -1 1))
       (cl-callf not +mu4e-compose-org-msg-toggle-next)))


### PR DESCRIPTION
Toggle behavior:

The `(integerp current-prefix-arg)` check didn't appropriately catch `C-u`/`SPC u` prefixes, where `current-prefix-arg` typically is `(4)`. This attempts to use `(prefix-numeric-value current-prefix-arg)` instead to normalize these cases.

Variable naming:

I'm not sure if this was supposed to continue to be called `+mu4e-compose-org-msg-toggle-next` or if the rename to private `+mu4e--compose-org-msg-toggle-next` was intentional and the usage wasn't updated accordingly. I see the `mu4e` README still mentions it, so I would guess the former and this was a typo.


<!-- ⚠️ Please do not ignore this template! -->

Ref: #8073
Relevant change: https://github.com/doomemacs/doomemacs/commit/a78237cc01adeabe0fd4a83ff8b8aca7cb269482#diff-e4ae34fcacdffca06aea528ca819a5b6b2332032b20005392503b6ac0e9d04aaR445

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
