### PR TITLE
fix(terraform): fix incorrect mapping

### DIFF
--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -18,7 +18,7 @@
         :desc "plan"     "p" (cmd! (compile (format "%s plan" +terraform-runner)))
         :desc "validate" "v" (cmd! (compile (format "%s validate" +terraform-runner)))
         :desc "fmt"      "f" (cmd! (compile (format "%s fmt" +terraform-runner)))
-        :desc "destroy"  "f" (cmd! (compile (format "%s destroy" +terraform-runner)))))
+        :desc "destroy"  "d" (cmd! (compile (format "%s destroy" +terraform-runner)))))
 
 (use-package! company-terraform
   :when (modulep! :completion company)


### PR DESCRIPTION
Both `fmt` and `destroy` are defined on `f`. In my case, this mean that which-key hinted `fmt`, but actually ran `destroy`. This mapping looks like a typo, and I have updated it to use `d`, matching the convention of using the first letter of the command.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).