### PR TITLE
fix(elixir): start lsp when ts and lsp are enabled

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -37,6 +37,9 @@
     (sp-local-pair "do " " end" :unless '(sp-in-comment-p sp-in-string-p))
     (sp-local-pair "fn " " end" :unless '(sp-in-comment-p sp-in-string-p)))
 
+  (when (modulep! +lsp +tree-sitter)
+    (add-hook 'elixir-ts-mode-local-vars-hook #'lsp! 'append)
+
   (when (modulep! +lsp)
     (add-hook 'elixir-mode-local-vars-hook #'lsp! 'append)
     (after! lsp-mode


### PR DESCRIPTION
LSP will now correctly auto start when you have both +lsp and +tree-sitter flags on elixir module.

As this was easy fix, I'm creating PR without creating a bug report.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

