### PR TITLE
tweak(latex): don't insert braces after sub/superscript

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -59,8 +59,6 @@ okular and pdf-tools.")
       TeX-source-correlate-method 'synctex
       ;; Don't start the Emacs server when correlating sources.
       TeX-source-correlate-start-server nil
-      ;; Automatically insert braces after sub/superscript in `LaTeX-math-mode'.
-      TeX-electric-sub-and-superscript t
       ;; Just save, don't ask before each compilation.
       TeX-save-query nil)
 


### PR DESCRIPTION
This avoids inserting braces when you type "a_", so you end up typing "a_i" instead of "a_{i}".

The official LaTeX manual says that braces are correct, but it doesn't matter for many cases, e.g., when the sub/superscript is just a single token like "i". It's simply a matter of taste in these cases.
 - Frank Mittelbach, a LaTeX maintainer, says that he types "a_i": https://tex.stackexchange.com/questions/82329/how-bad-for-tex-is-omitting-braces-even-if-the-result-is-the-same#comment176261_82331
 - David Carlisle, another LaTeX maintainer, says that a_i "arguably improves the look of the source code": https://tex.stackexchange.com/a/82337
 - Joseph Wright, yet another LaTeX maintainer, says that he "would always use braces here, so favour a_{i}": https://tex.stackexchange.com/a/1929

And I think if it is a matter of taste, then the sane default is to avoid any magic that gets in the way of users. Anyone who prefers braces can still enable this argument, but people who do not like them won't get upset every time they type "_" or "^".

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

----

Note that I skipped the linter due to #8425.