### PR TITLE
tweak: update dockerfile template

### DIFF
--- a/modules/editor/file-templates/templates/dockerfile-mode/__
+++ b/modules/editor/file-templates/templates/dockerfile-mode/__
@@ -1,4 +1,6 @@
+# expand-env: ((yas-indent-line 'fixed) (yas-wrap-around-region 'nil))
+# --
 FROM ${1:phusion/baseimage:latest}
-MAINTAINER ${2:`user-full-name` <`user-mail-address`>}
+LABEL org.opencontainers.image.authors="${2:`user-full-name` <`user-mail-address`>}"
 
 $0


### PR DESCRIPTION
Modernizes the template for new `Dockerfile`s

* modules/editor/file-templates/templates/dockerfile-mode/__:
  - preserves file indentation
  - replace deprecated `MAINTAINER` instruction with `LABEL`, as per: https://docs.docker.com/reference/dockerfile/

Side note: there's an argument to be made for replacing `phusion/baseimage` with something more bland as a default, since the advent of `docker run --init` solves the same problem.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ._. ] I am blindly checking these off.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
