### PR TITLE
fix(notmuch): afew: process only new mail

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -36,7 +36,7 @@
 
 (defun +notmuch-get-sync-command ()
   "Return a shell command string to synchronize your notmuch mail with."
-  (let* ((afew-cmd "afew -a -t")
+  (let* ((afew-cmd "afew -n -t")
          (sync-cmd
           (pcase +notmuch-sync-backend
             (`gmi


### PR DESCRIPTION
The `-a` option will cause afew to process all the user's mail. If the user has a lot of mail, this will take an extremely long time, every time. The expected usage is to process only mail that has been tagged 'new' by notmuch (which requires the [correct
setup](https://github.com/afewmail/afew/blob/master/docs/quickstart.rst)).

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
