### PR TITLE
fix(cc): replace opencl-mode with opencl-c-mode

### DIFF
--- a/modules/lang/cc/autoload.el
+++ b/modules/lang/cc/autoload.el
@@ -1,7 +1,7 @@
 ;;; lang/cc/autoload.el -*- lexical-binding: t; -*-
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.cl\\'" . opencl-mode))
+(add-to-list 'auto-mode-alist '("\\.cl\\'" . opencl-c-mode))
 
 ;; The plusses in c++-mode can be annoying to search for ivy/helm (which reads
 ;; queries as regexps), so we add these for convenience.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

opencl-mode source code was updated, renaming it to `opencl-c-mode`, as can be confirmed on the pinned commit it:

```el
# ./modules/lang/cc/packages.el 10: 
(package! opencl-mode :pin "204d5d9e0f5cb2cbe810f2933230eb08fe2c7695")
```

https://github.com/salmanebah/opencl-mode/commit/204d5d9e0f5cb2cbe810f2933230eb08fe2c7695

So opening *.cl files the expected mode does not get applied. 

Also mentioned in the discord help
https://discord.com/channels/406534637242810369/1312189226774954105


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).


<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
