### PR TITLE
fix: diff-hl revert not jumping back when aborted

### DIFF
--- a/modules/ui/vc-gutter/config.el
+++ b/modules/ui/vc-gutter/config.el
@@ -93,7 +93,7 @@ Respects `diff-hl-disable-on-remote'."
                 (put 'diff-hl-mode 'last graphic?))))))))
 
   :config
-  (set-popup-rule! "^\\*diff-hl" :select nil :size '+popup-shrink-to-fit)
+  (set-popup-rule! "^\\*diff-hl" :select nil)
 
   (setq diff-hl-global-modes '(not image-mode pdf-view-mode))
   ;; PERF: A slightly faster algorithm for diffing.

--- a/modules/ui/vc-gutter/config.el
+++ b/modules/ui/vc-gutter/config.el
@@ -156,7 +156,7 @@ Respects `diff-hl-disable-on-remote'."
     "Suppresses unexpected cursor movement by `diff-hl-revert-hunk'."
     :around #'diff-hl-revert-hunk
     (let ((pt (point)))
-      (prog1 (apply fn args)
+      (unwind-protect (apply fn args)
         (goto-char pt))))
 
   ;; FIX: `global-diff-hl-mode' enables `diff-hl-mode' *everywhere*, which calls


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
This has been a pet peeve of mine for a while and I finally decided enough was enough.

`diff-hl-revert-hunk-1` [will signal a user-error](https://github.com/dgutov/diff-hl/blame/65a5de16e21c87b7c12a78a63fc3b57e07c03c86/diff-hl.el#L656) if the user decides to abort the revert hunk operation which will prevent the goto-char function from executing and jumping us back to where we were previously. 

Wrapping the `apply` with `ignore-error 'user-error` sort of works, but not completely since hitting C-g or `abort-recursive-edit` wouldn't signal the `user-error` but it would still move the cursor in an odd way.

I thought about replacing it with a `save-excursion` since that seems like the intent of the original method anyways, but I'm not sure if there are other ramifications with that. In the end I think going with an `unwind-protect` felt somewhat safer and more inline with the existing solution.

Fix: #0000
Ref: #0000
Close: #0000

EDIT: I tested this with a before/after by running with an empty doom config and then manually applying the popup rule change. 
```
doom run --doomdir nodoomconfig/
```

https://github.com/user-attachments/assets/7854aeeb-a020-4513-bcf7-4b70e9afae30



-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
