### PR TITLE
fix(fold): make fold functions consistent

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -142,13 +142,13 @@ Return non-nil if successful in doing so."
 Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
-    (cond ((+fold--vimish-fold-p) (vimish-fold-toggle))
+    (cond ((+fold--ts-fold-p) (ts-fold-toggle))
+          ((+fold--vimish-fold-p) (vimish-fold-toggle))
           ((+fold--outline-fold-p)
            (cl-letf (((symbol-function #'outline-hide-subtree)
                       (symbol-function #'outline-hide-entry)))
              (outline-toggle-children)))
-          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-toggle-hiding)))
-          ((+fold--ts-fold-p) (ts-fold-toggle)))))
+          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-toggle-hiding))))))
 
 ;;;###autoload
 (defun +fold/open-rec ()
@@ -166,12 +166,12 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
 Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
-    (cond ((+fold--vimish-fold-p) (vimish-fold-unfold))
+    (cond ((+fold--ts-fold-p) (ts-fold-open))
+          ((+fold--vimish-fold-p) (vimish-fold-unfold))
           ((+fold--outline-fold-p)
            (outline-show-branches)
            (outline-show-entry))
-          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-show-block)))
-          ((+fold--ts-fold-p) (ts-fold-open)))))
+          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-show-block))))))
 
 ;;;###autoload
 (defun +fold/close ()
@@ -180,10 +180,10 @@ Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
 Targets `vimmish-fold', `hideshow', `ts-fold' and `outline' folds."
   (interactive)
   (save-excursion
-    (cond ((+fold--vimish-fold-p) (vimish-fold-refold))
+    (cond ((+fold--ts-fold-p) (ts-fold-close))
+          ((+fold--vimish-fold-p) (vimish-fold-refold))
           ((+fold--outline-fold-p) (outline-hide-subtree))
-          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-hide-block)))
-          ((+fold--ts-fold-p) (ts-fold-close)))))
+          ((+fold--hideshow-fold-p) (+fold-from-eol (hs-hide-block))))))
 
 ;;;###autoload
 (defun +fold/open-all (&optional level)


### PR DESCRIPTION
The +fold/{open,close}-all functions prioritized the ts-fold package, while +fold/{toggle,open,close} prioritized the hideshow package.

This will break +fold/{toggle,open,close} for using +fold/close-all buffer when tree-sitter is enabled.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
