### PR TITLE
fix(cli): some package files not being byte-compiled (2nd take)

### DIFF
--- a/lisp/doom-straight.el
+++ b/lisp/doom-straight.el
@@ -282,37 +282,5 @@ However, in batch mode, print to stdout instead of stderr."
        (error "Package was not properly cloned due to a connection failure, please try again later")
      (signal (car e) (cdr e))))))
 
-;; HACK: Fix an issue where straight wasn't byte-compiling some packages (or
-;;   some files in packages) due to missing (invisible) dependencies.
-(defadvice! doom-straight--byte-compile-a (recipe)
-  "See https://github.com/radian-software/straight.el/pull/1132"
-  :override #'straight--build-compile
-  (let* ((pkg (plist-get recipe :package))
-         (dir (straight--build-dir pkg))
-         (emacs (concat invocation-directory invocation-name))
-         (buffer straight-byte-compilation-buffer)
-         (deps
-          (let (tmp)
-            (dolist (dep (straight--flatten (straight-dependencies pkg)) tmp)
-              (let ((build-dir (straight--build-dir dep)))
-                (when (file-exists-p build-dir)
-                  (push build-dir tmp))))))
-         (print-circle nil)
-         (print-length nil)
-         (program
-          (format "%S" `(let ((default-directory ,(straight--build-dir))
-                              (lp load-path))
-                          (setq load-path (list default-directory))
-                          (normal-top-level-add-subdirs-to-load-path)
-                          (setq load-path (append '(,dir) ',deps load-path lp))
-                          (byte-recompile-directory ,dir 0 'force))))
-         (args (list "-Q" "--batch" "--eval" program)))
-    (when buffer
-      (with-current-buffer (get-buffer-create buffer)
-        (insert (format "\n$ %s %s \\\n %S\n" emacs
-                        (string-join (butlast args) " ")
-                        program))))
-    (apply #'call-process `(,emacs nil ,buffer nil ,@args))))
-
 (provide 'doom-straight)
 ;;; doom-packages.el ends here


### PR DESCRIPTION
This reverts a workaround for straight that is no longer necessary because it has been applied upstream and we've bumped the package since.

For some reason I don't understand, this reproducibly fixes a reoccurrence of the original problem for me: Before this commit, some files of the citar package were not byte-compiled. After this commit,the problem is gone.

This effectively reverts 54a084fed7e1, though it's not a reverting commit in strict sense because the code has been moved to a different file.

Revert: 54a084fed7e1
Ref: d80c5e51159f
Ref: #7707
Ref: radian-software/straight.el#1132
Ref: https://discourse.doomemacs.org/t/is-it-expected-that-doom-sync-does-not-byte-compile-native-compile-some-files/4946

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
