### PR TITLE
feat(file-templates): add apply method

### DIFF
--- a/modules/editor/file-templates/config.el
+++ b/modules/editor/file-templates/config.el
@@ -148,10 +148,10 @@ must be non-read-only, empty, and there must be a rule in
        (null (buffer-base-buffer))  ; ...isn't an indirect clone
        (file-templates-apply)))
 
-(defun file-templates-apply ()
+(defun +file-templates/apply ()
   "Actually expand a file template if one exists"
   (interactive)
-  (when-let (rule (cl-find-if #'+file-template-p +file-templates-alist))
+  (when-let* ((rule (cl-find-if #'+file-template-p +file-templates-alist)))
     (apply #'+file-templates--expand rule)))
 
 ;;

--- a/modules/editor/file-templates/config.el
+++ b/modules/editor/file-templates/config.el
@@ -146,7 +146,7 @@ must be non-read-only, empty, and there must be a rule in
        (not (file-exists-p buffer-file-name))  ; ...is a new file
        (not (buffer-modified-p))    ; ...hasn't been modified
        (null (buffer-base-buffer))  ; ...isn't an indirect clone
-       (file-templates-apply)))
+       (+file-templates/apply)))
 
 (defun +file-templates/apply ()
   "Actually expand a file template if one exists"

--- a/modules/editor/file-templates/config.el
+++ b/modules/editor/file-templates/config.el
@@ -146,9 +146,13 @@ must be non-read-only, empty, and there must be a rule in
        (not (file-exists-p buffer-file-name))  ; ...is a new file
        (not (buffer-modified-p))    ; ...hasn't been modified
        (null (buffer-base-buffer))  ; ...isn't an indirect clone
-       (when-let (rule (cl-find-if #'+file-template-p +file-templates-alist))
-         (apply #'+file-templates--expand rule))))
+       (file-templates-apply)))
 
+(defun file-templates-apply ()
+  "Actually expand a file template if one exists"
+  (interactive)
+  (when-let (rule (cl-find-if #'+file-template-p +file-templates-alist))
+    (apply #'+file-templates--expand rule)))
 
 ;;
 ;;; Bootstrap


### PR DESCRIPTION
Factor template application code into command file-templates-apply. This allows it to be invoked by the user.

Personally, I find file templates very annoying, and 9/10 times I would end up just deleting the template boilerplate, so I disabled it. However, in some cases I might want to use it. Rather than having to reconfigure whether templates are enabled and re-create the file, we simply pull the couple of lines where the template is actually applied out into a function and add `(interactive)`. Now I can just `M-x file-templates-apply` in the buffer where I want to use the templates.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
