### PR TITLE
fix(vterm): always set +vterm--id in +vterm/toggle

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -35,9 +35,9 @@ Returns the vterm buffer."
                                     return buf)
                            (get-buffer-create buffer-name))))
            (with-current-buffer buffer
-             (setq-local +vterm--id buffer-name)
              (unless (eq major-mode 'vterm-mode)
-               (vterm-mode)))
+               (vterm-mode))
+             (setq-local +vterm--id buffer-name))
            (pop-to-buffer buffer)))
        (get-buffer buffer-name)))))
 


### PR DESCRIPTION
Previously +vterm/toggle would only set +vterm--id if the vterm popup window already existed.

This happened because switching major modes removes all buffer-local variables.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
