### PR TITLE
tweak(csharp): add open brace to electric chars

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -4,7 +4,7 @@
   :hook (csharp-mode . rainbow-delimiters-mode)
   :config
   (set-formatter! 'csharpier '("dotnet-csharpier") :modes '(csharp-mode))
-  (set-electric! 'csharp-mode :chars '(?\n ?\}))
+  (set-electric! 'csharp-mode :chars '(?\n ?\{ ?\}))
   (set-rotate-patterns! 'csharp-mode
     :symbols '(("public" "protected" "private")
                ("class" "struct")))


### PR DESCRIPTION
With this commit, the electric characters list is now the same in csharp-mode as in cc-mode.

Before this commit, typing "if (true) RET { RET" would produce the following:

```
if (true)
    {

    }
```

After this commit, it produces the following:

```
if (true)
{

}
```

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).