### PR TITLE
fix(php): return composer keybinds to localleader

### DIFF
--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -125,9 +125,11 @@
         "o" #'composer-find-json-file
         "l" #'composer-view-lock-file)
   (map! :after php-mode
+        :localleader
         :map php-mode-map
         :desc "composer" "c" +php-common-mode-map)
   (map! :after php-ts-mode
+        :localleader
         :map php-ts-mode-map
         :desc "composer" "c" +php-common-mode-map))
 


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: PHP composer keys are added to a global scope with `(php +lsp +tree-sitter)`.

I don't have a screenshot, it's a problem to type anything in PHP mode that has a letter `c` in it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
