### PR TITLE
fix(python): renamed python-pytest commands

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -196,8 +196,8 @@
         "a" #'python-pytest
         "f" #'python-pytest-file-dwim
         "F" #'python-pytest-file
-        "t" #'python-pytest-function-dwim
-        "T" #'python-pytest-function
+        "t" #'python-pytest-run-def-or-class-at-point-dwim
+        "T" #'python-pytest-run-def-or-class-at-point
         "r" #'python-pytest-repeat
         "p" #'python-pytest-dispatch))
 


### PR DESCRIPTION
https://github.com/doomemacs/doomemacs/commit/1fa1eba5ac38d654a0763282f3ddd631e873c273 pined `python-pytest` to `dcdaec6fe203f08bda0f5ee1931370dfd075a4ff` which included [this change](https://github.com/wbolster/emacs-python-pytest/pull/75/files#diff-ec3a68c754a7f498ad96a584a259278a8827ede06e61b45dc43176e1f2dd92f5R294) that renamed:
* `python-pytest-function-dwim` -> `python-pytest-run-def-or-class-at-point`
* `python-pytest-function-dwim` -> `python-pytest-run-def-or-class-at-point-dwim`

