### PR TITLE
docs: init.el: add `+local` flag to agda

### DIFF
--- a/static/init.example.el
+++ b/static/init.example.el
@@ -112,7 +112,7 @@
        ;;tty               ; improve the terminal Emacs experience
 
        :lang
-       ;;agda              ; types of types of types of types...
+       ;;(agda +local)     ; types of types of types of types...
        ;;beancount         ; mind the GAAP
        ;;(cc +lsp)         ; C > C++ == 1
        ;;clojure           ; java with a lisp


### PR DESCRIPTION
Use the `agda-mode` executable that comes with your local `agda` install.

Without this option, usability gets very painful as agda-mode shipped with Doom is for Agda 2.9.0, which is not a stable release yet (can't be installed via `cabal`).  So out of the box, you immediately need to either upgrade Agda to an experimental version, or downgrade this package. Unless you use the `+local` option.

agda is commented out both before and after this change, so I classified it as `docs:` as it is merely a suggestion to the user to use the `+local` option (or read the docs to learn more).

Documentation for `+local` was added in PR #6274.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

----

Thanks for all your work on Doom.