### PR TITLE
fix(packages): use mirror for nongnu-elpa

### DIFF
--- a/lisp/lib/packages.el
+++ b/lisp/lib/packages.el
@@ -125,8 +125,8 @@ package's name as a symbol, and whose CDR is the plist supplied to its
               (melpa              :type git :host github
                                   :repo "melpa/melpa"
                                   :build nil)
-              (nongnu-elpa        :type git
-                                  :repo "https://git.savannah.gnu.org/git/emacs/nongnu.git"
+              (nongnu-elpa        :type git :host github
+                                  :repo "emacsmirror/nongnu_elpa"
                                   :local-repo "nongnu-elpa"
                                   :build nil)
               (gnu-elpa-mirror    :type git :host github


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Fixes package unavailability based on https://github.com/doomemacs/doomemacs/issues/7171#issuecomment-2574991205 's idea.

With the recent Emacs release it feels that more people are upgrading and facing this issue. Tested locally.

Fix: #7171 
Ref: https://github.com/doomemacs/doomemacs/pull/8271
Close: #7171

Based on my interpretation of `straight-vc-git-default-protocol` then this should be better than #8271.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
