### PR TITLE
feat: add +respect-visual flag to :editor evil

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -15,7 +15,11 @@ This holy module brings the Vim editing model to Emacs.
 - +everywhere ::
   Enable evilified keybinds everywhere possible. Uses the [[https://github.com/emacs-evil/evil-collection][evil-collection]] plugin
   as a foundation.
-
+- +respect-visual ::
+  Whether movement commands respect ~visual-line-mode~.If enabled, motions such
+  as j and k navigate by visual lines (on the screen) rather than "physical"
+  lines (defined by newline characters).  If nil, the setting of
+  ~visual-line-mode~ is ignored.
 ** Packages
 - [[doom-package:evil]]
 - [[doom-package:evil-args]]

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -22,7 +22,7 @@ directives. By default, this only recognizes C directives.")
 (defvar evil-want-C-w-delete t)
 (defvar evil-want-Y-yank-to-eol t)
 (defvar evil-want-abbrev-expand-on-insert-exit nil)
-(defvar evil-respect-visual-line-mode nil)
+(defvar evil-respect-visual-line-mode (modulep! +respect-visual))
 
 (use-package! evil
   :hook (doom-after-modules-config . evil-mode)


### PR DESCRIPTION
Adds a new `+respect-visual` flag to the :editor evil module.
When enabled, commands that operate on visual regions will prefer
the active visual selection instead of point. This makes operator
and motion behavior more intuitive for users who rely on visual
mode.
