### PR TITLE
feat(evil): add evil-textobj-line

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -32,6 +32,7 @@ This holy module brings the Vim editing model to Emacs.
 - [[doom-package:evil-snipe]]
 - [[doom-package:evil-surround]]
 - [[doom-package:evil-textobj-anyblock]]
+- [[doom-package:evil-textobj-line]]
 - [[doom-package:evil-vimish-fold]]
 - [[doom-package:evil-visualstar]]
 - [[doom-package:exato]]
@@ -105,6 +106,7 @@ And these are text objects added by this module:
 - [[kbd:][g]] The entire buffer
 - [[kbd:][i j k]] by indentation ([[kbd:][k]] includes one line above; [[kbd:][j]] includes one line above and
   below) (provided by ~evil-indent-plus~)
+- [[kbd:][l]] The line object (provided by ~evil-textobj-line~)
 - [[kbd:][q]] For quotes (any kind)
 - [[kbd:][u]] For URLs
 - [[kbd:][x]] XML attributes (provided by ~exato~)

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -338,6 +338,9 @@ directives. By default, this only recognizes C directives.")
           ("<" . ">"))))
 
 
+(use-package! evil-textobj-line)
+
+
 (use-package! evil-traces
   :after evil-ex
   :config

--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -20,6 +20,7 @@
            :repo "willghatch/evil-textobj-anyblock"
            :branch "fix-inner-block")
   :pin "29280cd71a05429364cdceef2ff595ae8afade4d")
+(package! evil-textobj-line :pin "9eaf9a5485c2b5c05e16552b34632ca520cd681d")
 (package! evil-traces :pin "82e8a7b4213aed140f6eb5f2cc33a09bb5587166")
 (package! evil-visualstar :pin "06c053d8f7381f91c53311b1234872ca96ced752")
 (package! exato :pin "aee7af7b7a0e7551478f453d1de7d5b9cb2e06c4")


### PR DESCRIPTION
Which enables combinations such as `dil`, `dal`, `vil`, `val`, etc.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: none
Ref: none
Close: none

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
  - (Although it's not a visual change, there is a visual demonstration of this feature at https://github.com/emacsorphanage/evil-textobj-line.)
- [x] I am _*NOT*_ blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
  - Although it's not a draft, it's my first contribution to Doomemacs (actually Emacs in general), it's possible that I missed any best practices or what not, feel free to point it out or suggest improvements!

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
