### PR TITLE
fix(magit): pin ghub to latest release

### DIFF
--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -8,6 +8,10 @@
     :pin "a31859547a1ea5e2acbab67b6b64f90134e2a156" ; 0.5.3
     ;; forge depends on ghub, which requires Emacs 29.1+
     :disable (version< emacs-version "29.1"))
+  (package! ghub
+    :pin "97a07691efad6fc16bc000a35be80d4f8dae251a" ; 4.3.2
+    ;; ghub requires Emacs 29.1+
+    :disable (version< emacs-version "29.1"))
   (package! code-review
     :recipe (:host github
              :repo "doomelpa/code-review"


### PR DESCRIPTION
`ghub` is in a state of flux right now, with some parts being split into their own packages¹. The latest ghub release (4.3.2)² is just three weeks old, so I think we are fine just pinning that one.

¹: https://github.com/magit/ghub/blob/3e7ad9d138c09869df171d945541562448af0174/CHANGELOG#v500----unreleased
²: https://github.com/magit/ghub/releases/tag/v4.3.2

Fix: #8421
Ref: magit/ghub@30e57b26169ad896f232b7681b5b99d3abd9c44c

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
