### PR TITLE
Add +global flag to make aw-scope configurable

### DIFF
--- a/modules/ui/window-select/README.org
+++ b/modules/ui/window-select/README.org
@@ -19,6 +19,8 @@ desired. Evil users can jump to window N in [[kbd:][C-w <N>]] (where N is a numb
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
+- +global ::
+  Set ace-window scope to 'global (all frames) instead of the default 'frame (current frame only).
 - +numbers ::
   Enable numbered windows and window selection (using [[doom-package:winum]]).
 - +switch-window ::

--- a/modules/ui/window-select/config.el
+++ b/modules/ui/window-select/config.el
@@ -17,7 +17,7 @@
   :config
   (unless (modulep! +numbers)
     (setq aw-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l)))
-  (setq aw-scope 'frame
+  (setq aw-scope (if (modulep! +global) 'global 'frame)
         aw-background t))
 
 


### PR DESCRIPTION
## Summary
- Add +global flag to make aw-scope configurable

This allows users to configure the scope of the aw-scope functionality through a module flag.