### PR TITLE
module: add :lang hledger

### DIFF
--- a/modules/lang/hledger/README.org
+++ b/modules/lang/hledger/README.org
@@ -1,0 +1,54 @@
+#+title:     :lang hledger
+#+subtitle:  ledger, but functional
+#+created:   September 28, 2024
+#+since:     3.0.0 (#COMMIT-OR-PR-REF)
+
+* Description :unfold:
+This module adds support for [[https://hledger.org/][hledger]] files. hledger is a command line double-entry
+accounting system that works with simple text files similar to [[https://ledger-cli.org/][ledger]].
+
+This module enables the following features:
+- Syntax and indentation support for hledger files
+- Add, edit and delete transactions
+- Generate reports
+- Schedule transactions
+- Sort transactions (with evil-ledger)
+
+** Maintainers
+/This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+/This module has no flags./
+
+** Packages
+- [[doom-package:evil-ledger]] if [[doom-module::editor evil +everywhere]]
+- [[doom-package:hledger-mode]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+/This module does not have a changelog yet./
+
+* Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+This module requires [[https://hledger.org/][hledger]] to generate reports from your ledgers.
+
+* Usage
+Please refer to ~hledger-mode~'s documentation for information on how to use it.
+
+* Configuration
+Set the [[var:hledger-jfile][hledger-jfile]] variable to the path to your main .journal file
+that will be used by hledger for generating reports.
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+ 󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/lang/hledger/config.el
+++ b/modules/lang/hledger/config.el
@@ -1,0 +1,24 @@
+;;; lang/hledger/config.el -*- lexical-binding: t; -*-
+
+(use-package! hledger-mode
+  :defer t
+  :mode ("\\.journal\\'" "\\.hledger\\'")
+  :init
+  (set-company-backend! 'hledger-mode 'hledger-company)
+  :config
+  (map! :map hledger-mode-map
+        :localleader
+        ("r" #'hledger-reschedule
+         "e" #'hledger-edit-amount
+         "s" #'hledger-toggle-star
+         "a" #'hledger-add-days-to-entry-date
+         "j" #'hledger-forward-entry
+         "k" #'hledger-backward-entry
+         "y" #'hledger-copy-to-clipboard
+         "i" #'hledger-increment-entry-date
+         "d" #'hledger-decrement-entry-date
+         "n" #'hledger-jentry)))
+
+(use-package! evil-ledger
+  :when (modulep! :editor evil +everywhere)
+  :hook (hledger-mode . evil-ledger-mode))

--- a/modules/lang/hledger/doctor.el
+++ b/modules/lang/hledger/doctor.el
@@ -1,0 +1,4 @@
+;;; lang/hledger/doctor.el -*- lexical-binding: t; -*-
+
+(unless (executable-find "hledger")
+  (warn! "hledger isn't installed"))

--- a/modules/lang/hledger/packages.el
+++ b/modules/lang/hledger/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/hledger/packages.el
+
+(package! hledger-mode :pin "5492509a23047f0a1f05a112b47fa34eba7c5e1d")
+
+(when (modulep! :editor evil)
+  (package! evil-ledger :pin "7a9f9f5d39c42fffdba8004f8982642351f2b233"))


### PR DESCRIPTION
This PR adds a `hledger` module based on `hledger-mode`, separate from the currently existing `ledger` module.

I first tried to extend the `ledger` module with optional hledger support, but it was effectively becoming two modules in one and they could each exist independently so it seems like separating them is a cleaner solution.

Despite being very similar they're still different tools with different behaviours, even the website for hledger only describes it as "comparable" to ledger rather than being a different implementation of the same tool.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).