### PR TITLE
Make `doom +org tangle` CLI load any available `ob-<lang>` libraries for the source langs of noweb-addressable blocks

### DIFF
--- a/modules/lang/org/cli.el
+++ b/modules/lang/org/cli.el
@@ -52,7 +52,16 @@ EXAMPLES:
                   (let* ((tags (org-get-tags-at))
                          (info (org-babel-get-src-block-info 'no-eval))
                          (src-lang (nth 0 info))
-                         (src-tfile (cdr (assq :tangle (nth 2 info)))))
+                         (src-tfile (cdr (assq :tangle (nth 2 info))))
+                         (src-noweb-ref (or (nth 4 info)
+                                            (cdr (assq :noweb-ref (nth 2 info))))))
+                    ;; a block which can be referenced via noweb may need to be
+                    ;; evaluated even if it will not be tangled per se
+                    (when-let* ((src-noweb-ref)
+                             (ob-library-name (concat "ob-" src-lang))
+                             ((locate-library ob-library-name)))
+                        (require (intern ob-library-name)))
+
                     (cond ((member "notangle" tags))
 
                           ((let* ((tags (seq-group-by (fn! (equal (car %) "--or")) tags))


### PR DESCRIPTION
## the issue here
It's a three-prong problem:
- Doom CLI functions like `doom +org tangle` run in a minimal environment in which only strictly necessary libraries are preloaded
- tangling a document which contains noweb-enabled blocks may trigger an org-babel evaluation of any noweb-addressable block
- any such org-babel evaluation will cause tangling to fail with a rather loud error if the requisite `ob-<language>` library has not been loaded

Put it all together and, well, :boom:

## how to fix that
This updates the code inside tangle CLI's `org-babel-tangle-collect-blocks` function; its per-block `let*` form gets a new `src-noweb-ref` binding to store noweb-addressable labels (i.e. any `#+NAME:` or `:noweb-ref` associated with a block) when iterating through the source document's src blocks; when such a label _and_ a corresponding `ob-<labeled src block's lang>`  library can be found, it `require`s the library, making it available for future noweb expansion.

## no pre-existing issues or PRs for this
A search for `tangle cli` in the repo's issues shows no results of any sort besides [#4273](https://github.com/doomemacs/doomemacs/issues/4273), which is pretty specifically centered on the config bootstrapping behavior of `doom {install,sync}`.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] Any relevant issues or PRs have been linked to.


## how I found it, plus a minimal repro and some test output in a dropdown
I personally ran into this when experimenting with using `doom +org tangle` to automate generating some dotfiles; it was specifically triggered by a kmonad config I tangled from an org file so I could git-track and share a single, hardware-independent[^1] source of truth between an old macbook and a thinkpad while still dynamically generating a hardware-specific `kmonad.kbd` for each. 

To reproduce the bug I made this minimal version of the offending kmonad literate config:

```org
#+name: keyboard-device-file
#+begin_src shell :tangle no :results tangle
find /dev/input/by-{path,id} -name '*-kbd' | head -n 1 | tr -d "\n"
#+end_src

#+begin_src kbd :tangle kmonad.kbd :noweb yes
(defcfg
  input (device-file "<<keyboard-device-file()>>")
  output (uinput-sink "My KMonad output")
  fallthrough true)

(defsrc caps)

(deflayer qwerty @cap)

(defalias cap (tap-hold-next 333 esc lctl))
#+end_src
```

I put those lines in a file—I used `/tmp/org/test.org`—and tried tangling it via CLI on both the `master` and `require-all-potentially-needed-ob-libraries-in-org-tangle-cli` branches[^2]. I've included the shell output of my own test run below:

[^1]: well, the hardware has to run linux
[^2]: a fun sideplot to dipping into CLI code is that the same sandboxed environment that makes doom CLI's startup time doom-config-independent means there's no need to wait on any `doom sync` runs when A/B testing a change.

<details>
  <summary>
    Shell output of manually reproducing the bug and testing the fix (not in that order, though)
  </summary>

```
┌ ~/.emacs.d [require-all-potentially-needed-ob-libraries-in-org-tangle-cli|✔] d1ff35bb6 🌑
└➣ ls /tmp/org
test.org

┌ ~/.emacs.d [require-all-potentially-needed-ob-libraries-in-org-tangle-cli|✔] d1ff35bb6 🌑
└➣ doom +org tangle /tmp/org/test.org                                                                                
> Reading /tmp/org/test.org...
  ✓ Tangled to /tmp/org/kmonad.kbd

┌ ~/.emacs.d [require-all-potentially-needed-ob-libraries-in-org-tangle-cli|✔] d1ff35bb6 🌑
└➣ cat /tmp/org/kmonad.kbd                                                                                           
(defcfg
  input (device-file "/dev/input/by-path/pci-0000:00:14.0-usb-0:5.1:1.2-event-kbd")
  output (uinput-sink "My KMonad output")
  fallthrough true)

(defsrc caps)

(deflayer qwerty @cap)

(defalias cap (tap-hold-next 333 esc lctl))

┌ ~/.emacs.d [require-all-potentially-needed-ob-libraries-in-org-tangle-cli|✔] d1ff35bb6 🌑
└➣ rm /tmp/org/kmonad.kbd

┌ ~/.emacs.d [require-all-potentially-needed-ob-libraries-in-org-tangle-cli|✔] d1ff35bb6 🌑
└➣ git checkout master                                                                                                               
Switched to branch 'master'
Your branch is up to date with 'upstream/master'.

┌ ~/.emacs.d [master|✔] 8406c1ff2 🌑
└➣ !ls                                                                                                               
ls /tmp/org
test.org

┌ ~/.emacs.d [master|✔] 8406c1ff2 🌑
└➣ doom +org tangle /tmp/org/test.org                                                                                
> Reading /tmp/org/test.org...

Error: error ("No org-babel-execute function for shell!")
  error("No org-babel-execute function for %s!" "shell")
  org-babel-execute-src-block(nil nil ((:results . "none")))
  org-babel-ref-resolve("keyboard-device-file()")
  
  [...SKIPPING PASS THE COLOSSAL ELISP STACK TRACE...]
  
  x There was an unexpected runtime error
  Message: No org-babel-execute function for shell!
  Backtrace:
    (error "No org-babel-execute function for %s!" "shell")
    (org-babel-execute-src-block nil nil ((:results . "none")))
    (org-babel-ref-resolve "keyboard-device-file()")
    (#[257 "r\303q\210\306 \307\310\"\216\311\312\"\311\313\"\314\315\316\317$\266\203\211\203H\32...
    (replace-regexp-in-string "\\(.*?\\)\\(<<\\([^ 	\n]\\(?:.*?[^ 	\n]\\)?\\)>>\\)" #[257 "r\303q\21...
    (org-babel-expand-noweb-references ("kbd" "(defcfg\n  input (device-file \"<<keyboard-device-file()>>\")\n  ou...
    (org-babel-tangle-single-block 2)
    (let* ((block (org-babel-tangle-single-block counter)) (src-tfile (cdr (assq :tangle (nth 4 block)))) (file-na...
    (cond ((member "notangle" tags)) ((let* ((tags (seq-group-by #'(lambda (%) (equal (car %) "--or")) tags)) (or-...
    (let* ((tags (org-get-tags-at)) (info (org-babel-get-src-block-info 'no-eval)) (src-lang (nth 0 info)) (src-tf...
    (if (or (org-in-commented-heading-p) (org-in-archived-heading-p)) nil (let* ((tags (org-get-tags-at)) (info (o...
    (let ((full-block (match-string 0)) (beg-block (match-beginning 0)) (end-block (match-end 0)) (lang (match-str...
GNU Emacs     v30.0.93         ce50a1d3c18bcf0e5f51f4ed49f292f7be31010d
Doom core     v3.0.0-pre       HEAD -> master, upstream/master, upstream/HEAD 8406c1ff2 2025-05-24 17:32:27 +0200
Doom modules  v25.06.0-pre     HEAD -> master, upstream/master, upstream/HEAD 8406c1ff2 2025-05-24 17:32:27 +0200
  ! Wrote extended backtrace to ~/.emacs.d/.local/state/logs/cli.doom.250529140816.50920.error
```

</details>