### PR TITLE
fix(ruby): replace the obsolete macro `featurep!` with `modulep!`

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -214,7 +214,7 @@
         "r" #'projectile-rails-command-map))
 
 (use-package! rails-routes
-  :when (featurep! +rails)
+  :when (modulep! +rails)
   :defer t
   :init
   (map! :after ruby-mode
@@ -229,7 +229,7 @@
         "C-c ! o" #'rails-routes-jump))
 
 (use-package! rails-i18n
-  :when (featurep! +rails)
+  :when (modulep! +rails)
   :defer t
   :init
   (map! :after ruby-mode


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Replace the obsolete macro `featurep!` with `modulep!`.

Fix: N/A
Ref: N/A
Close: N/A

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
