### PR TITLE
fix(latex): disable smartparens pairs handled by AucTeX

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -87,14 +87,16 @@ okular and pdf-tools.")
     ;; We have to use lower case modes here, because `smartparens-mode' uses
     ;; the same during configuration.
     (let ((modes '(tex-mode plain-tex-mode latex-mode LaTeX-mode)))
-      ;; All these excess pairs dramatically slow down typing in LaTeX buffers,
-      ;; so we remove them. Let snippets do their job.
-      (dolist (open '("\\left(" "\\left[" "\\left\\{" "\\left|"
-                      "\\bigl(" "\\biggl(" "\\Bigl(" "\\Biggl(" "\\bigl["
-                      "\\biggl[" "\\Bigl[" "\\Biggl[" "\\bigl\\{" "\\biggl\\{"
-                      "\\Bigl\\{" "\\Biggl\\{"
+      (dolist (open '(
+                      ;; All these pairs dramatically slow down typing in LaTeX
+                      ;; buffers, so remove them. Let snippets do their job.
+                      "\\left(" "\\left[" "\\left\\{" "\\left|"
+                      "\\bigl("   "\\biggl("   "\\Bigl("   "\\Biggl("
+                      "\\bigl["   "\\biggl["   "\\Bigl["   "\\Biggl["
+                      "\\bigl\\{" "\\biggl\\{" "\\Bigl\\{" "\\Biggl\\{"
                       "\\lfloor" "\\lceil" "\\langle"
-                      "\\lVert" "\\lvert" "`"))
+                      "\\lVert" "\\lvert"
+                      "`"))
         (sp-local-pair modes open nil :actions :rem))
       ;; And tweak these so that users can decide whether they want use LaTeX
       ;; quotes or not, via `+latex-enable-plain-double-quotes'.

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -96,11 +96,16 @@ okular and pdf-tools.")
                       "\\bigl\\{" "\\biggl\\{" "\\Bigl\\{" "\\Biggl\\{"
                       "\\lfloor" "\\lceil" "\\langle"
                       "\\lVert" "\\lvert"
-                      "`"))
-        (sp-local-pair modes open nil :actions :rem))
-      ;; And tweak these so that users can decide whether they want use LaTeX
-      ;; quotes or not, via `+latex-enable-plain-double-quotes'.
-      (sp-local-pair modes "``" nil :unless '(:add sp-in-math-p))))
+                      ;; Disable pairs that interfere with AucTeX,
+                      ;; see https://github.com/Fuco1/smartparens/pull/1151.
+                      "`" "``" "\""))
+        ;; Some of the above pairs are in smartparens' global list, which
+        ;; applies to all modes, so we need a local ":actions nil" override
+        ;; (instead of ":actions :rem", which removes from the local list).
+        ;; While this keeps the pairs in `sp-pairs', it has negligible
+        ;; performance impact because smartparens will omit the pairs when
+        ;; building the buffer-local `sp-local-pairs' used during operation.
+        (sp-local-pair modes open nil :actions nil))))
   ;; Hook LSP, if enabled.
   (when (modulep! +lsp)
     (add-hook! '(tex-mode-local-vars-hook


### PR DESCRIPTION
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.


Sorry, I had to skip the linter again. It claims that "latex" is not a valid scope. (Or is anything wrong with my commit messages?!) Perhaps a bug introduced by https://github.com/doomemacs/doomemacs/commit/ed9190ef005829c7a2331e12fb36207794c5ad75?

---

This disables smartparens pairs for quotation marks, which are broken.
Before this commit, typing a LaTeX comment
```
    % "Foo"
```
inserted
```
    % ''Foo`|`''
```
where `|` indicates the position of the cursor (wtf!).

Let's better AucTeX's support for quotation marks for now and accept
that the user won't get automatic insertions of closing quotation marks.

This also removes a wrong comment mentioning the non-existing variable
`+latex-enable-plain-double-quotes'.


