### PR TITLE
docs: update links in documentation and modules index

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -1659,6 +1659,7 @@ You have four options when it comes to launching the sandbox:
 All new instances will inherit your ~load-path~ so you can access any packages
 you have installed.
 #+END_QUOTE
+
 *** Testing packages in the sandbox
 Instances of Emacs launched from the sandbox have inherited your ~load-path~.
 This means you can load packages -- even in Vanilla Emacs -- without worrying
@@ -1672,4 +1673,22 @@ sandbox. e.g.
 #+END_SRC
 
 ** TODO Bisecting your private config
+
+You can put the following fragment anywhere in your ~config.el~
+to only load it until that point.
+
+#+begin_src elisp
+(with-current-buffer " *load*"
+  (goto-char (point-max)))
+#+end_src
+
+By progressively moving it and restarting,
+you can hunt down any configuration issues.
+
+Upon identifying the culprit,
+you may try reproducing the issue
+by running it on a minimal configuration with ~M-:~.
+
 ** TODO Bisecting Doom Emacs
+
+

--- a/docs/index.org
+++ b/docs/index.org
@@ -1,20 +1,20 @@
 #+TITLE: Doom Emacs Documentation
 #+STARTUP: nofold
 
-Doom is a configuration framework for [[https://www.gnu.org/software/emacs/][GNU Emacs 26.3+]] tailored for Emacs
-bankruptcy veterans who want less framework in their frameworks and the
-performance of a hand rolled config (or better). It can be a foundation for your
-own config or a resource for Emacs enthusiasts to learn more about our favorite
-OS.
+Doom is a configuration framework for [[https://www.gnu.org/software/emacs/][GNU Emacs 26.3+]]
+tailored for Emacs bankruptcy veterans who want less framework in their frameworks
+and the performance of a hand rolled config (or better).
+It can be a foundation for your own config
+or a resource for Emacs enthusiasts to learn more about our favorite OS.
 
-Doom is an opinionated collection of reasonable (and optional) defaults with a
-focus on performance (both runtime and startup) and on abstraction-light,
+Doom is an opinionated collection of reasonable (and optional) defaults
+with a focus on performance (both runtime and startup) and on abstraction-light,
 readable code design, so that there is less between you and Emacs.
 
 #+begin_quote
-The documentation is designed to be viewed within Doom Emacs. Access it by
-pressing =SPC h d h= (or =C-h d h= for non-evil users), or search it with =SPC h
-d s= (or =C-h d s=).
+The documentation is designed to be viewed within Doom Emacs.
+Access it by pressing =SPC h d h= (or =C-h d h= for non-evil users),
+or search it with =SPC h d s= (or =C-h d s=).
 #+end_quote
 
 * Table of Contents :TOC:
@@ -26,11 +26,11 @@ d s= (or =C-h d s=).
   - [[#workflow-tips-tricks--tutorials][Workflow Tips, Tricks & Tutorials]]
   - [[#module-appendix][Module Appendix]]
 - [[#community-resources][Community Resources]]
-  - [[#asking-for-help][Asking for help]]
-  - [[#project-roadmap][Project roadmap]]
-  - [[#tutorials--guides][Tutorials & guides]]
+  - [[#asking-for-help][Asking for Help]]
+  - [[#project-roadmap][Project Roadmap]]
+  - [[#tutorials--guides][Tutorials & Guides]]
   - [[#projects-that-supportcomplement-doom][Projects that support/complement Doom]]
-  - [[#similar-projects][Similar projects]]
+  - [[#similar-projects][Similar Projects]]
 
 * TODO Release Notes
 
@@ -63,19 +63,19 @@ d s= (or =C-h d s=).
 ** [[file:modules.org][Module Appendix]]
 
 * Community Resources
-** Asking for help
+** Asking for Help
 - [[https://discord.gg/qvGgnVx][Our Discord server]]
 - [[https://github.com/hlissner/doom-emacs/issues][Our issue tracker]]
 
-** Project roadmap
-- [[https://github.com/hlissner/doom-emacs/projects/3][Development roadmap]] - A timeline outlining what's being worked on and when it
+** Project Roadmap
+- [[https://discourse.doomemacs.org/t/development-roadmap/42][Development roadmap]] - A timeline outlining what's being worked on and when it
   is expected to be done.
-- [[https://github.com/hlissner/doom-emacs/projects/2][Plugins under review]] - A sitrep on third party plugins that we've considered,
+- [[https://github.com/orgs/doomemacs/projects/5][Packages under review]] - A sitrep on third party plugins that we've considered,
   rejected, or awaiting integration into Doom.
-- [[https://github.com/hlissner/doom-emacs/projects/5][Upstream bugs]] - Tracks issues originating from plugins and external programs
+- [[https://github.com/orgs/doomemacs/projects/7][Upstream bugs]] - Tracks issues originating from plugins and external programs
   that Doom relies on.
 
-** Tutorials & guides
+** Tutorials & Guides
 + *Doom Emacs*
   - (videos) [[https://www.youtube.com/playlist?list=PLyy8KUDC8P7X6YkegqrnEnymzMWCNB4bN][Doom Emacs Tutorials]] by [[https://www.youtube.com/channel/UCVls1GmFKf6WlTraIb_IaJg][DistroTube]]
   - (videos) [[https://www.youtube.com/playlist?list=PLhXZp00uXBk4np17N39WvB80zgxlZfVwj][DoomCasts]] by @zaiste
@@ -97,10 +97,10 @@ d s= (or =C-h d s=).
   - [[https://gist.github.com/dmsul/8bb08c686b70d5a68da0e2cb81cd857f][A crash course on modal editing and Ex commands]]
 
 ** Projects that support/complement Doom
-+ [[https://github.com/plexus/chemacs][plexus/chemacs]]
-+ [[https://github.com/r-darwish/topgrade][r-darwish/topgrade]]
++ [[https://github.com/plexus/chemacs2][plexus/chemacs2]] - emacs profile switcher
++ [[https://github.com/topgrade-rs/topgrade][topgrade]] - system updater that includes doom
 
-** Similar projects
-+ [[https://github.com/purcell/emacs.d][purcell/emacs.d]]
-+ [[https://github.com/seagle0128/.emacs.d][seagle0128/.emacs.d]]
-+ [[https://github.com/syl20bnr/spacemacs][syl20bnr/spacemacs]]
+** Similar Projects
++ [[https://github.com/purcell/emacs.d][purcell/emacs.d]] - a wise mans long-grown emacs config
++ [[https://github.com/seagle0128/.emacs.d][seagle0128/.emacs.d]] - centaur emacs, a personal distribution
++ [[https://github.com/syl20bnr/spacemacs][syl20bnr/spacemacs]] - spacemacs, an alternative community-driven distribution

--- a/docs/modules.org
+++ b/docs/modules.org
@@ -42,9 +42,10 @@ loaded last*, before =:config= modules.
 Modules that provide new interfaces or frameworks for completion, including code
 completion.
 
-+ [[file:../modules/completion/company/README.org][company]] =+childframe +tng= - The ultimate code completion backend
-+ helm =+fuzzy +childframe= - *Another* search engine for love and life
-+ ido - The /other/ *other* search engine for love and life
++ [[file:../modules/completion/corfu/README.org][corfu]] - The lightweight, customizable code completion backend
++ [[file:../modules/completion/company/README.org][company]] =+childframe +tng= - The ultimate code completion backend (deprecated)
++ [[file:../modules/completion/helm/README.org][helm]] =+fuzzy +childframe= - *Another* search engine for love and life
++ [[file:../modules/completion/ido/README.org][ido]] - The /other/ *other* search engine for love and life
 + [[file:../modules/completion/ivy/README.org][ivy]] =+fuzzy +prescient +childframe +icons= - /The/ search engine for love and life
 + [[file:../modules/completion/vertico/README.org][vertico]] =+icons= - The search engine of the future
 


### PR DESCRIPTION
some links were missing, outdated, or without description
tried to remedy that a bit,
pulling some information from behind the links to the overview

also small insertion for private config bisecting, some sembr lines (better reading flow in editor)
and headline capitalisation improvements

index.org duplicates a lot of info from the README and tends to lag behind, should consider options of merging - from what I know github could support a README.org that could also serve as index then,
or vice versa linking the markdown readme in emacs


- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.


sorry seems I violated https://github.com/orgs/doomemacs/projects/17?pane=issue&itemId=53447940 but as I was reviewing my now year-old config, having that incompleteness was a bit off-putting and I only saw that on the list now.

the donotpr list link on https://github.com/doomemacs/doomemacs/blob/master/docs/contributing.org#commits--prs is also out of date and a bit hidden away, I think this should be higher up so you see it before starting your work, not at the time you did something and are opening a PR

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
