### PR TITLE
Fix agda auto functionality reference to mimer

### DIFF
--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -24,7 +24,7 @@
         ","   #'agda2-goal-and-context
         "="   #'agda2-show-constraints
         "SPC" #'agda2-give
-        "a"   #'agda2-auto-maybe-all
+        "a"   #'agda2-mimer-maybe-all
         "b"   #'agda2-previous-goal
         "c"   #'agda2-make-case
         "d"   #'agda2-infer-type-maybe-toplevel


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

With version 2.7.0 of Agda and the introduction of mimer (instead of agsy) for agda auto mode, the auto mode call changed in agda mode emacs setting: https://github.com/agda/agda/blob/8512b9cd91761e7366291e111ada5141c0fad23a/src/data/emacs-mode/agda2-mode.el#L235

this change in Agda's agda-mode breaks the current doomemacs setting and doomemacs call for agda auto mode does not work. The proposed PR fixes this issue.


Fix: #0000
Ref: #0000
Close: #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


<!-- Remove checklist items above that don't apply to this PR -->



