### PR TITLE
fix: projectile: cache advice not in a project

### DIFF
--- a/lisp/doom-projects.el
+++ b/lisp/doom-projects.el
@@ -98,12 +98,15 @@ Must end with a slash.")
   ;; projects with dotfiles.
   (defadvice! doom--projectile-centralized-cache-files-a (fn &optional proot)
     :around #'projectile-project-cache-file
-    (let* ((proot (abbreviate-file-name (or proot (doom-project-root))))
-           (projectile-cache-file
-            (expand-file-name
-             (format "%s-%s" (doom-project-name proot) (sha1 proot))
-             doom-projectile-cache-dir)))
-      (funcall fn proot)))
+    (let* ((proot (or proot (doom-project-root))))
+      (if (not proot)
+          (funcall fn)
+        (let* ((proot (abbreviate-file-name proot))
+               (projectile-cache-file
+                (expand-file-name
+                 (format "%s-%s" (doom-project-name proot) (sha1 proot))
+                 doom-projectile-cache-dir)))
+          (funcall fn proot)))))
 
   ;; Support the more generic .project files as an alternative to .projectile
   (defadvice! doom--projectile-dirconfig-file-a ()


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

c3a9388 introduced a regression that breaks the following
workflow:

1. Fresh start of Emacs, no project has been switched to.

2. Press `<SPC> <SPC>`, bound to `projectile-find-file`. Since we are
not currently on a project, `projectile-find-file` does the sensible
thing and calls `projectile-switch-project`, which shows a list of
projects for us to pick one.

3. Select one such project, and subsequent presses of `<SPC> <SPC>` will
call `projectile-find-file` as expected (including the advice under
discussion), and everything is hunky-dory.

NOTE: On step 2., the advice is triggered, and it assumes that we are in
a project. Sadly, we are not yet.  So an error is produced, and shown in
the mini-buffer:

    Wrong type argument: stringp, nil

This happens because within the advice, `(doom-project-root)` returns
`nil`.  Bummer!

This commit fixes that, by calling the original function without
arguments if `proot` is `nil`, sidestepping the issue.

Supplemental considerations:
- After this broke I got the impression that you @hlissner either were not aware of this workflow, or don’t use it at all, am I right?
- If that’s the case, I think I understand now another peculiarity that I encountered, that I’ll just mention here (will open a separate issue/PR): if the projectile cache is invalidated or empty to begin with, if I press `<SPC> <SPC>` no projects will be shown, having to trigger a manual discovery first (`<SPC> p D`), but OTOH, if I go the `<SPC> p p` route, the cache project autovivifies and all my projects are there. Thoughts?

Fix: c3a9388452df549e40b644b3fd9e5dacb0550d91
Ref: #8317 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
- [x] I laughed sooo hard with [this](https://youtu.be/yup8gIXxWDU)[.](https://github.com/NanowarOfSteel/HelloWorld)

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
