### PR TITLE
refactor(latex): replace latex-preview-pane w/ auctex-cont-latexmk

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -1,9 +1,5 @@
 ;;; lang/latex/+viewers.el -*- lexical-binding: t; -*-
 
-;; Fall back PDF previewing to `latex-preview-pane-mode'.
-(add-to-list 'TeX-view-program-selection '(output-pdf "preview-pane") 'append)
-(add-to-list 'TeX-view-program-list '("preview-pane" latex-preview-pane-mode))
-
 (letf! (defun prepend-to-list (list-var value &optional append)
          (set list-var (delete value (symbol-value list-var)))
          (add-to-list list-var value append))
@@ -48,23 +44,3 @@
            (add-to-list 'TeX-view-program-list '("PDF Tools" TeX-pdf-tools-sync-view)))
          ;; Update PDF buffers after successful LaTeX runs.
          (add-hook 'TeX-after-compilation-finished-functions #'TeX-revert-document-buffer))))))
-
-
-(after! latex-preview-pane
-  (setq latex-preview-pane-multifile-mode 'auctex)
-
-  ;; TODO: PR this to maintained fork by arifer48. The original project appears abandoned.
-  (defadvice! +latex--dont-reopen-preview-pane-a (fn &rest args)
-    "Once the preview pane has been closed it should not be reopened."
-    :around #'latex-preview-pane-update
-    (letf! (defun init-latex-preview-pane (&rest _)
-             ;; HACK Avoid the function because it tries to delete the current
-             ;;      window, but it's already gone, so it ends up deleting the
-             ;;      wrong window.
-             (setq-local latex-preview-pane-mode nil))
-      (apply fn args)))
-
-  (define-key! doc-view-mode-map
-    "ESC" #'delete-window
-    "q"   #'delete-window
-    "k"   (cmd! (quit-window) (delete-window))))

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -10,7 +10,7 @@ Provide a helping hand when working with LaTeX documents.
 - Fontification of many popular commands
 - Pretty indentation of wrapped lines using the [[doom-package:adaptive-wrap]] package
 - Spell checking with [[doom-package:flycheck]]
-- Change PDF viewer to Okular or [[doom-package:latex-preview-pane]]
+- Change PDF viewer to Okular or AUCTeX-selected viewer
 - Bibtex editor
 - Autocompletion using [[doom-package:company-mode]]
 - Compile your =.tex= code only once using LatexMk
@@ -36,7 +36,7 @@ Provide a helping hand when working with LaTeX documents.
 - [[doom-package:auctex]]
 - [[doom-package:cdlatex]] if [[doom-module:+cdlatex]]
 - [[doom-package:evil-tex]] if [[doom-module::editor evil +everywhere]]
-- [[doom-package:latex-preview-pane]]
+- [[doom-package:auctex-cont-latexmk]]
 - if [[doom-module::completion company]]
   - [[doom-package:company-auctex]]
   - [[doom-package:company-math]]
@@ -126,10 +126,6 @@ tool, for instance:
 (setq +latex-viewers '(zathura))
 #+end_src
 
-If none of these tools are found, ~latex-preview-pane~ (uses ~DocView~ in Emacs)
-is used as a fallback. You can use this exclusively by setting ~+latex-viewers~
-to ~nil~.
-
 ** Using cdlatex's snippets despite having yasnippet
 [[doom-package:cdlatex]] has a snippet insertion capability which is disabled in favor of
 [[doom-package:yasnippet]] when using [[doom-module::editor snippets]]. If you still wanna use it, simply rebind
@@ -150,7 +146,6 @@ in latex buffers.
 * Frequently asked questions
 /This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
 
-* TODO Appendix
-#+begin_quote
- 󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
-#+end_quote
+* Appendix
+** Commands
+- ~+latex/live-preview~: Pop up the viewer of choice and display the document compiled live with each save.

--- a/modules/lang/latex/autoload.el
+++ b/modules/lang/latex/autoload.el
@@ -65,3 +65,11 @@ typically insert macros."
   (if +latex-enable-unicode-math
       (company-math-symbols-unicode command arg)
     (company-math-symbols-latex command arg)))
+
+;;;###autoload
+(defun +latex/live-preview ()
+  "Launch the AUCTeX viewer and keep the document live compiled on save."
+  (interactive)
+  (auctex-cont-latexmk-mode)
+  (TeX-command-sequence t t)
+  )

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -31,9 +31,7 @@ package to be installed.")
 (defvar +latex-viewers '(skim evince sumatrapdf zathura okular pdf-tools)
   "A list of enabled LaTeX viewers to use, in this order. If they don't exist,
 they will be ignored. Recognized viewers are skim, evince, sumatrapdf, zathura,
-okular and pdf-tools.
-
-If no viewer is found, `latex-preview-pane-mode' is used.")
+okular and pdf-tools.")
 
 ;;
 (defvar +latex--company-backends nil)
@@ -219,7 +217,8 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
     (let ((LaTeX-indent-environment-list LaTeX-indent-environment-list))
       (dolist (item '("itemize" "enumerate" "description"))
         (setf (alist-get item LaTeX-indent-environment-list nil t #'equal) nil))
-      (apply fn args))))
+      (apply fn args)))
+  )
 
 
 (use-package! preview

--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -6,7 +6,7 @@
                    "doc" "etc" "images" "latex" "style"))
   :pin "6fb366064c6cc5ce5a5e14ccec404dfe31b460ad")
 (package! adaptive-wrap :pin "d75665b9c88e65f91dadd1e5880905bbdb7c09b7")
-(package! latex-preview-pane :pin "5297668a89996b50b2b62f99cba01cc544dbed2e")
+(package! auctex-cont-latexmk :pin "88c5f04d841c212d2b8331153e9e5c2767cb7197")
 (when (modulep! :editor evil +everywhere)
   (package! evil-tex :pin "2a3177c818f106e6c11032ac261f8691f5e11f74"))
 


### PR DESCRIPTION
Since latex-preview-pane is unmaintained, replace it with auctex-cont-latexmk.el and a simple function to compile the document and open the default viewer. It can potentially fix #5249 with a single extra line to start the correlation server, but at minimum it leaves that issue irrelevant since it removes latex-preview-pane.

Fix: #3128

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
