### PR TITLE
fix(ada): use gpr-specific modes and indent properly

### DIFF
--- a/modules/lang/ada/README.org
+++ b/modules/lang/ada/README.org
@@ -20,8 +20,8 @@ This module adds support for the Ada and SPARK programming languages.
 ** Module flags
 # Flags should be in alphanumerical order.
 - +lsp ::
-  Enable LSP support for ~ada-mode~ / ~ada-ts-mode~. Requires [[doom-module::tools lsp]]
-  and a langserver (supports [[https://github.com/AdaCore/ada_language_server][ada_language_server]]).
+  Enable LSP support for ~ada-mode~ / ~ada-ts-mode~, ~gpr-mode~ / ~gpr-ts-mode~.
+  Requires [[doom-module::tools lsp]] and a langserver (supports [[https://github.com/AdaCore/ada_language_server][ada_language_server]]).
 - +tree-sitter ::
   Leverages tree-sitter for better syntax highlighting and structural text
   editing. Requires [[doom-module::tools tree-sitter]] and Emacs 29.1+.
@@ -29,6 +29,8 @@ This module adds support for the Ada and SPARK programming languages.
 ** Packages
 - [[doom-package:ada-mode]]
 - [[doom-package:ada-ts-mode]] if [[doom-module:+tree-sitter]]
+- [[doom-package:gpr-mode]]
+- [[doom-package:gpr-ts-mode]] if [[doom-module:+tree-sitter]]
 
 ** Hacks
 - ~ada-ts-mode~ has been advised not to set ~treesit-language-source-alist~ and

--- a/modules/lang/ada/config.el
+++ b/modules/lang/ada/config.el
@@ -8,14 +8,25 @@
     (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append))
 
   (map! :map ,(intern (format "%s-map" mode))
+        [remap newline] #'reindent-then-newline-and-indent ; Non-Evil
+        :i "RET" #'reindent-then-newline-and-indent ; Evil
         :localleader
         :desc "Build Alire Project" "b" #'+ada/alr-build
         :desc "Run Alire Project"   "r" #'+ada/alr-run
         :desc "Clean Alire Project" "c" #'+ada/alr-clean))
 
 
+(defun +gpr-common-config (mode)
+  (when (modulep! +lsp)
+    (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append))
+
+  (map! :map ,(intern (format "%s-map" mode))
+        [remap newline] #'reindent-then-newline-and-indent ; Non-Evil
+        :i "RET" #'reindent-then-newline-and-indent)) ; Evil
+
+
 (use-package! ada-mode
-  :mode "\\.gpr\\'"
+  :defer t
   :config
   (+ada-common-config 'ada-mode))
 
@@ -42,3 +53,19 @@
     :after #'ada-ts-mode
     (kill-local-variable 'treesit-language-source-alist)
     (kill-local-variable 'eglot-server-programs)))
+
+
+(use-package! gpr-mode
+  :defer t
+  :config
+  (+gpr-common-config 'gpr-mode))
+
+
+(use-package! gpr-ts-mode
+  :when (modulep! +tree-sitter)
+  :defer t
+  :init
+  (set-tree-sitter! 'gpr-mode 'gpr-ts-mode
+    '((gpr :url "https://github.com/brownts/tree-sitter-gpr")))
+  :config
+  (+gpr-common-config 'gpr-ts-mode))

--- a/modules/lang/ada/packages.el
+++ b/modules/lang/ada/packages.el
@@ -4,3 +4,6 @@
 (package! ada-mode :pin "ce8a2dfebc2b738f32b61dbe2668f7acb885db93")
 (when (and (modulep! +tree-sitter) (treesit-available-p))
   (package! ada-ts-mode :pin "d0c1c124b236b402b884188948cb1f3502ef8779"))
+(package! gpr-mode :pin "03141c6b9a39c31a6e759b594b41617b97b02753")
+(when (and (modulep! +tree-sitter) (treesit-available-p))
+  (package! gpr-ts-mode :pin "b8aeca2c8fd5ed370dad0676da8f380627c916d5"))


### PR DESCRIPTION
GNAT Project modes (`gpr-mode` and `gpr-ts-mode`) exist to handle .gpr files. These modes are now used instead of the Ada major mode.

Lines may need to be re-indented when RET is pressed.  This is to handle cases of incomplete syntax and ambiguity in what may be entered when an empty line is initially indented.  Re-indenting after text has been entered corrects incorrectly guessed initial indentation.  To accommodate this scenario, RET is remapped to `reindent-then-newline-and-indent`.

Also updates documentation to reflect these changes.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).