### PR TITLE
Fix (void-variable evil-windows-map) on startup of fresh install

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -341,7 +341,7 @@
       :desc "Org Capture"           "X"    #'org-capture
       ;; C-u is used by evil
       :desc "Universal argument"    "u"    #'universal-argument
-      :desc "window"                "w"    evil-window-map
+      (:after evil :desc "window"   "w"    evil-window-map)
       :desc "help"                  "h"    help-map
 
       (:when (modulep! :ui popup)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

It's very possible this is a me problem, because I'm shocked nobody else has reported it yet if not.

While trying to do a fresh install of Doom, I ran into `/modules/config/default/+evil-bindings.el` having a `(void-variable evil-windows-map)` error. It looks to be related to #8298, but between previous fresh installs of Doom and now, I don't think I've changed anything Evil-related in my config.

Simply binding `evil-window-map` after Evil loads seems to do the trick. 

If this is a me problem, I'd like to know how I can fix this in my config.

-----
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project. (The closest DNP only mentions no conditional wrapping.)
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.