### PR TITLE
tweak(lib): interactively set opacity for current and future frames

### DIFF
--- a/lisp/lib/ui.el
+++ b/lisp/lib/ui.el
@@ -176,22 +176,37 @@ Use `winner-undo' to undo this. Alternatively, use
     (while (ignore-errors (windmove-down)) (delete-window))))
 
 ;;;###autoload
-(defun doom/set-frame-opacity (opacity)
-  "Interactively change the current frame's opacity.
+(defun doom/set-frame-opacity (opacity &optional all-frames?)
+  "Interactively change the current and all new frames' opacity.
 
-OPACITY is an integer between 0 to 100, inclusive."
+OPACITY is an integer between 0 to 100, inclusive. If nil, prompt user
+for value and if it should be applied to future frames.
+
+ALL-FRAMES? is an optional that if non-nil defines sets OPACITY to all
+future frames."
   (interactive '(interactive))
+  (setq prompt-user? (eq opacity 'interactive))
   (let* ((parameter
           (if (eq window-system 'pgtk)
               'alpha-background
             'alpha))
          (opacity
-          (if (eq opacity 'interactive)
+          (if prompt-user?
               (read-number "Opacity (0-100): "
                            (or (frame-parameter nil parameter)
                                100))
             opacity)))
-    (set-frame-parameter nil parameter opacity)))
+
+    ;; current frame
+    (set-frame-parameter nil parameter opacity)
+
+    (if prompt-user?
+        (setq all-frames? (y-or-n-p (format "Apply opacity %d to all future frames? " opacity))))
+
+    ;; future frames
+    (if all-frames?
+        (setf (alist-get parameter default-frame-alist) opacity)
+      (modify-all-frames-parameters `((,parameter . ,opacity))))))
 
 (defvar doom--narrowed-base-buffer nil)
 ;;;###autoload


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

## Context
I use Emacs in daemon mode and wanted a way to set opacity to all new Emacs frames as soon as they're spawned. 

## Analysis
doom/set-frame-opacity only sets the current frame's opacity, but all new frames are not affected by it, and I couldn't find any other readily available way to do so.

I found two workarounds:

1) adding a hook server-after-make-frame-hook in config.el:

`
(add-hook! 'server-after-make-frame-hook
    (doom/set-frame-opacity opacity))
`

Would be a nice addition to the documentation somewhere in the UI readme's FAQ, but from what I gathered [docs are DNP until the doom modules refactor is finished](https://github.com/orgs/doomemacs/projects/17?pane=issue&itemId=76207420).

2) Change doom/set-frame-opacity so that it affects all frames
Proposed by this PR.

## Previous work on opacity handling

- #4007 (not merged) intended to implement a module to handle interactive current frame opacity handling, but it didn't solve my problem for it doesn't work on other frames. 
- #7721 fixed a PGTK related regression, a priori this PR does not touch this part of the code.

## Testing
Tested on PopOS 22.04, Wayland session.


-----
- [ x] I searched the issue tracker and this hasn't been PRed before.
- [ x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x ] Any relevant issues or PRs have been linked to.
- [x ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
