### PR TITLE
docs(cc): Bear requires `--` for command

### DIFF
--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -119,7 +119,7 @@ $ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
 #+begin_src sh
 # For non-CMake projects
 $ make clean
-$ bear make
+$ bear -- make
 #+end_src
 
 *** Known issues with bear on macOS
@@ -151,7 +151,7 @@ brew install make
 #+end_src
 #+begin_src sh
 make clean
-bear gmake
+bear -- gmake
 #+end_src
 
 Additional info:


### PR DESCRIPTION
Improve docs for cc to specify that bear needs `--` before the command (as specified in its [README](https://github.com/rizsotto/Bear/blob/master/README.md)). Otherwise it doesn't work (tested with version 3.1.5)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
