### PR TITLE
fix: project-current-directory-override takes a directory

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -160,7 +160,7 @@ If DIR is not a project, it will be indexed (but not cached)."
           ((and (bound-and-true-p helm-mode)
                 (fboundp 'helm-find-files))
            (call-interactively #'helm-find-files))
-          ((when-let* ((project-current-directory-override t)
+          ((when-let* ((project-current-directory-override dir)
                        (pr (project-current t dir)))
              (condition-case _
                  (project-find-file-in nil nil pr)


### PR DESCRIPTION
`project-current-directory-override` takes a string, not a `t`. [It overrides `default-directory`](https://github.com/emacs-mirror/emacs/blob/6c1c3120b98652de149ee9d8c241cd3636755171/lisp/progmodes/project.el#L196-L198) which is always a string.

This was causing a crash for me when using `doom/find-file-in-private-config` from a buffer outside a project:

```
  Debugger entered--Lisp error: (wrong-type-argument stringp t)
    file-remote-p(t)
    projectile-project-root(t)
    project-projectile(t)
    run-hook-with-args-until-success(project-projectile t)
    project--find-in-directory(t)
  [...lots, available on request, but it doesn't seem relevant...]
    doom-project-find-file("/Users/user/.doom.d/")
    doom/find-file-in-private-config()
    funcall-interactively(doom/find-file-in-private-config)
    command-execute(doom/find-file-in-private-config)
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).