### PR TITLE
Fix '@startXXX' otherwise it will contain 2 backslashes before the @startXXX ('\\@startXXX')

### DIFF
--- a/modules/lang/plantuml/autoload.el
+++ b/modules/lang/plantuml/autoload.el
@@ -8,7 +8,7 @@ This function is called by `org-babel-execute-src-block'."
   ;; REVIEW Refactor me
   (let* ((body (replace-regexp-in-string
                 "^[[:blank:]\n]*\\(@start\\)"
-                "\\\\\\1"
+                "\\1"
                 body))
          (fullbody (org-babel-plantuml-make-body body params))
          (out-file (or (cdr (assq :file params))


### PR DESCRIPTION
With the current implementation any `@startXXX` lines will be renamed to `\\@startXXX` ... the double-backslash before '@startXXX' doesn't make any sense so it should be removed.

Background info how I found that: I am currently working on a few fixes for the plantuml behaviour in the org-mode repo (refactoring the `org-babel-plantuml-make-body` function):
https://lists.gnu.org/archive/html/emacs-orgmode/2025-09/msg00066.html

These fixes however would not work with your plantuml module unless this PR is also applied to your codebase. Hope this can be done. In case you have further questions please let me know.

Best
Tim

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
