### PR TITLE
fix(php): tree-sitter indent rule should use cdar instead of cadr

### DIFF
--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -98,7 +98,7 @@
                 `(((parent-is "member_call_expression") parent-bol php-ts-mode-indent-offset)))
                ;; Room for other corrections
                )
-           ,@(cadr rules)))))))
+           ,@(cdar rules)))))))
 
 
 (use-package! php-refactor-mode


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The php-ts-mode indentation hack logic was mistakenly using `cadr` to pick the
second element of `rules`, 
Switching to `cdar` makes the extra offsets actually take effect and
keeps the alist structure intact.

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
