### PR TITLE
default: add omnicompletion bindings to minibuffer

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -31,6 +31,21 @@ and Emacs states, and for non-evil users.")
 (defvar doom-leader-map (make-sparse-keymap)
   "An overriding keymap for <leader> keys.")
 
+(defvar doom-minibuffer-maps
+  (append '(minibuffer-local-map
+            minibuffer-local-ns-map
+            minibuffer-local-completion-map
+            minibuffer-local-must-match-map
+            minibuffer-local-isearch-map
+            read-expression-map)
+          (cond ((modulep! :completion ivy)
+                 '(ivy-minibuffer-map
+                   ivy-switch-buffer-map))
+                ((modulep! :completion helm)
+                 '(helm-map
+                   helm-rg-map
+                   helm-read-file-map))))
+  "A list of all the keymaps used for the minibuffer.")
 
 ;;
 ;;; Global keybind settings

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -3,22 +3,7 @@
 (defvar +default-want-RET-continue-comments t
   "If non-nil, RET will continue commented lines.")
 
-(defvar +default-minibuffer-maps
-  (append '(minibuffer-local-map
-            minibuffer-local-ns-map
-            minibuffer-local-completion-map
-            minibuffer-local-must-match-map
-            minibuffer-local-isearch-map
-            read-expression-map)
-          (cond ((modulep! :completion ivy)
-                 '(ivy-minibuffer-map
-                   ivy-switch-buffer-map))
-                ((modulep! :completion helm)
-                 '(helm-map
-                   helm-rg-map
-                   helm-read-file-map))))
-  "A list of all the keymaps used for the minibuffer.")
-
+(defvaralias '+default-minibuffer-maps 'doom-minibuffer-maps)
 
 ;;
 ;;; Reasonable defaults

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -581,3 +581,17 @@ directives. By default, this only recognizes C directives.")
            :i "C-o"  #'completion-at-point
            :i "C-n"  #'cape-dabbrev
            :i "C-p"  #'+corfu/dabbrev-this-buffer))))
+
+
+(unless evil-disable-insert-state-bindings
+  (when (modulep! :completion corfu)
+    (define-key!
+      :keymaps (append doom-minibuffer-maps
+                       (when (modulep! :editor evil +everywhere)
+                         '(evil-ex-completion-map)))
+      "C-x C-f"  #'cape-file
+      "C-x s"    #'cape-dict
+      "C-x C-s"  #'yasnippet-capf
+      "C-x C-o"  #'completion-at-point
+      "C-x C-n"  #'cape-dabbrev
+      "C-x C-p"  #'+corfu/dabbrev-this-buffer)))


### PR DESCRIPTION
This commit adds omnicompletion bindings to the minibuffer. This is only done for Corfu because we do not currently enable Company in the minibuffer. This is primarily because sometimes I want to insert a file name into the minibuffer and want to do so with C-x C-f. If you have any suggestions on improving this, please comment below. Not all the bindings are added, because some of them do not make sense in the minibuffer unless you wrap them with special forms.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
