### PR TITLE
fix(fold): Use function variables over direct func

### DIFF
--- a/modules/editor/fold/autoload/fold.el
+++ b/modules/editor/fold/autoload/fold.el
@@ -35,8 +35,8 @@ Return non-nil if successful in doing so."
   (when (+fold--ensure-hideshow-mode)
     (save-excursion
       (ignore-errors
-        (or (hs-looking-at-block-start-p)
-            (hs-find-block-beginning)
+        (or (funcall hs-looking-at-block-start-p-func)
+            (funcall hs-find-block-beginning-func)
             (unless (eolp)
               (end-of-line)
               (+fold--hideshow-fold-p)))))))


### PR DESCRIPTION
Replace direct calls to `hs-looking-at-block-start-p` and `hs-find-block-beginning` with their corresponding function variables to ensure compatibility with hideshow mode's configurable function handling.

These function variables are set in [`treesit` in Emacs 31][1]. It broke fold because `hs-block-start-regexp` is set to `nil` explicitly by treesit overrides.

The default for `hs-looking-at-block-start-p-func` and `hs-find-block-beginning-func` are same as what was being called before.

[1]: https://github.com/emacs-mirror/emacs/commit/2e3b085d447bc2cd1a0e779145be9cab9a15d7af

