### PR TITLE
fix: rebar3 does not work with fmt -v arguments

### DIFF
--- a/modules/lang/erlang/doctor.el
+++ b/modules/lang/erlang/doctor.el
@@ -10,5 +10,10 @@
          "This module requires (:tools tree-sitter)")
 
 (when (modulep! :editor format)
-  (unless (and (executable-find "rebar3") (zerop (car (doom-call-process "rebar3" "fmt" "-v"))))
+  (unless (executable-find "erlfmt")
     (warn! "Couldn't find erlfmt. Formatting will be disabled.")))
+
+(when (modulep! :editor format)
+  (unless (and (executable-find "rebar3")
+               (zerop (car (doom-call-process "rebar3" "format"))))
+    (warn! "Couldn't find rebar3 with format plugin installed (needed in Erlang module). Formatting will be disabled.")))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [v] I searched the issue tracker and this hasn't been PRed before.
- [v] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [v] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] I am blindly checking these off.
- [v] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to finish it.

`doom doctor` utility raises a warning however the command it tries to invoke does not exist in `rebar3`
 i changed it to proper command call, and added check for `erlfmt -v` command, changed the text of warnings accordingly 