### PR TITLE
feat: add MCP for gptel

### DIFF
--- a/modules/tools/llm/config.el
+++ b/modules/tools/llm/config.el
@@ -11,7 +11,9 @@
     :select t
     :size 0.3
     :quit nil
-    :ttl nil))
+    :ttl nil)
+  (when (modulep! +mcp)
+    (require 'gptel-integrations)))
 
 
 (use-package! gptel-quick
@@ -26,6 +28,12 @@
 (use-package! gptel-magit
   :when (modulep! :tools magit)
   :hook (magit-mode . gptel-magit-install))
+
+(use-package! mcp
+  :when (and (modulep! +mcp)
+             (>= emacs-major-version 30))
+  :config
+  (require 'mcp-hub))
 
 
 ;; TODO: Aidermacs?

--- a/modules/tools/llm/doctor.el
+++ b/modules/tools/llm/doctor.el
@@ -1,0 +1,5 @@
+;;; tools/llm/doctor.el -*- lexical-binding: t; -*-
+
+(when (and (modulep! +mcp)
+           (< emacs-major-version 30))
+  (error! "MCP requires Emacs version >= 30. MCP will not work."))

--- a/modules/tools/llm/packages.el
+++ b/modules/tools/llm/packages.el
@@ -9,3 +9,7 @@
 
 (when (modulep! :tools magit)
   (package! gptel-magit :pin "f27c01821b67ed99ddf705c2b995f78b71394d8b"))
+
+(when (and (modulep! +mcp)
+           (>= emacs-major-version 30))
+  (package! mcp :pin "4708c5849ce4ddb632016eca662a7405bfa642d4"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Adds MCP integration to gptel so that MCP can be easily enabled by just adding the +mcp flag to the llm module. for Doom Emacs users.

After adding the module flag, users need to add MCP servers as described in [mcp.el documentation](https://github.com/lizqwerscott/mcp.el?tab=readme-ov-file#configuring-mcp-servers)

Then they can [use MCP in gptel](https://github.com/karthink/gptel/tree/master?tab=readme-ov-file#model-context-protocol-mcp-integration).

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
