### PR TITLE
Update +workspce/switch-left[right] in workspaces.el

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -413,10 +413,10 @@ end of the workspace list."
         ('error (+workspace-error ex t))))))
 
 ;;;###autoload
-(defun +workspace/switch-left ()  (interactive) (+workspace/cycle -1))
+(defun +workspace/switch-left (&optional n)  (interactive "p") (+workspace/cycle (- n)))
 
 ;;;###autoload
-(defun +workspace/switch-right () (interactive) (+workspace/cycle +1))
+(defun +workspace/switch-right (&optional n) (interactive "p") (+workspace/cycle n))
 
 ;;;###autoload
 (defun +workspace/close-window-or-workspace ()


### PR DESCRIPTION
feat: Switches workspace left and right more than one at a time.
scope: For doomemacs/doomemacs

Added optional number to switch the workspace left or right by a count


Added optional number to `+workspace/switch-left`(and right) to be able
to jump more than one workspace at a time because
`+workspace:switch-next`(and previous) jumps directly to the numbered
workspace not the next 'nth' workspace from current one. I find this
more intuitive (for vim/evil though) and easier to add here where
it (hopefully) won't mess with anybodies config rather than breaking
`+workspace:switch-next' (and previous).


FILENAME: /modules/ui/workspaces/autoload/workspace.el


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] Any relevant issues or PRs have been linked to.

