### PR TITLE
fix(python): stop anaconda-eldoc-mode when lsp server launches

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -107,9 +107,15 @@
 
   (add-hook! 'eglot-server-initialized-hook
     (defun +python-disable-anaconda-mode-h (&rest _)
-      "Ensure `anaconda-mode' doesn't interfere with `eglot'."
+      "When `eglot' started, disable `anaconda-mode' so they don't interfere."
       (when (bound-and-true-p anaconda-mode)
+
+        ;; disable `anaconda-eldoc-mode' without disabling `eldoc-mode'
+        ;; by just removing the documentation hook.
+        (remove-hook 'eldoc-documentation-functions
+                     'anaconda-mode-eldoc-function 't)
         (anaconda-mode -1))))
+
   :config
   (set-company-backend! 'anaconda-mode '(company-anaconda))
   (set-lookup-handlers! 'anaconda-mode
@@ -118,7 +124,10 @@
     :documentation #'anaconda-mode-show-doc)
   (set-popup-rule! "^\\*anaconda-mode" :select nil)
 
-  (add-hook 'anaconda-mode-hook #'anaconda-eldoc-mode)
+  ;; `anaconda-eldoc-mode' enables/disables `eldoc-mode' internally
+  ;; so let's just add the doc hook.
+  (add-hook 'eldoc-documentation-functions
+            'anaconda-mode-eldoc-function nil 't)
 
   (defun +python-auto-kill-anaconda-processes-h ()
     "Kill anaconda processes if this buffer is the last python buffer."


### PR DESCRIPTION
`anaconda-mode` launches `anaconda-eldoc-mode` through hook, but when `+python-disable-anaconda-mode-h` stops anaconda, `anaconda-eldoc-mode` keeps running.

since `anaconda-eldoc-mode` internally stops `eldoc-mode` when disabled, eldoc hooks are added directly now.

Ref: pythonic-emacs/anaconda-mode#440