### PR TITLE
fix(magit): use messages instead of modeline

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -150,6 +150,11 @@ Only has an effect in GUI Emacs.")
   :preface
   (setq forge-database-file (concat doom-data-dir "forge/forge-database.sqlite"))
   (setq forge-add-default-bindings (not (modulep! :editor evil +everywhere)))
+  :init
+  (after! ghub-graphql
+    ;; Killing recreating the status buffer prevents progress updates from being
+    ;; relayed through the modeline. Use `message' instead.
+    (setq ghub-graphql-message-progress t))
   :config
   ;; All forge list modes are derived from `forge-topic-list-mode'
   (map! :map forge-topic-list-mode-map :n "q" #'kill-current-buffer)


### PR DESCRIPTION
Without this PR, Forge will try to transmit progress updates to the modeline. However,  these progress updates are tied to the magit status buffer so after you kill it, they will stop being relayed even if you run `magit-status` again. 

With this PR, the Forge status updates are relayed through `message` instead when you fetch all topics in a repository, say with `SPC g g @ f f` in `~/.config/emacs`.

To reproduce this issue, do  `SPC g g @ f f` in `~/.config/emacs`, then kill the magit status buffer. When you run magit-status again, the status updates of the Forge pull operation will no longer show up in the modeline and `forge--mode-line-buffer` will say KILLED BUFFER.

Refer to the discussions on https://github.com/magit/forge/pull/744 and https://github.com/magit/forge/discussions/633 and https://github.com/douo/magit-gptcommit/issues/20#issuecomment-2737277282.