### PR TITLE
tweak: consistent order for profile init functions

### DIFF
--- a/lisp/lib/profiles.el
+++ b/lisp/lib/profiles.el
@@ -242,7 +242,8 @@ caches them in `doom--profiles'. If RELOAD? is non-nil, refresh the cache."
   (doom-initialize-packages)
   (let* ((default-directory doom-profile-dir)
          (init-dir  doom-profile-init-dir-name)
-         (init-file (doom-profile-init-file doom-profile)))
+         (init-file (doom-profile-init-file doom-profile))
+         (generators (seq-sort-by #'car #'string< doom-profile-generators)))
     (print! (start "(Re)building profile in %s/...") (path default-directory))
     (condition-case-unless-debug e
       (with-file-modes #o750
@@ -255,12 +256,12 @@ caches them in `doom--profiles'. If RELOAD? is non-nil, refresh the cache."
                      do (print! (item "Deleting %s...") file)
                      and do (delete-file file)))
           (let ((auto-files (doom-glob init-dir "*.auto.el")))
-            (print! (start "Generating %d init files...") (length doom-profile-generators))
+            (print! (start "Generating %d init files...") (length generators))
             (print-group! :level 'info
               (dolist (file auto-files)
                 (print! (item "Deleting %s...") file)
                 (delete-file file))
-              (pcase-dolist (`(,file ,fn _) doom-profile-generators)
+              (pcase-dolist (`(,file ,fn _) generators)
                 (let ((file (doom-path init-dir file)))
                   (doom-log "Building %s..." file)
                   (insert "\n;;;; START " file " ;;;;\n")
@@ -298,7 +299,7 @@ caches them in `doom--profiles'. If RELOAD? is non-nil, refresh the cache."
                       ;; init file.
                       (when (or (doom-context-p 'startup)
                                 (doom-context-p 'reload))
-                        ,@(cl-loop for (_ genfn initfn) in doom-profile-generators
+                        ,@(cl-loop for (_ genfn initfn) in generators
                                    if (fboundp genfn)
                                    collect (list initfn))))
                    (current-buffer)))


### PR DESCRIPTION
Doom embeds the partials generated by functions on `doom-profile-generators` in lexicographical order by filename, but after recent refactoring all these partials generally do is define a function which Doom calls from `doom-startup`. When Doom generates `doom-startup`, it inserts these calls in `doom-profile-generators` order.

This does not affect Doom itself, since it initializes `doom-profile-generators` in a sensible order. But any additional entries pushed onto `doom-profile-generators` run first, which is surprising (and might break them if they depend on loaddefs or modules having initialized).

Fix it by sorting the list. Do so up front just for simplicity: although the order in which we generate the partials is unlikely to matter, if we have to sort the list we might as well use the sorted one throughout.

Amend: b3aa41fd7424

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

(I'm guessing barely anyone outside Doom uses `doom-profile-generators`, but figured I'd send this your way just in case, as I doubt this behavior was intended and it seemed easy enough to fix...)

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
