### PR TITLE
fix(org): do not rely on org-indent being loaded

### DIFF
--- a/modules/lang/org/contrib/pretty.el
+++ b/modules/lang/org/contrib/pretty.el
@@ -19,7 +19,7 @@
   ;;   rely on just that.
   (add-hook! 'org-modern-mode-hook
     (defun +org-modern-show-hidden-stars-in-indent-mode-h ()
-      (when org-indent-mode
+      (when (bound-and-true-p org-indent-mode)
         (setq-local org-modern-hide-stars nil))))
 
   ;; Carry over the default values of `org-todo-keyword-faces', `org-tag-faces',


### PR DESCRIPTION
Small fix on top of 9dfcb5401f5655168bb90fcaec5149e8c159f535 to make the check for `org-indent-mode` more robust: because Org only requires `org-indent` when needed, one cannot assume that `org-indent-mode` has been declared.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.
