### PR TITLE
fix: check that DEBUG envvar is non-empty

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -49,9 +49,11 @@
 
   ;; UX: Respect DEBUG envvar as an alternative to --debug-init, and to make
   ;;   startup more verbose sooner.
-  (when (getenv-internal "DEBUG")
-    (setq init-file-debug t
-          debug-on-error t))
+  (let ((env-debug (getenv-internal "DEBUG")))
+    (when (and (stringp env-debug)
+               (not (string-empty-p env-debug)))
+      (setq init-file-debug t
+            debug-on-error t)))
 
   (let (;; FIX: Unset `command-line-args' in noninteractive sessions, to
         ;;   ensure upstream switches aren't misinterpreted.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Starting in 8c7711920e6dfc2996200fde786bf1b09f58730f, `doom--if-compile` sets the `DEBUG` environment variable to an empty string if `doom-debug-mode` is disabled. But in `early-init.el`, we were just checking that the `DEBUG` envvar was present, even if `DEBUG` was an empty string. In this PR, we also check that `DEBUG` is non-empty. This affects commands like `doom/reload`.

This should fix a problem that was discussed in the Discord: <https://discord.com/channels/406534637242810369/1342523588603019346/1342523588603019346>.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
