### PR TITLE
fix: early-init with DOOMPROFILE set

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -89,8 +89,8 @@
                            emacs-major-version)
                    (or (if windows? (getenv-internal "LOCALAPPDATA"))
                        (getenv-internal "XDG_DATA_HOME")
-                       "~/.local/share"))
-                  'noerror (not init-file-debug) 'nosuffix))
+                       "~/.local/share")))
+                'noerror (not init-file-debug) 'nosuffix)
           (user-error "Profiles not initialized yet; run 'doom sync' first"))))
 
   ;; PERF: When `load'ing or `require'ing files, each permutation of


### PR DESCRIPTION
Recent changes to early-init.el accidentally moved some arguments intended for `load` to an inner `let`, which means only the last argument gets passed to `load`. This results in

```
> Debugger entered--Lisp error: (wrong-type-argument stringp nosuffix)
>   load(nosuffix)
>   (or (load (let ((windows? (memq system-type '(ms-dos windows-nt cygwin)))) (expand-file-name...
```

when starting Doom (or running a doomscript) with DOOMPROFILE set.

Move these arguments back out of the `let`.

Amend: 9ae7aa1122781c8b4353fad049bc7b5cea1b0638

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
