### PR TITLE
docs(hl-todo): Remove removed keybinding

### DIFF
--- a/modules/ui/hl-todo/README.org
+++ b/modules/ui/hl-todo/README.org
@@ -56,7 +56,6 @@ occur in code comments:
 |---------+----------------------------------|
 | [[kbd:][]t]]      | go to next TODO item             |
 | [[kbd:][[t]]      | go to previous TODO item         |
-| [[kbd:][SPC p t]] | show all TODO items in a project |
 | [[kbd:][SPC s p]] | search project for a string      |
 | [[kbd:][SPC s b]] | search buffer for string         |
 


### PR DESCRIPTION
Commit 0893edefae1fe548c7e1112038c6e50b9e35bd26 removed magit-todos and the "SPC p t" keybinding. The documentation of hl-todo does not reflect this change.

This commit removes said keybinding from hl-todos documentation.

REF: 0893edefae1fe548c7e1112038c6e50b9e35bd26
-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).