### PR TITLE
fix: Run hooks only after switch-to-buffer for server

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -737,7 +737,7 @@ triggering hooks during startup."
   (add-hook 'window-selection-change-functions #'doom-run-switch-window-hooks-h)
   (add-hook 'window-buffer-change-functions #'doom-run-switch-buffer-hooks-h)
   ;; `window-buffer-change-functions' doesn't trigger for files visited via the server.
-  (add-hook 'server-visit-hook #'doom-run-switch-buffer-hooks-h))
+  (add-hook 'server-switch-hook #'doom-run-switch-buffer-hooks-h))
 
 ;; Apply fonts and theme
 (let ((hook (if (daemonp)


### PR DESCRIPTION
When a file is visited via `emacsclient`, server.el does the following in this order:
 - create a buffer `b` visiting the file
 - run `(set-buffer b)`
 - trigger `server-visit-hook`
 - run `(switch-buffer b)`
 - trigger `server-switch-hook`

Thus, the right hook for `doom-run-switch-buffer-hooks-h` is `server-switch-hook` because the "switch buffer" hooks may assume that the buffer has already been switched to.

This fixes an org error that occurs when running

    emacsclient --create-file --no-wait foo.txt

while there's a frame containing an org-roam file. Without this commit, the server will create a new frame and set the current buffer to foo.txt. But the new frame will still display the (duplicated) window for the org-roam file. Then `server-visit-hook` will be triggered and eventually run `+org-roam-manage-backlinks-buffer-h`, which will try to enable the org-roam backlinks buffer. But this will error because the current buffer is not an org(-roam) buffer.

Amend: 4a6de2419c81

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
