### PR TITLE
feat(marginalia): Annotate `doom/help-packages'

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -334,12 +334,54 @@ orderless."
             '(doom/find-file-in-other-project . project-file)
             '(doom/find-file-in-private-config . file)
             '(doom/describe-active-minor-mode . minor-mode)
+            '(doom/help-packages . doom-package)
             '(flycheck-error-list-set-filter . builtin)
             '(persp-switch-to-buffer . buffer)
             '(projectile-find-file . project-file)
             '(projectile-recentf . project-file)
             '(projectile-switch-to-buffer . buffer)
-            '(projectile-switch-project . project-file)))
+            '(projectile-switch-project . project-file))
+
+  ;; Add Marginalia annotations for `doom/help-packages'
+  (add-to-list 'marginalia-annotator-registry '(doom-package +marginalia--annotate-doom-package-fn none))
+  (defun +marginalia--annotate-doom-package-fn (cand)
+    "Annotate Doom package CAND with source, pin status, and summary."
+    (when-let ((package (intern-soft cand)))
+      (let* ((backend (doom-package-backend package))
+             (source (pcase backend
+                       (`straight "Straight")
+                       (`elpa "ELPA")
+                       (`builtin "Built-in")
+                       (_ "Other")))
+             (pin (when (eq backend 'straight)
+                    (plist-get (cdr (assq package doom-packages)) :pin)))
+             (summary
+              ;; when the package is not built in
+              (if (not (eq backend 'builtin))
+                  (let* ((local-repo (doom-package-recipe-repo package))
+                         (repo-dir (straight--repos-dir local-repo)))
+                    (if (file-exists-p repo-dir)
+                        (marginalia--library-doc
+                         (file-name-concat repo-dir
+                                           (format "%s%s" local-repo ".el")))
+                      ""))
+                ;; If the package is built in
+                (if-let (built-in (assq package package--builtins))
+                    (package-desc-summary (package--from-builtin built-in))
+                  (marginalia--library-doc (gethash local-repo (marginalia--library-cache)))))))
+        (marginalia--fields
+         ;; Display the package source with a specific width
+         ((propertize source 'face
+                      (if (string-equal source "Other")
+                          'marginalia-key 'marginalia-file-name)))
+         ;; Display pin status if applicable
+         ((propertize (if pin (concat (substring pin 0 4) "...")
+                        ;; If no pin, then create padding
+                        (make-string 7 ?\s))
+                      'face 'marginalia-number))
+         ;; Display the package summary:
+         ((propertize (string-trim summary) ;; Remove whitespace from summary
+                      'face 'marginalia-documentation)))))))
 
 
 (use-package! wgrep


### PR DESCRIPTION
This will provide annotations for `doom/help-packages' command.
Specifically, it will display the source of the package:
- Straight: The package was installed using Straight (dooms package manager).
- Built-in: The package is bundled in with Emacs.
- 'Other': This is for when a package is known to Doom but not installed (such as when you disable a package in 'package.el').

When the package is installed and was installed using Straight, then the commit pin is displayed.

The package also displays documentation for the package (if found).

-----

This pull request adds a feature that adds some annotations for `doom/help-packages`.

I was thinking of making it an autoload function inside the `.../modules/completion/vertico/autoload/` folder. But I did not see a `marginalia.el` file so I just left it in the `use-package!` block.

This is my first Emacs Lisp function so I don't expect it to be very good so I would appreciate any feedback on the code (even if this PR is not going to get merged).


## Screenshots
Difference visually:
Before (no annotations):
![pic-selected-240924-0944-14](https://github.com/user-attachments/assets/d0679ffa-1031-462b-9247-a4b43625ff82)


After (with annotations):
![pic-selected-240924-0926-12](https://github.com/user-attachments/assets/8b54fbfb-3a82-4b80-a229-6f7d35413b8c)

Thank you, 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] This a draft PR; I need more time to finish it.

