### PR TITLE
bump: :lang factor

### DIFF
--- a/modules/lang/factor/packages.el
+++ b/modules/lang/factor/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/factor/packages.el
 
-(package! fuel :pin "31dc1a386b06bbde4062f57c12bb4efe3fc635db")
+(package! fuel :pin "6d0e98494f89d8b7dcfcae4cf83775562bf44ea9")


### PR DESCRIPTION
factor/fuel@31dc1a386b06 -> factor/fuel@6d0e98494f89

Melpa's upstream and recipe for `fuel` changed (see https://github.com/melpa/melpa/commit/4a3d7cdefacce68fcc53e9428cb2a9a5ec1bf978): previously it was pulled from a subdirectory of the main `factor` repository, it now has its own repository. Applying Doom's previous pin to the new recipe does not seem to work correctly, so update.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
