### PR TITLE
fix(lsp): Add missing `(require 'gcmh)`

### DIFF
--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -1,4 +1,5 @@
 ;;; tools/lsp/config.el -*- lexical-binding: t; -*-
+(require 'gcmh)
 
 (defvar +lsp-defer-shutdown 3
   "If non-nil, defer shutdown of LSP servers for this many seconds after last


### PR DESCRIPTION
`+lsp-optimization-mode` calls `(gcmh-set-high-threshold)` without specifying 'gcmh as a requirement. This is problematic for situation when Emacs loads a desktop file with a buffer in lsp-mode. Here is the error:

```text
Debugger entered--Lisp error: (void-function gcmh-set-high-threshold)
  (gcmh-set-high-threshold)
  (if +lsp--optimization-init-p nil (progn (setq +lsp--default-read-process-output-max (default-value 'read-process-output-max)) (setq +lsp--default-gcmh-high-cons-threshold (default-value 'gcmh-high-cons-threshold))) (progn (set-default 'read-process-output-max (* 1024 1024))) (progn (set-default 'gcmh-high-cons-threshold (* 2 +lsp--default-gcmh-high-cons-threshold))) (gcmh-set-high-threshold) (setq +lsp--optimization-init-p t))
  (if (not +lsp-optimization-mode) (progn (set-default 'read-process-output-max +lsp--default-read-process-output-max) (set-default 'gcmh-high-cons-threshold +lsp--default-gcmh-high-cons-threshold) (set-default '+lsp--optimization-init-p nil)) (if +lsp--optimization-init-p nil (progn (setq +lsp--default-read-process-output-max (default-value 'read-process-output-max)) (setq +lsp--default-gcmh-high-cons-threshold (default-value 'gcmh-high-cons-threshold))) (progn (set-default 'read-process-output-max (* 1024 1024))) (progn (set-default 'gcmh-high-cons-threshold (* 2 +lsp--default-gcmh-high-cons-threshold))) (gcmh-set-high-threshold) (setq +lsp--optimization-init-p t)))
  (let ((last-message (current-message))) (progn (set-default '+lsp-optimization-mode (cond ((eq arg 'toggle) (not (default-value '+lsp-optimization-mode))) ((and (numberp arg) (< arg 1)) nil) (t t)))) (if (boundp 'global-minor-modes) (progn (setq global-minor-modes (delq '+lsp-optimization-mode global-minor-modes)) (if (default-value '+lsp-optimization-mode) (progn (setq global-minor-modes (cons '+lsp-optimization-mode global-minor-modes)))))) (if (not +lsp-optimization-mode) (progn (set-default 'read-process-output-max +lsp--default-read-process-output-max) (set-default 'gcmh-high-cons-threshold +lsp--default-gcmh-high-cons-threshold) (set-default '+lsp--optimization-init-p nil)) (if +lsp--optimization-init-p nil (progn (setq +lsp--default-read-process-output-max (default-value 'read-process-output-max)) (setq +lsp--default-gcmh-high-cons-threshold (default-value 'gcmh-high-cons-threshold))) (progn (set-default 'read-process-output-max (* 1024 1024))) (progn (set-default 'gcmh-high-cons-threshold (* 2 +lsp--default-gcmh-high-cons-threshold))) (gcmh-set-high-threshold) (setq +lsp--optimization-init-p t))) (run-hooks '+lsp-optimization-mode-hook (if (default-value '+lsp-optimization-mode) '+lsp-optimization-mode-on-hook '+lsp-optimization-mode-off-hook)) (if (called-interactively-p 'any) (progn (customize-mark-as-set '+lsp-optimization-mode) (if (and (current-message) (not (equal last-message (current-message)))) nil (let ((local "")) (message "%s %sabled%s" "+Lsp-Optimization mode" (if (default-value ...) "en" "dis") local))))))
  +lsp-optimization-mode()
  lsp-mode(1)
  desktop-create-buffer(208 "/home/john/src/doomemacs-test/test-project/test.js" "test.js" rjsx-mode (lsp-completion-mode lsp-mode font-lock-mode evil-local-mode rainbow-delimiters-mode yas-minor-mode js2-refactor-mode npm-mode vi-tilde-fringe-mode highlight-numbers-mode display-line-numbers-mode hl-todo-mode dtrt-indent-mode cursor-sensor-mode) 1 (nil nil) nil nil ((indicate-empty-lines . t) (buffer-display-time 26632 43615 956642 205000) (buffer-file-coding-system . undecided-unix) (overwrite-mode)) ((mark-ring nil)))
  load-with-code-conversion("/home/john/src/doomemacs-test/test-project/.emacs.desktop" "/home/john/src/doomemacs-test/test-project/.emacs.desktop" t t)
  load("/home/john/src/doomemacs-test/test-project/.emacs.desktop" t t t)
  desktop-read()
  #f(compiled-function () #<bytecode 0x233b6f12146df89>)()
  run-hooks(after-init-hook delayed-warnings-hook)
  command-line()
  normal-top-level()
```

Doom Emacs is configured by enabling `lsp` and `(javascript +lsp)` plus this custom configuration:

```emacs-lisp
(use-package desktop
  :init
  (desktop-save-mode +1)
  :custom (desktop-path (list ".")))
```

<!-- ⚠️ Please do not ignore this template! -->

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
