### PR TITLE
tweak(vertico): remove consult-man remapping

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -115,7 +115,6 @@ orderless."
     [remap Info-search]                   #'consult-info
     [remap locate]                        #'consult-locate
     [remap load-theme]                    #'consult-theme
-    [remap man]                           #'consult-man
     [remap recentf-open-files]            #'consult-recent-file
     [remap switch-to-buffer]              #'consult-buffer
     [remap switch-to-buffer-other-window] #'consult-buffer-other-window


### PR DESCRIPTION
`consult-man` is not a good drop-in replacement for `man`. `consult-man` searches man pages and descriptions (like the apropos program). The original `man` function lets the user pick a man page from the list of man pages.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.