### PR TITLE
Fix typo in org module README

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -49,7 +49,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   Enable drag-and-drop support for images and files; inserts inline previews for
   images and an icon+link for other media types.
 - +crypt ::
-  Enable [[doom-package:org-crypt]] integraiton for encryption and decryption on org
+  Enable [[doom-package:org-crypt]] integration for encryption and decryption on org
   files.
 - +gnuplot ::
   Install gnuplot & gnuplot-mode, which enables rendering images from gnuplot


### PR DESCRIPTION
Corrected typo 'integraiton' to 'integration' in modules/lang/org/README.org