### PR TITLE
fix: correct typo in module check for flycheck-kotlin

### DIFF
--- a/modules/lang/kotlin/packages.el
+++ b/modules/lang/kotlin/packages.el
@@ -3,5 +3,5 @@
 
 (package! kotlin-mode :pin "fddd747e5b4736e8b27a147960f369b86179ddff")
 
-(when (modulep! :checker syntax -flymake)
+(when (modulep! :checkers syntax -flymake)
   (package! flycheck-kotlin :pin "a2a6abb9a7f85c6fb15ce327459ec3c8ff780188"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

When checking module requirements for =flycheck-kotlin= there is a typo in the =:tools= used, leading to package not getting installed.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
