### PR TITLE
feat(eww): Add jump-to-heading in EWW

### DIFF
--- a/modules/emacs/eww/config.el
+++ b/modules/emacs/eww/config.el
@@ -6,7 +6,7 @@
   (map! :map eww-mode-map
         [remap text-scale-increase] #'+eww/increase-font-size
         [remap text-scale-decrease] #'+eww/decrease-font-size
-        [remap imenu] #'+eww/jump-to-url-on-page
+        [remap imenu] #'+eww/jump-to-heading-on-page
         [remap quit-window] #'+eww/quit
         :ni [C-return] #'+eww/open-in-other-window
         :n "yy" #'+eww/copy-current-url
@@ -16,6 +16,7 @@
         (:localleader
          :desc "external browser" "e" #'eww-browse-with-external-browser
          :desc "buffers" "b" #'eww-switch-to-buffer
+         :desc "jump to link" "l" #'+eww/jump-to-url-on-page
 
          (:prefix ("t" . "toggle")
           :desc "readable" "r" #'eww-readable


### PR DESCRIPTION
1. Add jump-to-heading functionality for EWW buffers (replaces jump-to-url in `imenu`)

The new functions are based on existing `eww--capture-url-on-page` and `+eww/jump-to-url-on-page`. However, I took a different approach and used alists to hide the position/coordinates from the `completing-read`. Also, unlike `+eww/jump-to-url-on-page`, we don't give the user an option of limiting the scope to a region or visible portion of the buffer. `+eww/jump-to-heading-on-page` always prompts based on the entire buffer.

Examples:

1. `<h1>H1</h1>`
    - "H1"
3. `<h1>H1</h1><h2>H2</h2>`
    - "H1"
    - "H1/h2"
4. `<h1>H1</h1><h2>H2</h2><h3>H3</h3>`
    - "H1"
    - "H1/H2"
    - "H1/H2/H3"
5. `<h1>H1-1</h1><h2>H2</h2><h1>H1-2</h1>`
    - "H1-1"
    - "H1-1/H2"
    - "H1-2"

![screenshot on the Emacs Wikipedia entry](https://github.com/user-attachments/assets/c2210f0f-c026-4325-9b1b-c2427ec13cd5)

Gaps in the hierarchy (for example a `<h2>` followed by an `<h5>`) are not represented in the labels presented to the user. Take the Wikipedia entry for Emacs (above) as an example. The `<h2>` "Content" is the first heading on the page, there's no preceeding `<h1>`, so it's shown to the user as "Content" without any prefix. Examples:

1. `<h2>H2</h2>`
    - "H2"
2. `<h2>H2</h2><h4>H4</h4>`
    - "H2"
    - "H2/H4"
3. `<h2>H2</h2><h4>H4</h4><h5>H5</h5>`
    - "H2"
    - "H2/H4"
    - "H2/H4/H5"
4. `<h2>H2</h2><h1>H1</h1><h5>H5</h5>`
    - "H2"
    - "H1"
    - "H1/H5"

- modules/emacs/eww/autoload.el
  - (eww--capture-url-on-page): Rename to `eww--capture-urls-on-page`
  - (eww--capture-headings-on-page): Add; based on existing `eww--capture-urls-on-page`
  - (+eww/jump-to-heading-on-page): Add; based on existing `+eww/jump-to-url-on-page`
- modules/emacs/eww/config.el
  - (keybind) Bind `+eww/jump-to-heading-on-page` to `<:localleader.>`; based on existing org-mode jump-to-heading keybind (`consult-org-heading`)

-----

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.