### PR TITLE
fix(doom-dashboard): right text overflow in modeline

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -276,6 +276,7 @@ whose dimensions may not be fully initialized by the time this is run."
         (set-window-fringes win 0 0)
         (set-window-margins
          win (max 0 (/ (- (window-total-width win) +doom-dashboard--width) 2))))
+      (setq mode-line-right-align-edge 'right-margin)
       (with-current-buffer (doom-fallback-buffer)
         (save-excursion
           (with-silent-modifications


### PR DESCRIPTION
This commit fixes a bug where the right string 'DOOM v3.0.0-pre  🕝 6:24PM' in *doom* buffer's mode line gets cut off. The previous screenshot is as follows,
<img width="300" alt="before-screenshot" src="https://github.com/user-attachments/assets/d2436e1a-1ae4-430d-9e1f-ec23075e7ceb">
and the screenshot after this commit is below.
<img width="300" alt="after-screenshot" src="https://github.com/user-attachments/assets/707aa9b3-21fa-4327-ba3c-56ae4159359d">

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
