### PR TITLE
fix(ruby): don't load robe with the flag +lsp

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -44,10 +44,11 @@
   :init
   (add-hook! 'ruby-mode-hook
     (defun +ruby-init-robe-mode-maybe-h ()
-      "Start `robe-mode' if `lsp-mode' isn't active."
-      (or (bound-and-true-p lsp-mode)
-          (bound-and-true-p lsp--buffer-deferred)
-          (robe-mode +1))))
+      "Start `robe-mode' if `lsp-mode' or `+lsp' aren't active."
+      (unless (or (bound-and-true-p lsp-mode)
+                  (bound-and-true-p lsp--buffer-deferred)
+                  (modulep! +lsp))
+        (robe-mode +1))))
   :config
   (set-repl-handler! 'ruby-mode #'+ruby-robe-repl-handler)
   (set-company-backend! 'ruby-mode 'company-robe 'company-dabbrev-code)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Eglot competes with robe for functionality, just like lsp-mode.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
