### PR TITLE
fix(python): +python-executable-find ipython

### DIFF
--- a/modules/lang/python/autoload/python.el
+++ b/modules/lang/python/autoload/python.el
@@ -16,8 +16,8 @@ falling back on searching your PATH."
                (let ((bin (expand-file-name (concat conda-env-current-name "/" exe-root)
                                             (conda-env-default-location))))
                  (if (file-executable-p bin) bin))))
-            ((when-let (bin (projectile-locate-dominating-file default-directory "bin/python"))
-               (setq-local doom-modeline-python-executable (expand-file-name "bin/python" bin))))
+            ((when-let (bin (projectile-locate-dominating-file default-directory exe-root))
+               (setq-local doom-modeline-python-executable (expand-file-name exe-root bin))))
             ((executable-find exe))))))
 
 ;;;###autoload


### PR DESCRIPTION
+python-executable-find cannot find `ipython` since `/bin/python` is hardcoded instead of using the parameter that tells which executable we are finding. Therefore this commit fix `+python/open-ipython-repl` 
