### PR TITLE
Fix syntax for setting tree-sitter URL in Erlang config

### DIFF
--- a/modules/lang/erlang/config.el
+++ b/modules/lang/erlang/config.el
@@ -17,4 +17,4 @@
   :defer t
   :init
   (set-tree-sitter! 'erlang-mode 'erlang-ts-mode
-    '((erlang "https://github.com/WhatsApp/tree-sitter-erlang"))))
+    '((erlang :url "https://github.com/WhatsApp/tree-sitter-erlang"))))


### PR DESCRIPTION
Quick heads up for anyone using Tree Sitter and Erlang — small syntax issue in the grammar specification causes Tree Sitter to fall over.

Just need to add a `:url` keyword to the specification and you're good to go!

-----

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).