### PR TITLE
fix(lib): doom/sandbox: tree-sitter extra load path

### DIFF
--- a/lisp/lib/sandbox.el
+++ b/lisp/lib/sandbox.el
@@ -87,6 +87,9 @@
                   package-archives ',package-archives)
             (with-eval-after-load 'doom
               (run-hooks 'doom-before-init-hook))
+            (with-eval-after-load 'treesit
+              (add-to-list 'treesit-extra-load-path
+                           ,(file-name-concat doom-profile-data-dir "tree-sitter")))
             (with-eval-after-load 'undo-tree
               ;; HACK `undo-tree' sometimes throws errors because
               ;;      `buffer-undo-tree' isn't correctly initialized.


### PR DESCRIPTION
Configure tree-sitter extra load path for vanilla versions of the sandbox.  This allows using installed tree-sitter grammar libraries if a tree-sitter major mode is used in the vanilla environment without having to manually configure `treesit-extra-load-path`.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
