### PR TITLE
fix(:completion): Remove undefined completion

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -88,15 +88,14 @@ orderless."
 
   (add-to-list
    'completion-styles-alist
-   '(+vertico-basic-remote
-     +vertico-basic-remote-try-completion
+   '(+vertico-basic-remote-try-completion
      +vertico-basic-remote-all-completions
      "Use basic completion on remote files only"))
   (setq completion-styles '(orderless basic)
         completion-category-defaults nil
         ;; note that despite override in the name orderless can still be used in
         ;; find-file etc.
-        completion-category-overrides '((file (styles +vertico-basic-remote orderless partial-completion)))
+        completion-category-overrides '((file (styles orderless partial-completion)))
         orderless-component-separator #'orderless-escapable-split-on-space)
   ;; ...otherwise find-file gets different highlighting than other commands
   (set-face-attribute 'completions-first-difference nil :inherit nil))
@@ -377,13 +376,13 @@ orderless."
     "If MODE is enabled, highlight it as font-lock-constant-face."
     (let ((sym (intern cmd)))
       (with-current-buffer (nth 1 (buffer-list))
-      (if (or (eq sym major-mode)
-              (and
-               (memq sym minor-mode-list)
-               (boundp sym)
-               (symbol-value sym)))
-          (add-face-text-property 0 (length cmd) 'font-lock-constant-face 'append cmd)))
-        cmd))
+        (if (or (eq sym major-mode)
+                (and
+                 (memq sym minor-mode-list)
+                 (boundp sym)
+                 (symbol-value sym)))
+            (add-face-text-property 0 (length cmd) 'font-lock-constant-face 'append cmd)))
+      cmd))
 
   (add-to-list 'vertico-multiform-categories
                '(file


### PR DESCRIPTION
Fix this error when using "Find file":
Error in post-command-hook (vertico--exhibit):
  (error "Invalid completion style +vertico-basic-remote")
Remove undefined style completion type +vertico-basic-remote Relative to this comment:
URL_TOO_LONG /issues/7491#issuecomment-2012682178

* modules/completion/vertico/config.el : remove `+vertico-basic-remote` use as it's not defined.

Fix: #7491

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #7491

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
