### PR TITLE
fix: use dumb-jump xref instead of dumb-jump-go

### DIFF
--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -223,14 +223,18 @@ This can be passed nil as its second argument to unset handlers for MODES. e.g.
       (+lookup--xref-show 'xref-backend-references identifier #'xref--show-xrefs)
     (cl-no-applicable-method nil)))
 
-(defun +lookup-dumb-jump-backend-fn (_identifier)
+(defun +lookup-dumb-jump-backend-fn (identifier)
   "Look up the symbol at point (or selection) with `dumb-jump', which conducts a
 project search with ag, rg, pt, or git-grep, combined with extra heuristics to
 reduce false positives.
 
 This backend prefers \"just working\" over accuracy."
   (and (require 'dumb-jump nil t)
-       (dumb-jump-go)))
+       ;; See: https://github.com/jacktasia/dumb-jump/issues/353
+       ;; This is a workaround for a workaround to actually both fall back to dumb-jump and use the xref integration for it.
+       (let ((xref-backend-functions '(dumb-jump-xref-activate))
+             (stop-infinite-dumb-jump-recursion t))
+         (+lookup-xref-definitions-backend-fn identifier))))
 
 (defun +lookup-project-search-backend-fn (identifier)
   "Conducts a simple project text search for IDENTIFIER.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Without this dumb-jump uses that older deprecated style of completion either via the popup library or completing read, but it didn't conform as nicely with the all the xref goodies like line numbers, file separators, consult previewing etc..

This (albeit a little hacky) way of temporarily setting the xref-backend-functions to be dumb jump after lsp-mode completion fails, works quite nicely. 

Fix: #0000
Ref: #0000
Close: #0000

# Screenshots
## Before: 
### With 'dumb-jump-selector as 'popup (default)
![Screenshot 2025-01-25 at 1 21 35 AM](https://github.com/user-attachments/assets/9a659f56-be3c-4f29-95cb-d0fa791ddee2)

### as 'completing-read
![image](https://github.com/user-attachments/assets/6d091e1c-f16f-4136-8f14-47b2f9ca6f47)



## After:
![image](https://github.com/user-attachments/assets/a9d540c5-7f10-45ac-9323-402ccde3939b)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to. The ones I found relating to dumb jump were closed already.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
