### PR TITLE
fix: `auto-mode-alist`: make `/*rc` rule low-priority

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -247,7 +247,7 @@ tell you about it. Very annoying. This prevents that."
 ;;; Extra file extensions to support
 
 (add-to-list 'auto-mode-alist '("/LICENSE\\'" . text-mode))
-(add-to-list 'auto-mode-alist '("rc\\'" . conf-mode))
+(add-to-list 'auto-mode-alist '("rc\\'" . conf-mode) 'append)
 
 
 ;;


### PR DESCRIPTION
When `nconc` was changed to `add-to-list`, that made this fallback rule be added to the beginning of `auto-mode-alist` instead of the end.