### PR TITLE
bump ob-restclient version to fix view-mode issue

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -142,7 +142,7 @@
     :recipe (:host github :repo "DEADB17/ob-racket")
     :pin "d8fd51bddb019b0eb68755255f88fc800cfe03cb"))
 (when (modulep! :lang rest)
-  (package! ob-restclient :pin "8183f8af08838854cf145ca4855b373f3e7c44b0"))
+  (package! ob-restclient :pin "94dd9cd98ff50717135ed5089afb378616faf11a"))
 (when (modulep! :lang scala)
   (package! ob-ammonite :pin "39937dff395e70aff76a4224fa49cf2ec6c57cca"))
 


### PR DESCRIPTION
Newest version of restclient (in use by doomemacs) sets output buffer to `view-mode`. This creates a bug that prevents org-babel from extracting information and creating a result.

`ob-restclient` fixed this upstream, so we must also bump the pin to include that fix.

Fix: #8641
Close: #8641

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.