### PR TITLE
tweak(macos): use full path for open

### DIFF
--- a/modules/os/macos/autoload.el
+++ b/modules/os/macos/autoload.el
@@ -13,12 +13,11 @@
                               (dired-get-file-for-visit)
                             (buffer-file-name)))
                  nil t)))
-         (command (format "/usr/bin/open %s"
-                          (if app-name
-                              (format "-a %s '%s'" (shell-quote-argument app-name) path)
-                            (format "'%s'" path)))))
-    (message "Running: %s" command)
-    (shell-command command)))
+         (args (cons "open"
+                     (append (if app-name (list "-a" app-name))
+                             (list path)))))
+    (message "Running: %S" args)
+    (apply #'doom-call-process args)))
 
 (defmacro +macos--open-with (id &optional app dir)
   `(defun ,(intern (format "+macos/%s" id)) ()

--- a/modules/os/macos/autoload.el
+++ b/modules/os/macos/autoload.el
@@ -13,7 +13,7 @@
                               (dired-get-file-for-visit)
                             (buffer-file-name)))
                  nil t)))
-         (command (format "open %s"
+         (command (format "/usr/bin/open %s"
                           (if app-name
                               (format "-a %s '%s'" (shell-quote-argument app-name) path)
                             (format "'%s'" path)))))


### PR DESCRIPTION
Use the full path for the MacOS "open" command.

Using plain "open" will conflict with nushell's "open" command. Use the full path for open to make it working.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).


<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
