### PR TITLE
fix(emacs-lisp): handle malformed outline-regexp

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -32,7 +32,9 @@ to a pop up buffer."
 (defun +emacs-lisp-outline-level ()
   "Return outline level for comment at point.
 Intended to replace `lisp-outline-level'."
-  (- (match-end 1) (match-beginning 1)))
+  (if (match-beginning 1)
+      (- (match-end 1) (match-beginning 1))
+    0))
 
 
 ;;


### PR DESCRIPTION
Sometimes elisp files specify a local outline-regexp which does not match any groups so with this PR, outline-level returns a default value of 0 instead of an error. As an example, take `gptel-rewrite.el`. 

This is part of my goal of reducing the amount of errors I see while using Emacs to as close to 0 as possible. I would rather the highlight be incorrect than see an error, because errors distract us from working on things that are more important to us.