### PR TITLE
fix a warning when open sly

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -356,14 +356,15 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
   (add-hook 'comint-exec-hook #'buffer-disable-undo)
   (defadvice! doom--comint-enable-undo-a (process _string)
     :after #'comint-output-filter
-    (let ((start-marker comint-last-output-start))
-      (when (and start-marker
-              (< start-marker
-                (or (if process (process-mark process))
-                  (point-max-marker)))
-              (eq (char-before start-marker) ?\n)) ;; Account for some of the IELM’s wilderness.
-        (buffer-enable-undo)
-        (setq buffer-undo-list nil))))
+    (with-current-buffer (process-buffer process)
+      (let ((start-marker comint-last-output-start))
+        (when (and start-marker
+                (< start-marker
+                  (or (if process (process-mark process))
+                    (point-max-marker)))
+                (eq (char-before start-marker) ?\n)) ;; Account for some of the IELM’s wilderness.
+          (buffer-enable-undo)
+          (setq buffer-undo-list nil)))))
 
   ;; Protect prompts from accidental modifications.
   (setq-default comint-prompt-read-only t)
@@ -375,23 +376,24 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
   ;;   the broken text in the buffer),
   (defadvice! doom--comint-protect-output-in-visual-modes-a (process _string)
     :after #'comint-output-filter
+    (with-current-buffer (process-buffer process)
     ;; Adapted from https://github.com/michalrus/dotfiles/blob/c4421e361400c4184ea90a021254766372a1f301/.emacs.d/init.d/040-terminal.el.symlink#L33-L49
-    (let* ((start-marker comint-last-output-start)
-           (end-marker (or (if process (process-mark process))
-                           (point-max-marker))))
-      (when (and start-marker (< start-marker end-marker));; Account for some of the IELM’s wilderness.
-        (let ((inhibit-read-only t))
-          ;; Make all past output read-only (disallow buffer modifications)
-          (add-text-properties comint-last-input-start (1- end-marker) '(read-only t))
-          ;; Disallow interleaving.
-          (remove-text-properties start-marker (1- end-marker) '(rear-nonsticky))
-          ;; Make sure that at `max-point' you can always append. Important for
-          ;; bad REPLs that keep writing after giving us prompt (e.g. sbt).
-          (add-text-properties (1- end-marker) end-marker '(rear-nonsticky t))
-          ;; Protect fence (newline of input, just before output).
-          (when (eq (char-before start-marker) ?\n)
-            (remove-text-properties (1- start-marker) start-marker '(rear-nonsticky))
-            (add-text-properties    (1- start-marker) start-marker '(read-only t)))))))
+      (let* ((start-marker comint-last-output-start)
+              (end-marker (or (if process (process-mark process))
+                            (point-max-marker))))
+        (when (and start-marker (< start-marker end-marker));; Account for some of the IELM’s wilderness.
+          (let ((inhibit-read-only t))
+            ;; Make all past output read-only (disallow buffer modifications)
+            (add-text-properties comint-last-input-start (1- end-marker) '(read-only t))
+            ;; Disallow interleaving.
+            (remove-text-properties start-marker (1- end-marker) '(rear-nonsticky))
+            ;; Make sure that at `max-point' you can always append. Important for
+            ;; bad REPLs that keep writing after giving us prompt (e.g. sbt).
+            (add-text-properties (1- end-marker) end-marker '(rear-nonsticky t))
+            ;; Protect fence (newline of input, just before output).
+            (when (eq (char-before start-marker) ?\n)
+              (remove-text-properties (1- start-marker) start-marker '(rear-nonsticky))
+              (add-text-properties    (1- start-marker) start-marker '(read-only t))))))))
 
   ;; UX: If the user is anywhere but the last prompt, typing should move them
   ;;   there instead of unhelpfully spew read-only errors at them.

--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -357,10 +357,11 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
   (defadvice! doom--comint-enable-undo-a (process _string)
     :after #'comint-output-filter
     (let ((start-marker comint-last-output-start))
-      (when (and (< start-marker
-                    (or (if process (process-mark process))
-                        (point-max-marker)))
-                 (eq (char-before start-marker) ?\n)) ;; Account for some of the IELM’s wilderness.
+      (when (and start-marker
+              (< start-marker
+                (or (if process (process-mark process))
+                  (point-max-marker)))
+              (eq (char-before start-marker) ?\n)) ;; Account for some of the IELM’s wilderness.
         (buffer-enable-undo)
         (setq buffer-undo-list nil))))
 
@@ -378,7 +379,7 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
     (let* ((start-marker comint-last-output-start)
            (end-marker (or (if process (process-mark process))
                            (point-max-marker))))
-      (when (< start-marker end-marker) ;; Account for some of the IELM’s wilderness.
+      (when (and start-marker (< start-marker end-marker));; Account for some of the IELM’s wilderness.
         (let ((inhibit-read-only t))
           ;; Make all past output read-only (disallow buffer modifications)
           (add-text-properties comint-last-input-start (1- end-marker) '(read-only t))


### PR DESCRIPTION

<!-- ⚠️ Please do not ignore this template! -->
Check the `start-marker` null or not in `lisp/doom-ui.el`.
Because when I open a sly it will report wrong type number-or-maker-p.
So we should check the value of `start-marker` either null or not.

And I found that we may operate on a wrong buffer. So I bind the current-buffer with the process.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
