### PR TITLE
fix(common-lisp): typo file instead of pfile

### DIFF
--- a/lisp/lib/autoloads.el
+++ b/lisp/lib/autoloads.el
@@ -182,7 +182,7 @@ non-nil, treat FILES as pre-generated autoload files instead."
               ;; Fixup the special #$ reader form and throw away comments.
               (while (re-search-forward "#\\$\\|^;\\(.*\n\\)" nil 'move)
                 (unless (ppss-string-terminator (save-match-data (syntax-ppss)))
-                  (replace-match (if (match-end 1) "" pfile) t t))))
+                  (replace-match (if (match-end 1) "" file) t t))))
             (let ((load-file-name file)
                   (load-path
                    (append (list doom-user-dir)


### PR DESCRIPTION
This typo is responsible of a startup error `delayed-warnings-hooks void-variable warning-minimum-log-level` because of common-lisp module

Fix: #8144 

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
