### PR TITLE
fix(magit): Remove +magit-optimize-process-calls-h

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -164,16 +164,6 @@ FUNCTION
                    (right (or (cdr-safe +magit-fringe-size) +magit-fringe-size)))
                (set-window-fringes nil left right))))))
 
-  ;; An optimization that particularly affects macOS and Windows users: by
-  ;; resolving `magit-git-executable' Emacs does less work to find the
-  ;; executable in your PATH, which is great because it is called so frequently.
-  ;; However, absolute paths will break magit in TRAMP/remote projects if the
-  ;; git executable isn't in the exact same location.
-  (add-hook! 'magit-status-mode-hook
-    (defun +magit-optimize-process-calls-h ()
-      (when-let (path (executable-find magit-git-executable t))
-        (setq-local magit-git-executable path))))
-
   (add-hook! 'magit-diff-visit-file-hook
     (defun +magit-reveal-point-if-invisible-h ()
       "Reveal the point if in an invisible region."


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The magit documentation on https://magit.vc/manual/magit/Git-Executable.html 
says the optimization is already done by default on windows and macOS.
Also, this hook breaks the ellipsis feature in magit-process, so removing it fixes it.

Fix: https://discourse.doomemacs.org/t/magit-process-doesnt-show-ellipsis-for-magit-git-global-arguments/5103/2

Before:
![image](https://github.com/user-attachments/assets/f8aec298-d6ae-4c17-8d6f-8fe243d7cf6f)

After:
![image](https://github.com/user-attachments/assets/1139c357-dee3-4c33-ac45-f282742cb87d)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
