### PR TITLE
tweak(markdown): doctor: allow for alternate grips

### DIFF
--- a/modules/lang/markdown/doctor.el
+++ b/modules/lang/markdown/doctor.el
@@ -18,5 +18,7 @@
                     cmd))))))
 
 (when (modulep! +grip)
-  (unless (executable-find "grip")
-    (warn! "Couldn't find grip. grip-mode will not work")))
+  (unless (or (executable-find "mdopen")
+              (executable-find "go-grip")
+              (executable-find "grip"))
+    (warn! "Couldn't find the mdopen, go-grip or grip binaries. grip-mode will not work")))


### PR DESCRIPTION
Note that we are pinned to the latest release of `seagle0128/grip-mode`, which supports¹ alternate grip-like programs, namely `mdopen` and `go-grip`. Although a specific one can be configured, `grip-mode` will try and load any of the three (the two mentioned plus `grip`).

I’ve added them in the same order that `grip-mode` searches for them².

¹: https://github.com/seagle0128/grip-mode?tab=readme-ov-file#alternative-markdown-preview-without-accessing-github-api
²: https://github.com/seagle0128/grip-mode/blob/96a927dce69d7607b981d7754cf8b415ebf9d6a8/grip-mode.el#L177-L179

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
