### PR TITLE
fix(layout): Rotate bépo keybindings in dirvish

### DIFF
--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -211,6 +211,23 @@ In all cases, 'h' functions go to 'c' and 'l' ones go to 'r' so the navigation k
           "s" nil
           "t" nil))
 
+  (after! dirvish
+    ;; Without this, "s" stays mapped to 'symlinks' prefix of dirvish (in the
+    ;; 'dirvish' map, configured in (:emacs dired) module
+    (map! :map dirvish-mode-map "s" nil)
+    ;; Manual rotation of the gh/gl bindings
+    (map! :map dirvish-mode-map
+          :n "gh" nil
+          :n "gl" nil
+          :n "gc" '#dirvish-subtree-up
+          :n "gr" '#dirvish-subtree-toggle)
+    (if (eq +layout-bepo-cr-rotation-style 'ergodis)
+        (map! :map dirvish-mode-map
+              :n "gh" '#revert-buffer)
+      (map! :map dirvish-mode-map
+            :n "gl" '#revert-buffer))
+    (+layout-bepo-rotate-keymaps '(dirvish-mode-map)))
+
   
   ;; Start of the Magit zone
   ;;


### PR DESCRIPTION
Close: #8129

<!-- ⚠️ Please do not ignore this template! -->

Dirvish wasn’t taken care of in the bépo-specific rotations, and ended up having issues around the binding for the `s` key

The PR is a draft because it’s untested yet (I don’t write in Bépo so testing actually takes more time than writing the code)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] ~~My changes are visual; I've included before and after screenshots.~~
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to ~~finish~~ test it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
