### PR TITLE
fix(eval): remove duplicate REPL entries

### DIFF
--- a/modules/tools/eval/autoload/repl.el
+++ b/modules/tools/eval/autoload/repl.el
@@ -88,7 +88,7 @@ human-readable variant of its associated major mode name."
                          (+eval-repl-known-repls)))
          (founds (mapcar (lambda (fn) (list (+eval-pretty-mode-name-from-fn fn) fn))
                          (+eval-repl-found-repls)))
-         (repls (cl-delete-duplicates (append knowns founds)))
+         (repls (cl-delete-duplicates (append knowns founds) :test #'equal))
          (names (mapcar #'car repls))
          (choice (or (completing-read "Open a REPL for: " names)
                      (user-error "Aborting"))))


### PR DESCRIPTION
Using `+eval/open-repl-other-window` in a window that isn't associated with a given repl (for example, the starting screen), I would get duplicate entries in the prompt, because cl-delete-duplicates compares with `eql` by default.

Another issue that I see that's similar is that the different python repls (`+python/open-jupyter-repl`, `+python/open-repl`) are listed under the same name in the prompt. This pr doesn't fix that, however.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
