### PR TITLE
fix(fold): fix recursive unfolding

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -113,9 +113,7 @@ Return non-nil if successful in doing so."
   (when (featurep 'vimish-fold)
     ;; from `vimish-fold-unfold-all'
     (mapc #'vimish-fold--unfold
-          (vimish-fold--folds-in
-           (point-min)
-           (point-max))))
+          (vimish-fold--folds-in beg end)))
   (and (+fold--outline-fold-p)
        (outline-show-subtree))
   (hs-life-goes-on
@@ -126,7 +124,7 @@ Return non-nil if successful in doing so."
   (when (bound-and-true-p ts-fold-mode)
     ;; from `ts-fold-open-all'
     (ts-fold--ensure-ts
-      (thread-last (overlays-in (point-min) (point-max))
+      (thread-last (overlays-in beg end)
                    (seq-filter
                     (lambda (ov)
                       (eq (overlay-get ov 'invisible) 'ts-fold)))


### PR DESCRIPTION
`point-min` and `point-max` were used in some places in `+fold--open-rec-between` instead of `beg` and `end`. This caused `+fold/open-rec` to open all folds rather than only the one the curser is on.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
