### PR TITLE
fix(evil): clear modeline search highlights on zero matches

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -117,7 +117,8 @@ directives. By default, this only recognizes C directives.")
   (add-hook! 'doom-escape-hook
     (defun +evil-disable-ex-highlights-h ()
       "Disable ex search buffer highlights."
-      (when (evil-ex-hl-active-p 'evil-ex-search)
+      (when (or (evil-ex-hl-active-p 'evil-ex-search)
+                (bound-and-true-p anzu--state))
         (evil-ex-nohighlight)
         t)))
 


### PR DESCRIPTION
Zero matches on `M-x evil-ex-search-next` and `M-x evil-ex-search-previous` persists and cannot be escaped when pressing `<escape>` or `C-g`; anzu mode's state (`"0/0"`) will persist in the modeline. The pr adds an extra check into `doom-escape-hook` when getting zero evil-ex-search matches.

Reproducing the problem:
1. `M-x evil-ex-search-word-forward` on a symbol/word to start an evil-ex-search. The last search will be continued/resumed when invoking `M-x evil-ex-search-next` and `M-x evil-ex-search-previous`.
2. Change into another buffer where the last searched word doesn't exist. Invoke `M-x evil-ex-search-next` in this new buffer. This will create a Zero match search state which currently cannot be escaped with `<escape>` or `C-g`.

-----
 - [x] I searched the issue tracker and this hasn't been PRed before.
 - [x] My changes are not on the do-not-PR list for this project.
 - [x] My commits conform to Doom's git conventions.
 - [ ] My changes are visual; I've included before and after screenshots.
 - [ ] I am blindly checking these off.
 - [x] Any relevant issues or PRs have been linked to.
 - [ ] This a draft PR; I need more time to finish it.
