### PR TITLE
fix(elixir): Consolidate package configurations

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -10,17 +10,17 @@
 
 (defun +elixir-common-config (mode)
   (set-ligatures! mode
-    ;; Functional
-    :def "def"
-    :lambda "fn"
-    ;; :src_block "do"
-    ;; :src_block_end "end"
-    ;; Flow
-    :not "!"
-    :in "in" :not-in "not in"
-    :and "and" :or "or"
-    :for "for"
-    :return "return" :yield "use")
+                  ;; Functional
+                  :def "def"
+                  :lambda "fn"
+                  ;; :src_block "do"
+                  ;; :src_block_end "end"
+                  ;; Flow
+                  :not "!"
+                  :in "in" :not-in "not in"
+                  :and "and" :or "or"
+                  :for "for"
+                  :return "return" :yield "use")
 
   ;; ...and only complete the basics
   (sp-with-modes mode
@@ -32,7 +32,27 @@
     (sp-local-pair "fn " " end" :unless '(sp-in-comment-p sp-in-string-p)))
 
   (when (modulep! +lsp)
-    (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append)))
+    (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append))
+
+  (use-package! flycheck-credo
+    :when (modulep! :checkers syntax -flymake)
+    :after elixir-mode
+    :config (flycheck-credo-setup))
+
+
+  (use-package! exunit
+    :hook (elixir-mode . exunit-mode)
+    :init
+    (map! :after elixir-mode
+          :localleader
+          :map elixir-mode-map
+          :prefix ("t" . "test")
+          "a" #'exunit-verify-all
+          "r" #'exunit-rerun
+          "v" #'exunit-verify
+          "T" #'exunit-toggle-file-and-test
+          "t" #'exunit-toggle-file-and-test-other-window
+          "s" #'exunit-verify-single)))
 
 
 (use-package! elixir-mode
@@ -55,7 +75,7 @@
   :init
   (set-tree-sitter! 'elixir-mode 'elixir-ts-mode
     '((elixir :url "https://github.com/elixir-lang/tree-sitter-elixir"
-              :commit "02a6f7fd4be28dd94ee4dd2ca19cb777053ea74e")
+       :commit "02a6f7fd4be28dd94ee4dd2ca19cb777053ea74e")
       (heex :url "https://github.com/phoenixframework/tree-sitter-heex"
             :commit "f6b83f305a755cd49cf5f6a66b2b789be93dc7b9")))
   :config
@@ -66,24 +86,3 @@
   :when (modulep! +tree-sitter)
   :when (fboundp 'heex-ts-mode) ; 30.1+ only
   :mode "\\.[hl]?eex\\'")
-
-
-(use-package! flycheck-credo
-  :when (modulep! :checkers syntax -flymake)
-  :after elixir-mode
-  :config (flycheck-credo-setup))
-
-
-(use-package! exunit
-  :hook (elixir-mode . exunit-mode)
-  :init
-  (map! :after elixir-mode
-        :localleader
-        :map elixir-mode-map
-        :prefix ("t" . "test")
-        "a" #'exunit-verify-all
-        "r" #'exunit-rerun
-        "v" #'exunit-verify
-        "T" #'exunit-toggle-file-and-test
-        "t" #'exunit-toggle-file-and-test-other-window
-        "s" #'exunit-verify-single))


### PR DESCRIPTION
Move the `flycheck-credo` and `exunit` configurations into the `+elixir-common-config` function to group all common setup logic in one place to make it available for both `elixir-mode` and `elixir-ts-mode`.

<!-- ⚠️ Please do not ignore this template! -->

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
