### PR TITLE
docs(macos): add emacs-builds to getting_started.org

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -288,6 +288,15 @@ xcode-select --install
 
 For Emacs itself, these three formulas are the best options, ordered from most
 to least recommended for Doom (based on compatibility).
+- [[https://github.com/jimeh/emacs-builds]].
+  this is what I just used for a fresh setup
+  is at emacs v30 whereas mituharu/emacs-mac is at 29?
+  should this repo be recommended?
+  #+BEGIN_SRC bash
+  brew tap jimey/emacs-builds
+  brew install --cask jimeh/emacs-builds/emacs-app
+  # installs `emacs` cli command also. to run in a terminal need addtl flags
+  #+END_SRC
 
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]]. It offers good integration
   with macOS, native emojis and better childframe support.


### PR DESCRIPTION
Is [emacs-builds](https://github.com/jimeh/emacs-builds) a viable source to be added to the instructions?
I don't know enough to evaluate yes or no.
I recently used this a few days ago before installing doom.

-----
 
I left a TODO in the commit
upon review by anyone knowledgeable of mac builds
I will update the comment similar to the other options listed

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
This commit does not comply to doom's conventional commits convention.
I saw this afterwards.. the pull request title is edited to comply.
I can squash merge it later.
- [ ] I am blindly checking these off.
no
- [ ] This PR contains AI-generated work.
no
- [x] Any relevant issues or PRs have been linked to.
tried, found one
- [ ] This a draft PR; I need more time to finish it.