### PR TITLE
fix: no default to hl-line in describe-face

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -398,7 +398,16 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
   (add-hook! 'evil-visual-state-exit-hook
     (defun doom-enable-hl-line-maybe-h ()
       (when doom--hl-line-mode
-        (hl-line-mode +1)))))
+        (hl-line-mode +1))))
+
+  ;; Otherwise we always hit hl-line-face
+  (define-advice face-at-point (:around (&rest args))
+    (if hl-line-mode
+        (unwind-protect
+            (progn (hl-line-mode -1)
+                   (apply args))
+          (hl-line-mode +1))
+      (apply args))))
 
 
 (use-package! winner


### PR DESCRIPTION
One issue that always bugged me as a new user of doom and other distros, especially when I had less elisp skills, was that I could never use `describe-face` to get useful info about faces (in order to figure anything out) since `hl-line-face` was always in the way. I never wanted info about `hl-line-face`. So just disable the mode while running the proc that gets the default prompt value for `describe-face`.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
