### PR TITLE
fix(clojure): type error evilifying cider-debug keys

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -131,9 +131,10 @@
              (let* ((from (car replacement))
                     (to (cadr replacement))
                     (item (assoc from cider-debug-prompt-commands)))
-               ;; Position matters, hence the update-in-place
-               (setf (car item) (car to))
-               (setf (cdr item) (cdr to))))
+               (when item
+                 ;; Position matters, hence the update-in-place
+                 (setf (car item) (car to))
+                 (setf (cdr item) (cdr to)))))
            '((?h (?H "here" "Here"))
              (?i (?I "in" "In"))
              (?j (?J "inject" "inJect"))


### PR DESCRIPTION
When I call (doom/reload) there is an error like:
```
⛔ Warning (initialization): An error occurred while booting Doom Emacs:

Error in a Doom module: modules/lang/clojure/config.el, (wrong-type-argument consp nil)
```

There is small bug with replacing param which doesn't handle case where param already replaced