### PR TITLE
fix(fold): autoload `+fold--ensure-hideshow-mode`

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -8,6 +8,7 @@
 ;;
 ;;; Helpers
 
+;;;###autoload
 (defun +fold--ensure-hideshow-mode ()
   "Enable `hs-minor-mode' if not already enabled.
 


### PR DESCRIPTION
This function may be called by `+fold--ensure-hideshow-mode-a`, before autoload/fold.el has been loaded.

Amend: #8067

<!-- ⚠️ Please do not ignore this template! -->
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
