### PR TITLE
fix(org): allow tab to expand yasnippets in org

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -839,11 +839,6 @@ between the two."
             #'+org-delete-backward-char-and-realign-table-maybe-h)
 
   (map! :map org-mode-map
-        ;; Recently, a [tab] keybind in `outline-mode-cycle-map' has begun
-        ;; overriding org's [tab] keybind in GUI Emacs. This is needed to undo
-        ;; that, and should probably be PRed to org.
-        :ie [tab]    #'org-cycle
-
         "C-c C-S-l"  #'+org/remove-link
         "C-c C-i"    #'org-toggle-inline-images
         ;; textmate-esque newline insertion


### PR DESCRIPTION
I do not see any evidence of a [tab] binding in `outline-mode-cycle-map` in Emacs29, Emacs30, nor Emacs31. Moreover, this keybinding is overriding our TAB keybinding in GUI Emacs, so YaSnippets are not being expanded.

This references "yasnippet in org-mode. Fix TAB for jumping to $1 and $2" from the Discord server.

Also referencesconversations spread around other issues & PRs.