### PR TITLE
fix(packages): use git://git.sv.gnu.org

### DIFF
--- a/lisp/lib/packages.el
+++ b/lisp/lib/packages.el
@@ -126,7 +126,7 @@ package's name as a symbol, and whose CDR is the plist supplied to its
                                   :repo "melpa/melpa"
                                   :build nil)
               (nongnu-elpa        :type git
-                                  :repo "https://git.savannah.gnu.org/git/emacs/nongnu.git"
+                                  :repo "git://git.sv.gnu.org/emacs/nongnu.git"
                                   :local-repo "nongnu-elpa"
                                   :build nil)
               (gnu-elpa-mirror    :type git :host github


### PR DESCRIPTION
There are a few threads about related issues. For me, consistently the Git endpoint has been working, while the HTTPS one is often down. As far as I know this should be a transparent change.