### PR TITLE
fix: RET and TAB keybindings for emacs daemon

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -57,22 +57,27 @@ and Emacs states, and for non-evil users.")
 ;;   "<tab>" and "<return>"), which are only triggered in GUI frames, so here, I
 ;;   create one for C-i. Won't work in TTY frames, though. Doom's :os tty module
 ;;   has a workaround for that though.
-(pcase-dolist (`(,key ,fallback . ,events)
-               '(([C-i] [?\C-i] tab kp-tab)
-                 ([C-m] [?\C-m] return kp-return)))
-  (define-key
-   input-decode-map fallback
-   (cmd! (if (when-let ((keys (this-single-command-raw-keys)))
-               (and (display-graphic-p)
-                    (not (cl-loop for event in events
-                                  if (cl-position event keys)
-                                  return t))
-                    ;; Use FALLBACK if nothing is bound to KEY, otherwise we've
-                    ;; broken all pre-existing FALLBACK keybinds.
-                    (key-binding
-                     (vconcat (if (= 0 (length keys)) [] (cl-subseq keys 0 -1))
-                              key) nil t)))
-             key fallback))))
+(defun doom-setup-ret-tab-bindings (&optional frame)
+  (pcase-dolist (`(,key ,fallback . ,events)
+                 '(([C-i] [?\C-i] tab kp-tab)
+                   ([C-m] [?\C-m] return kp-return)))
+    (define-key
+     input-decode-map fallback
+     (cmd! (if (when-let ((keys (this-single-command-raw-keys)))
+                 (and (display-graphic-p)
+                      (not (cl-loop for event in events
+                                    if (cl-position event keys)
+                                    return t))
+                      ;; Use FALLBACK if nothing is bound to KEY, otherwise we've
+                      ;; broken all pre-existing FALLBACK keybinds.
+                      (key-binding
+                       (vconcat (if (= 0 (length keys)) [] (cl-subseq keys 0 -1))
+                                key) nil t)))
+               key fallback)))))
+
+(if (daemonp)
+    (add-hook 'server-after-make-frame-hook #'doom-setup-ret-tab-bindings)
+  (doom-setup-ret-tab-bindings))
 
 
 ;;


### PR DESCRIPTION
Before this commit, the hack that distinguishes between `TAB`/`C-i` and `RET`/`C-m` didn't properly execute when running Emacs as a daemon. This was because `display-graphic-p` returns `nil` during daemon initialization when no frames exist yet, causing `input-decode-map` to lack the necessary entries.

This PR wraps the relevant code in a function and adds conditional logic:
- When `daemonp` is `t`, it adds the function to `server-after-make-frame-hook` so it runs after a frame is created
- Otherwise, it executes the code immediately as before


Fix: #8269
Ref: #7997, #8101
Close: #8269

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
