### PR TITLE
docs(cli): remove references to `clean`

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -622,7 +622,6 @@ If you want to update Doom manually, ~doom upgrade~ is equivalent to:
 #+BEGIN_SRC bash
 cd ~/.emacs.d
 git pull        # updates Doom
-doom clean      # Ensure your config isn't byte-compiled
 doom sync       # synchronizes your config with Doom Emacs
 doom update     # updates installed packages
 #+END_SRC
@@ -1506,10 +1505,6 @@ provide tools to make this easier. Here are a few things you can try, first:
 
 + Run ~bin/doom doctor~ on the command line to diagnose common issues with your
   environment and config. It will suggest solutions for them as well.
-
-+ ~bin/doom clean~ will ensure the problem isn't stale bytecode in your private
-  config or Doom core. If you haven't used ~bin/doom compile~, there's no need
-  to do this.
 
 + ~bin/doom sync~ will ensure the problem isn't missing packages or outdated
   autoloads files


### PR DESCRIPTION
Because the command has been removed [1].

[1]: https://github.com/doomemacs/doomemacs/commit/63c470bff32875098fa5a7f205e0b5eb08247686

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).