### PR TITLE
fix(tools): double prompt when region sent to repl

### DIFF
--- a/modules/tools/eval/autoload/repl.el
+++ b/modules/tools/eval/autoload/repl.el
@@ -157,8 +157,7 @@ immediately after."
                (delete-region (point-min) (point)))
              (indent-rigidly (point) (point-max)
                              (- (skip-chars-forward " \t")))
-             (concat (string-trim-right (buffer-string))
-                     "\n"))))
+             (string-trim-right (buffer-string)))))
       (with-selected-window (get-buffer-window buffer)
         (with-current-buffer buffer
           (dolist (line (split-string selection "\n"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

# Problem
Using `+eval/send-region-to-repl` makes the python repl add too many newlines and causes double prompts.
<img width="641" alt="Screenshot 2024-11-08 at 11 12 06 PM" src="https://github.com/user-attachments/assets/c26ca8ff-3510-4669-984c-e78ab82eed37">

## Why problem happens
The `+eval/send-region-to-repl` function takes a region, formats it, and adds a newline at the end of it. Then each line is fed to the repl one by one, i.e. each line is pasted into the repl buffer and submitted by simulating a "RET" key press. Because there is a newline added at the end of the region and "RET" is simulated, there are essentially two newlines being sent to the repl with the last line of the region. This double newline causes the odd spacing and double prompting.

## Solution
The solution is to not concatenate a newline at the end of the region. This prevents the double newline on the last line sent to the repl.
<img width="628" alt="Screenshot 2024-11-08 at 11 39 37 PM" src="https://github.com/user-attachments/assets/49e6e513-16df-41c7-b515-a1329caab56a">

## Before change demo:
https://github.com/user-attachments/assets/12234c82-7452-4209-ab33-cc6f015903fa

## After change demo:
https://github.com/user-attachments/assets/13374354-5431-44bf-bda2-61ee749a6673

### Side discussion
I noticed some other issues with the repl functions that I wanted to tackle. However, I decided to start small with this pr. While debugging, I noticed something. Looking at `+eval/send-region-to-repl`, the region being sent to the repl is carefully formatted and sent line by line. The function `+eval-open-repl` first opens a repl, and if a region is active it sends the region to the repl. However it just slaps the entire region itself into the repl. This causes strange behavior, but additional screenshots would look confusing in this pr. The '+eval-open-repl' function should reuse the region surgery code that already exists in `+eval/send-region-to-repl` to prevent this. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
