### PR TITLE
fix(:lang): missing grammar recipe for tsx-ts-mode

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -85,11 +85,15 @@
   (+javascript-common-config 'typescript-ts-mode))
 
 
-(use-package! tsx-ts-mode
+(use-package! tsx-ts-mode  ; 29.1+ only
   :when (modulep! +tree-sitter)
-  :when (fboundp 'tsx-ts-mode) ; 29.1+ only
   :mode "\\.[tj]sx\\'"
   :defer t
+  :init
+  (set-tree-sitter! 'typescript-tsx-mode 'tsx-ts-mode
+    '((tsx :url "https://github.com/tree-sitter/tree-sitter-typescript"
+                  :commit "8e13e1db35b941fc57f2bd2dd4628180448c17d5"
+                  :source-dir "tsx/src")))
   :config
   (+javascript-common-config 'tsx-ts-mode))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This PR is jsut add missing tree-sitter grammer recipe for `tsx-ts-mode`.

Currently we will got a warning when open a `.tsx` buffer:
```
Warning (treesit): Cannot activate tree-sitter, because language grammar for tsx is unavailable (not-found)
```

And we do not have grammer recipe for `tsx`. Eventhough the grammer of `tsx` is in the same repo w/ `typescript` but they are under different folder.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).


<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
