### PR TITLE
fix(corfu): fix default minibuffer completion

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -66,24 +66,41 @@ If any return non-nil, `corfu-auto' will not invoke as-you-type completion.")
   (add-to-list 'corfu-continue-commands #'+corfu/smart-sep-toggle-escape)
   (add-hook 'evil-insert-state-exit-hook #'corfu-quit)
 
-  ;; Respect `+corfu-want-minibuffer-completion'
+  (defun +corfu--other-completion-active-p ()
+    "Return non-nil if another completion framework is already active.
+
+This checks for several completion systems such as mct, vertico,
+auth-source’s read-passwd-map, helm, ido, and ivy. When one of these
+systems is active, Corfu should not enable its own completion."
+    (or (bound-and-true-p mct--active)
+        (bound-and-true-p vertico--input)
+        (and (featurep 'auth-source)
+             (eq local-map read-passwd-map))
+        (and (featurep 'helm-core)
+             (helm--alive-p))
+        (and (featurep 'ido)
+             (ido-active))
+        (where-is-internal 'minibuffer-complete (list (current-local-map)))
+        (memq #'ivy--queue-exhibit post-command-hook)))
+
+  ;; Return non-nil if Corfu should be enabled in the minibuffer.
+  ;; This respects `+corfu-want-minibuffer-completion'.
   (defun +corfu-enable-in-minibuffer-p ()
     "Return non-nil if Corfu should be enabled in the minibuffer.
-See `+corfu-want-minibuffer-completion'."
+
+This function respects the value of `+corfu-want-minibuffer-completion':
+- If set to nil, Corfu is disabled.
+- If set to 'aggressive, enable Corfu when no other completion
+  framework is active.
+- Otherwise, enable Corfu only when there’s a bound completion
+  command in the current local keymap."
     (pcase +corfu-want-minibuffer-completion
       ('nil nil)
-      ('aggressive
-       (not (or (bound-and-true-p mct--active)
-                (bound-and-true-p vertico--input)
-                (and (featurep 'auth-source)
-                     (eq (current-local-map) read-passwd-map))
-                (and (featurep 'helm-core) (helm--alive-p))
-                (and (featurep 'ido) (ido-active))
-                (where-is-internal 'minibuffer-complete
-                                   (list (current-local-map)))
-                (memq #'ivy--queue-exhibit post-command-hook))))
-      (_ (where-is-internal #'completion-at-point
-                            (list (current-local-map))))))
+      ('aggressive (not (+corfu--other-completion-active-p)))
+      (_ (and (where-is-internal #'completion-at-point
+                                 (list (current-local-map)))
+              (not (+corfu--other-completion-active-p))))))
+
   (setq global-corfu-minibuffer #'+corfu-enable-in-minibuffer-p)
 
   ;; HACK: Augments Corfu to respect `+corfu-inhibit-auto-functions'.


### PR DESCRIPTION
After setting +corfu-want-minibuffer-completion to t, I noticed that it Corfu was still being enabled in Consult when finding files. This change fixes that by ensuring that Corfu gets disabled in the minibuffer whenever another completion framework is active.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.