### PR TITLE
fix: restore previous default transient menu visibility during minibuffer use

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -84,6 +84,7 @@ Only has an effect in GUI Emacs.")
   ;; 2. The status screen isn't buried when viewing diffs or logs from the
   ;;    status screen.
   (setq transient-display-buffer-action '(display-buffer-below-selected)
+        transient-show-during-minibuffer-read t
         magit-display-buffer-function #'+magit-display-buffer-fn
         magit-bury-buffer-function #'magit-mode-quit-window)
   (set-popup-rule! "^\\(?:\\*magit\\|magit:\\| \\*transient\\*\\)" :ignore t)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

I noticed that recently the default option for [showing/hiding the transient menu](https://github.com/magit/transient/blob/32a7e256aab281bada5db8569e0871c8c3ad2115/CHANGELOG#v080----2024-12-06) in transient changed

> While the minibuffer is in use, the menu window is now hidden by default

It seems like this conflicts with `transient-display-buffer-action` being set to `display-buffer-below-selected` for some reason.

This PR restores the old default behavior of keeping the transient menu visible while the minibuffer is active, resolving the unexpected window splitting behavior.

Fix: #8194 
Ref: https://github.com/doomemacs/doomemacs/issues/8194#issuecomment-2645868695

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->

Solves #8194 

### Before
![CleanShot 2025-02-08 at 10 05 19](https://github.com/user-attachments/assets/b801e386-b539-48a3-aa95-81da6dcb2bae)

### After
![CleanShot 2025-02-08 at 10 06 53](https://github.com/user-attachments/assets/107547ab-0bd3-4ea0-ab37-eeeb84f9ea77)
