### PR TITLE
fix(coq): void-function company-coq

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -87,7 +87,7 @@
              (when (bound-and-true-p company-mode)
                (company-mode -1))
              (add-hook 'completion-at-point-functions
-                       (cape-company-to-capf 'company-coq)
+                       (cape-company-to-capf 'company-coq-master-backend)
                        nil t)))
          (defadvice! +coq--proof-goto-point-advice (&rest _)
            :override #'company-coq--proof-goto-point-advice


### PR DESCRIPTION
The recent fixes for corfu integration in 61f69ca reference `company-coq` to access the Company backend. This does not exist and causes the following error on pretty much any text insert keystroke

> Error running timer ‘corfu--auto-complete-deferred’: (void-function company-coq)

The (main) backend appears to be called `company-coq-master-backend`, so I've updated the reference to use this instead. With this fix, completion works correctly and I see completion candidates in my UI

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.