### PR TITLE
fix(org): reconcile ob-async with new org, lazy loading

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -298,11 +298,11 @@ Also adds support for a `:sync' parameter to override `:async'."
   "Load babel libraries lazily when babel blocks are executed."
   (defun +org--babel-lazy-load (lang &optional async)
     (cl-check-type lang (or symbol null))
+    ;; ob-async has its own agenda for lazy loading packages (in the child
+    ;; process), so we only need to make sure it's loaded.
+    (when async
+      (require 'ob-async nil t))
     (unless (cdr (assq lang org-babel-load-languages))
-      (when async
-        ;; ob-async has its own agenda for lazy loading packages (in the child
-        ;; process), so we only need to make sure it's loaded.
-        (require 'ob-async nil t))
       (prog1 (or (run-hook-with-args-until-success '+org-babel-load-functions lang)
                  (require (intern (format "ob-%s" lang)) nil t)
                  (require lang nil t))


### PR DESCRIPTION
#### fix(org): check :async on already loaded languages
Running a regular/`:sync` source block would prevent successive
invocations of blocks of that same language with `:async` from loading
`ob-async`.


#### fix(org): don't export noweb-cache-related var
Org added a global cache for noweb expansion that includes a buffer
object. Those aren’t readable by the Lisp reader across processes, so
when async.el serializes the parent environment and hits that cons
`'(#<buffer *new*> . 739 )`, the child later tries to read it and errors
with `Invalid read syntax: "#<"'`

Fix: https://github.com/astahlman/ob-async/issues/99

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
