### PR TITLE
Update homebrew-emacsmacport linking instruction

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -294,7 +294,11 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
   brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  # Apple Silicon Macs
+  osascript -e 'tell application "Finder" to make alias file to POSIX file "/opt/homebrew/opt/emacs-mac/Emacs.app" at POSIX file "/Applications"'
+
+  # Intel Macs
+  osascript -e 'tell application "Finder" to make alias file to POSIX file "/usr/local/opt/emacs-mac/Emacs.app" at POSIX file "/Applications"'
   #+END_SRC
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have


### PR DESCRIPTION
The current linking instruction no longer work after some breaking homebrew change.

Update it to the latest instruction recommended by the maintainer that basically functions the same as `ln -s`: https://github.com/railwaycat/homebrew-emacsmacport/blob/master/docs/emacs-start-helpers.md

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.