### PR TITLE
perf: do not load pp at startup

### DIFF
--- a/lisp/doom-lib.el
+++ b/lisp/doom-lib.el
@@ -954,7 +954,10 @@ If N and M = 1, there's no benefit to using this macro over `remove-hook'.
   (macroexp-progn
    (cl-loop for (var val hook fn) in (doom--setq-hook-fns hooks var-vals)
             collect `(defun ,fn (&rest _)
-                       ,(format "%s = %s" var (pp-to-string val))
+                       ,(format "%s = %s" var
+                                (let ((print-level nil)
+                                      (print-length nil))
+                                  (prin1-to-string val)))
                        (setq-local ,var ,val))
             collect `(add-hook ',hook #',fn -90))))
 


### PR DESCRIPTION
Hi. I'm thinking we can avoid using `pp` in `setq-hook!` and to avoid loading `pp` and use the faster `prin1-to-string` since it's rare that people look at the form `setq-hook!` outputs anyways.