### PR TITLE
fix(ansible): check for metadata/config file

### DIFF
--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -32,4 +32,8 @@
 (def-project-mode! +ansible-yaml-mode
   :modes '(yaml-mode)
   :add-hooks '(ansible-mode ansible-auto-decrypt-encrypt ansible-doc-mode)
-  :files (or "roles/" "tasks/main.yml" "tasks/main.yaml"))
+  :files (or "roles/"
+             "tasks/main.yml"
+             "tasks/main.yaml"
+             "galaxy.yml"
+             "galaxy.yaml"))

--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -35,5 +35,6 @@
   :files (or "roles/"
              "tasks/main.yml"
              "tasks/main.yaml"
+             "ansible.cfg"
              "galaxy.yml"
              "galaxy.yaml"))


### PR DESCRIPTION
galaxy metadata file is now the main component of Ansibe collections, this should help with #1139 (collections with playbooks only, custom layouts).

Fix: #1139

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
