### PR TITLE
fix(lib): pass correct argument `project-current-directory-override`

### DIFF
--- a/lisp/lib/projects.el
+++ b/lisp/lib/projects.el
@@ -160,7 +160,7 @@ If DIR is not a project, it will be indexed (but not cached)."
           ((and (bound-and-true-p helm-mode)
                 (fboundp 'helm-find-files))
            (call-interactively #'helm-find-files))
-          ((when-let* ((project-current-directory-override t)
+          ((when-let* ((project-current-directory-override nil)
                        (pr (project-current t dir)))
              (condition-case _
                  (project-find-file-in nil nil pr)


### PR DESCRIPTION
`project-current-directory-override` is `nil` by default and expect the value of directory name i.e. string when non-nil. The value set to this variable is to detect directory which fails with:
`(wrong-argument-type stringp t)`
