### PR TITLE
fix(erlang): correct tree-sitter config

### DIFF
--- a/modules/lang/erlang/config.el
+++ b/modules/lang/erlang/config.el
@@ -17,4 +17,4 @@
   :defer t
   :init
   (set-tree-sitter! 'erlang-mode 'erlang-ts-mode
-    '((erlang "https://github.com/WhatsApp/tree-sitter-erlang"))))
+    '((erlang :url "https://github.com/WhatsApp/tree-sitter-erlang"))))


### PR DESCRIPTION
Missing `:url` in the config caused error during the initialization, if Erlang module with `+tree-sitter` was turned on in `init.el`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
