### PR TITLE
Update +html.el

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -175,8 +175,8 @@
   :init
   (set-tree-sitter! 'html-mode 'html-ts-mode
     '((html :url "https://github.com/tree-sitter/tree-sitter-html"
-            :rev "v0.23.0"
-            :commit "6a442a3cf461b0ce275339e5afa178693484c927"))))
+            :rev "v0.23.2"
+            :commit "5a5ca8551a179998360b4a4ca2c0f366a35acc03"))))
 
 
 (use-package! mhtml-ts-mode  ; 31+ only


### PR DESCRIPTION
Updates tree-sitter-html grammar to 0.23.2, this also resolves the incorrect commit hash which is causing errors when trying to build.

Fix: #8497
Ref: #8497
Close: #8497

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
