### PR TITLE
fix(workspaces): avoid duplicate workspace creation when no frame exists

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -532,16 +532,16 @@ created."
 (defun +workspaces-associate-frame-fn (frame &optional _new-frame-p)
   "Create a blank, new perspective and associate it with FRAME."
   (when persp-mode
-    (if (not (persp-frame-list-without-daemon))
-        (+workspace-switch +workspaces-main t)
-      (with-selected-frame frame
-        (+workspace-switch (format "#%s" (+workspace--generate-id)) t)
-        (unless (doom-real-buffer-p (current-buffer))
-          (switch-to-buffer (doom-fallback-buffer)))
-        (set-frame-parameter frame 'workspace (+workspace-current-name))
-        ;; ensure every buffer has a buffer-predicate
-        (persp-set-frame-buffer-predicate frame))
-      (run-at-time 0.1 nil #'+workspace/display))))
+    (with-selected-frame frame
+      (if (not (cdr-safe (persp-frame-list-without-daemon)))
+          (+workspace-switch +workspaces-main t)
+        (+workspace-switch (format "#%s" (+workspace--generate-id)) t))
+      (unless (doom-real-buffer-p (current-buffer))
+        (switch-to-buffer (doom-fallback-buffer)))
+      (set-frame-parameter frame 'workspace (+workspace-current-name))
+      ;; ensure every buffer has a buffer-predicate
+      (persp-set-frame-buffer-predicate frame))
+    (run-at-time 0.1 nil #'+workspace/display)))
 
 ;;;###autoload
 (defun +workspaces-switch-to-project-h (&optional dir)


### PR DESCRIPTION
When Emacs is started as a daemon and no frames exist, `emacsclient -c` should simply switch to the main workspace. However, before `+workspaces-associate-frame-fn` is called, the new frame is already added to the frame list, which causes `persp-frame-list-without-daemon` to always return a non-empty list. A new workspace will be created instead of switching to the main one.

Before:
``` bash
emacs --daemon
emacsclient --eval "(+workspace-list-names)"
# => ("main")
emacsclient -c --eval "(+workspace-list-names)"
# => ("main" "#1")
```

Affter:
``` bash
emacsclient -c --eval "(+workspace-list-names)"
# => ("main")
```

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
