### PR TITLE
fix(vc): browse to remote from git-timemachine revisions

### DIFF
--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -98,8 +98,8 @@ file in your browser at the visited revision."
                 (file-relative-name
                  buffer-file-name (expand-file-name (vc-git-root buffer-file-name))))
                (target-repo (browse-at-remote--get-url-from-remote remote))
-               (remote-type (browse-at-remote--get-remote-type target-repo))
-               (repo-url (cdr target-repo))
+               (remote-type (browse-at-remote--get-remote-type (plist-get target-repo :unresolved-host)))
+               (repo-url (plist-get target-repo :url))
                (url-formatter (browse-at-remote--get-formatter 'region-url remote-type)))
           (unless url-formatter
             (error (format "Origin repo parsing failed: %s" repo-url)))

--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -89,8 +89,10 @@
 file in your browser at the visited revision."
     :around #'browse-at-remote-get-url
     (if git-timemachine-mode
-        (let* ((start-line (line-number-at-pos (min (region-beginning) (region-end))))
-               (end-line (line-number-at-pos (max (region-beginning) (region-end))))
+        (let* ((start-line (and (use-region-p) (line-number-at-pos
+                                                (min (region-beginning) (region-end)))))
+               (point-end (and (use-region-p) (max (region-beginning) (region-end))))
+               (end-line (and (use-region-p) (line-number-at-pos point-end)))
                (remote-ref (browse-at-remote--remote-ref buffer-file-name))
                (remote (car remote-ref))
                (ref (car git-timemachine-revision))
@@ -105,7 +107,8 @@ file in your browser at the visited revision."
             (error (format "Origin repo parsing failed: %s" repo-url)))
           (funcall url-formatter repo-url ref relname
                    (if start-line start-line)
-                   (if (and end-line (not (equal start-line end-line))) end-line)))
+                   (when (and end-line (not (equal start-line end-line)))
+                     (if (eq (char-before point-end) ?\n) (- end-line 1) end-line))))
       (funcall fn)))
 
   (defadvice! +vc-update-header-line-a (revision)


### PR DESCRIPTION
This PR fixes errors that happen when invoking `+vc/browse-at-remote` from git-timemachine buffers.

The function `browse-at-remote--get-url-from-remote` returns a plist. Previously, these plist values were not being read correctly. The first commit fixes this.

Previously, having an inactive region/unset mark in a git-timemachine buffer and invoking `+vc/browse-at-remote` would return an error. Also line selection and highlighting at remote remained inconsistent with the behavior seen when browsing to remote from non git-timemachine buffers. This PR (second commit) fixes these issues.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.