### PR TITLE
fix persp-mode eglot workspace corruption when jumping to definition in new workspace

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -433,12 +433,6 @@ files, so this replace calls to `pp' with the much faster `prin1'."
 (use-package! better-jumper
   :hook (doom-first-input . better-jumper-mode)
   :commands doom-set-jump-a doom-set-jump-maybe-a doom-set-jump-h
-  :preface
-  ;; REVIEW Suppress byte-compiler warning spawning a *Compile-Log* buffer at
-  ;; startup. This can be removed once gilbertw1/better-jumper#2 is merged.
-  (defvar better-jumper-local-mode nil)
-  ;; REVIEW: Remove if/when gilbertw1/better-jumper#26 is addressed.
-  (defvaralias 'evil--jumps-jump-command 'evil--jumps-jumping-backward)
   :init
   (global-set-key [remap evil-jump-forward]  #'better-jumper-jump-forward)
   (global-set-key [remap evil-jump-backward] #'better-jumper-jump-backward)

--- a/modules/ui/workspaces/packages.el
+++ b/modules/ui/workspaces/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/workspaces/packages.el
 
-(package! persp-mode :pin "f146ddccaf598feb402664bc6848b60321b2dc78")
+(package! persp-mode :pin "82680795b3dbb9f9fb023b1754902f38519d9875")


### PR DESCRIPTION
Bad-ptr/persp-mode.el@82680795b3dbb9f9fb023b1754902f38519d9875 fixes a nasty problem where jumping to a destination of a new eglot workspace corrupts the current buffer to be read-only and renamed.

When jumping to definition in a different Rust crate using rustic & eglot, the buffer I'm jumping from becomes uneditable and its name becomes `*EGLOT (axum-core-0.5.2/(rustic-mode)) stderr*` (depending on the destination).

Since persp-mode hooks `kill-buffer`, the `jsonrpc` subprocess stderr buffer mechanism gets corrupted:

`jsonrpc.el`:
```lisp
(cl-defmethod initialize-instance :after ...

(let* ((stderr-buffer-name (format "*%s stderr*" name))
           (stderr-buffer (jsonrpc--forwarding-buffer stderr-buffer-name "[stderr] " conn))
           (hidden-name (concat " " stderr-buffer-name)))
      (setq proc (if (functionp proc)
                     (if (zerop (cdr (func-arity proc)))
                         (funcall proc)
                       (funcall proc conn))
                   proc))
      (with-current-buffer stderr-buffer
        ;;; HERE (current-buffer) is the stderr buffer -> correct
        (ignore-errors (kill-buffer hidden-name))
        ;;; HERE (current-buffer) is the one that's we're comming from, so the wrong will be renamed
        (rename-buffer hidden-name)
        (setq buffer-read-only t))
      (process-put proc 'jsonrpc-stderr stderr-buffer))
```

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.