### PR TITLE
Add opam-switch-mode to  lang: coq and fix configuration of opam-switch-mode in lang: ocaml

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -93,3 +93,17 @@
           "e" #'company-coq-document-error
           "E" #'company-coq-browse-error-messages
           "h" #'company-coq-doc)))
+
+(use-package! opam-switch-mode
+  :hook (coq-mode . opam-switch-mode)
+  :preface
+  (map! :after coq
+        :localleader
+        :map coq-mode-map
+        "w" #'opam-switch-set-switch)
+  :init
+  (defadvice! +coq--init-opam-switch-mode-maybe-h (fn &rest args)
+    "Activate `opam-switch-mode' if the opam executable exists."
+    :around #'opam-switch-mode
+    (when (executable-find opam-switch-program-name)
+      (apply fn args))))

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -3,3 +3,5 @@
 
 (package! proof-general :pin "3a99da275523c8f844fdfa3dd073295eece939f3")
 (package! company-coq :pin "5affe7a96a25df9101f9e44bac8a828d8292c2fa")
+
+(package! opam-switch-mode :pin "1069e56a662f23ea09d4e05611bdedeb99257012")

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -125,10 +125,10 @@
     (when (executable-find opam-switch-program-name)
       (apply fn args)))
   :config
-  ;; Use opam to set environment
-  (setq tuareg-opam-insinuate t)
-  (opam-switch-set-switch (tuareg-opam-current-compiler)))
-
+  (after! tuareg
+    ;; Use opam to set environment
+    (setq tuareg-opam-insinuate t)
+    (opam-switch-set-switch (tuareg-opam-current-compiler))))
 
 (when (modulep! +tree-sitter)
   (add-hook 'tuareg-mode-local-vars-hook #'tree-sitter!))


### PR DESCRIPTION
This PR adds configuration to install and use `opam-switch-mode` to manage `opam` switches to the `coq` module. The configuration is taken almost straight from PR #7806 which added the same capability to the `ocaml` module. The only difference is that, unlike in the `ocaml` module, we do not initialize the environment right away.
Incidentally, we need to wrap this initialization inside the `ocaml` module, or it will try to execute even if `tuareg` isn't loaded and produce an error.

Note that this is my first PR, and that I am not very familiar with Emacs and `use-package`, so I'm not very confident that commit bdb4d6064650a5435c5f153b9180aac82b7c5db5 is doing the right thing; at least, it seems to work on my machine.
I'm also not sure if it's fine to use the same `package!` in two different, non-mutually-exclusive modules.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
