### PR TITLE
fix(bidi): set the font for Arabic characters

### DIFF
--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -102,10 +102,10 @@ easier."
               (font (symbol-value font-var)))
     (condition-case e
         (let ((scale (symbol-value (intern (format "+bidi-%s-font-scale" name)))))
-          (set-fontset-font t 'hebrew font)
+          (set-fontset-font t name font)
           (set-face-font (intern (format "+bidi-%s-face" name)) font)
           (when (/= scale 1.0)
-            (setf (alist-get (font-get font :family) face-font-rescale-alist nil nil #'equal)
+            (setf (alist-get (symbol-name (font-get font :family)) face-font-rescale-alist nil nil #'equal)
                   scale)))
       ('error
        (if (string-prefix-p "Font not available" (error-message-string e))


### PR DESCRIPTION
In function `+bidi--set-font`, the character set was incorrectly hardcoded to `'hebrew` instead of using the provided character set `name` parameter. This caused `+bidi-arabic-font` to have no effect when set.

Additionally, setting the scale throws an error:

    string-match-p: Wrong type argument: stringp, DejaVu\ Sans

Converting the font family property to string fixed the issue.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
