### PR TITLE
fix(modeline): change macOS default EOL type to LF

### DIFF
--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -23,8 +23,7 @@
         ;; Only show file encoding if it's non-UTF-8 and different line endings
         ;; than the current OSes preference
         doom-modeline-buffer-encoding 'nondefault
-        doom-modeline-default-eol-type
-        (pcase (car doom-system) ('macos 2) ('windows 1) (_ 0)))
+        doom-modeline-default-eol-type (if (featurep :system 'windows) 1 0))
 
   :config
   ;; Fix an issue where these two variables aren't defined in TTY Emacs on MacOS


### PR DESCRIPTION
It looks like CR was only the default line ending type for Mac in Mac OS 9 and earlier, and it's now quite uncommon:
- https://retrocomputing.stackexchange.com/a/21906
- https://superuser.com/a/439443

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
