### PR TITLE
docs: clarify that the lean module is for lean3

### DIFF
--- a/static/init.example.el
+++ b/static/init.example.el
@@ -145,7 +145,7 @@
        ;;julia             ; a better, faster MATLAB
        ;;kotlin            ; a better, slicker Java(Script)
        ;;latex             ; writing papers in Emacs has never been so fun
-       ;;lean              ; for folks with too much to prove
+       ;;lean              ; for the OBSOLETE Lean 3
        ;;ledger            ; be audit you can be
        ;;lua               ; one-based indices? one-based indices
        markdown          ; writing docs for people to ignore


### PR DESCRIPTION
Lean 4 was released some time ago, so I was surprised to find the lean module installed lean3-mode.  To avoid confusion, could we, at least for now, replace the cutesy message with a warning that the user is installing a mode for a deprecated language?

We could later add lean4 as a `lean4` module. I don't think it makes sense to complicate things by adding support for both Lean 4 and Lean 3 in the same module, because the Lean 3 is deprecated and going to become increasingly niche.

Related: Lean 4 module, PR #7439

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.