### PR TITLE
fix(python): fix eglot client config for pyright lsp

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -35,12 +35,9 @@
     (add-hook 'python-mode-local-vars-hook #'lsp! 'append)
     (add-hook 'python-ts-mode-local-vars-hook #'lsp! 'append)
 
-    ;; REVIEW: PR this upstream, which assumes the wrong names for the
-    ;;   (based)pyright executables.
     (set-eglot-client! '(python-mode python-ts-mode)
                        "pylsp" "pyls"
                        '("basedpyright-langserver" "--stdio")
-                       '("pyright" "--stdio")
                        '("pyright-langserver" "--stdio")
                        '("pyrefly" "lsp")
                        "jedi-language-server"


### PR DESCRIPTION
## Summary

This PR fixes the eglot client configuration for the pyright language server in the Python module.

### Changes Made
- Removed the incorrect `'("pyright" "--stdio")` entry from the eglot client configuration

### Rationale
The `pyright` executable is the CLI tool for type checking, not the language server. The correct executable for the LSP is `pyright-langserver`, which was already properly configured. Having the incorrect `"pyright"` entry could cause eglot to attempt using the wrong executable, leading to LSP failures or unexpected behavior.

This change ensures that eglot only attempts to connect using valid language server executables:
- `basedpyright-langserver` (BasedPyright fork)
- `pyright-langserver` (official LSP server)
- Other configured servers (pylsp, pyls, pyrefly, jedi-language-server)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.