### PR TITLE
tweak(notmuch): include the user's name in From: header

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -116,7 +116,9 @@
   (notmuch-mua-mail
    nil
    nil
-   (list (cons 'From  (completing-read "From: " (notmuch-user-emails))))))
+   (list (cons 'From  (message-make-from
+                         (notmuch-user-name)
+                         (completing-read "From: " (notmuch-user-emails)))))))
 
 ;;;###autoload
 (defun +notmuch/open-message-with-mail-app-notmuch-tree ()


### PR DESCRIPTION
The notmuch/compose function allows selecting between the email addresses that the user has configured, but the email address is used directly in the From header. Messages display much nicer in people's inbox when the From contains a name in addition to an emeail address, so construct the From header with the user's name as well as the chosen email address.

<!-- ⚠️ Please do not ignore this template! -->

Before this change, running "notmuch/compose" creates a buffer with the From: field populated just with my email address. After, the from field is in the form `From: My Name <my_email@example.com>`.

Thanks!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
