### PR TITLE
fix: set-formatter! align with documentation

### DIFF
--- a/modules/editor/format/autoload/settings.el
+++ b/modules/editor/format/autoload/settings.el
@@ -87,5 +87,5 @@ Advanced examples:
                         (t args))))
         (setf (alist-get name apheleia-formatters) formatter))
       (when modes
-        (dolist (mode modes)
+        (dolist (mode (ensure-list modes))
           (setf (alist-get mode apheleia-mode-alist) name))))))


### PR DESCRIPTION
The documentation for `set-formatter!` states:

    MODES is a major mode, a list thereof, or a list of two-element sublists with
    the structure: (MAJOR-MODE FORM).
    
It however, assumed it would a list and would blow up when passed a single major mode.

I figured it was easier to fix the code than adjust the documentation...