### PR TITLE
docs(tree-sitter): treesit-font-lock-level setting 

### DIFF
--- a/modules/tools/tree-sitter/README.org
+++ b/modules/tools/tree-sitter/README.org
@@ -138,27 +138,13 @@ outer}-text-objects-map~:
 #+end_src
 
 ** Configuring Tree sitter highlighting
-Highlighting is controlled by the variable =+tree-sitter-hl-enabled-modes=
-This list allows you to whitelist, blacklist, fully enable or fully disable
-tree-sitter highlighting for all major modes
+To control the level of syntax highlighting, adjust the =treesit-font-
+lock-level= variable. A higher value enables more detailed highlighting.
+To apply all available highlighting, set it to 4.
 
-To use highlighting in select modes add major-modes to
-~+tree-sitter-hl-enabled-modes~. This disables highlighting in all other modes.
-The symbol that should be used is the major mode symbol, *not the package
-symbol*.
 #+begin_src emacs-lisp
-(setq +tree-sitter-hl-enabled-modes '(python-mode go-mode))
+(setq treesit-font-lock-level 4)
 #+end_src
-
-If you want to disallow highlighting in certain modes then the car of
-~+tree-sitter-hl-enabled-modes~ should be =not=. This enables highlighting in
-all modes except the ones disallowed.
-#+begin_src emacs-lisp
-(setq +tree-sitter-hl-enabled-modes '(not web-mode typescript-tsx-mode))
-#+end_src
-
-If ~+tree-sitter-hl-enabled-modes~ is set to ~nil~ or ~t~ it will fully disable
-or fully enable highlighting in every tree sitter enabled language respectively.
 
 * Troubleshooting
 [[doom-report:][Report an issue?]]


### PR DESCRIPTION
I updated doom today and find the code highlighting a little bit off. As doomemacs is moving to treesit, the variable `+tree-sitter-hl-enabled-modes` doesn't work anymore. To have the same level of code highlighting, we must set `treesit-font-lock-level` to the most detailed level. 

Adding the documentation here for better discovery.

```lisp
(setq treesit-font-lock-level 4)
```

------
I don't touch other outdated tree-sitter documentations but it seems future integration with something like combulate will fix that. 