### PR TITLE
fix(vertico): search for ripgrep on remote machine

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -17,7 +17,7 @@
 :args LIST
   Arguments to be appended to `consult-ripgrep-args'."
   (declare (indent defun))
-  (unless (executable-find "rg")
+  (unless (executable-find "rg" t)
     (user-error "Couldn't find ripgrep in your PATH"))
   (require 'consult)
   (setq deactivate-mark t)


### PR DESCRIPTION
When running project is located on a remote host, we should search for "rg" on the remote host. (executable-find) without the optional 't' will search only on the local host.

Fix: #8525
-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
