### PR TITLE
feat(terraform): add terraform-docs

### DIFF
--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -22,3 +22,16 @@
   :after terraform-mode
   :config
   (set-company-backend! 'terraform-mode 'company-terraform))
+
+(use-package! terraform-docs
+  :when (modulep! +docs)
+  :defer t
+  :after terraform-mode
+  :config
+  (map! :map terraform-mode-map
+        :localleader
+        :desc "docs" "d" #'terraform-docs
+        (:prefix ("D" . "docs submenu")
+         :desc "to buffer"        "D" #'terraform-docs-to-buffer
+         :desc "to file"          "d" (cmd! (terraform-docs-to-file nil (read-file-name "Output file: ")))
+         :desc "to file and open" "o" (cmd! (terraform-docs-to-file-and-open nil (read-file-name "Output file: "))))))

--- a/modules/tools/terraform/doctor.el
+++ b/modules/tools/terraform/doctor.el
@@ -2,3 +2,7 @@
 
 (unless (executable-find "terraform")
   (warn! "Couldn't find terraform."))
+
+(when (modulep! +lsp)
+  (unless (executable-find "terraform-docs")
+    (warn! "Couldn't find terraform-docs")))

--- a/modules/tools/terraform/packages.el
+++ b/modules/tools/terraform/packages.el
@@ -4,3 +4,8 @@
 (package! terraform-mode :pin "abfc10f5e313c4bb99de136a14636e9bc6df74f6")
 (when (modulep! :completion company)
   (package! company-terraform :pin "8d5a16d1bbeeb18ca49a8fd57b5d8cd30c8b8dc7"))
+
+(when (modulep! +docs)
+  (package! terraform-docs
+    :recipe (:host github :repo "loispostula/terraform-docs.el" :branch "main")
+    :pin "94a78999ec03e66ce49f7343cc8705354e195c3a"))


### PR DESCRIPTION
Add `terraform-docs` package to the :tools terraform

The package allows for integrating terraform-docs in emacs

Also added keybindings to it. The usage of the keybindings is heavily inspired from 'ox-publish

It's also gated by the `+docs` flag as this requires the `terraform-docs` binary to exists

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
