### PR TITLE
docs(org): Warn if makeinfo is missing

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -223,6 +223,7 @@ For [[doom-module:+jupyter]], install =jupyterlab= or =jupyter-notebook= ([[http
 #+begin_src sh
 apt-get install texlive dvipng
 apt-get install gnuplot
+apt-get install texinfo        # for makeinfo binary
 #+end_src
 
 ** NixOS

--- a/modules/lang/org/doctor.el
+++ b/modules/lang/org/doctor.el
@@ -1,6 +1,9 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/org/doctor.el
 
+(unless (executable-find "makeinfo")
+  (warn! "Couldn't find makeinfo. Org Mode and Org Guide info manuals will not be available."))
+
 (when (modulep! +gnuplot)
   (unless (executable-find "gnuplot")
     (warn! "Couldn't find gnuplot. org-plot/gnuplot will not work")))


### PR DESCRIPTION
The "Org Mode" and "Org Guide" documents have broken links. This is due to the `doc` subfolder make process failing for lack of the `makeinfo` binary. This is not a preventable error, but rather a missing dependency requirement on the target operating systems. This update simply documents this with a `doctor.el` update and a single line example on how to fix it in the `README.org`.

- modules/lang/org/README.org
- modules/lang/org/doctor.el

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #5457

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project. **NOPE, this one definitely is in the do-not-PR, but it should be opened to reference what the problem is for others to discover**
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
