### PR TITLE
fix: off by one when switching workspaces

### DIFF
--- a/modules/ui/workspaces/autoload/evil.el
+++ b/modules/ui/workspaces/autoload/evil.el
@@ -30,10 +30,10 @@
 (evil-define-command +workspace:switch-next (&optional count)
   "Switch to next workspace. If COUNT, switch to COUNT-th workspace."
   (interactive "<c>")
-  (if count (+workspace/switch-to count) (+workspace/cycle +1)))
+  (if count (+workspace/switch-to (max (1- count) 0)) (+workspace/cycle +1)))
 
 ;;;###autoload (autoload '+workspace:switch-previous "ui/workspaces/autoload/evil" nil t)
 (evil-define-command +workspace:switch-previous (&optional count)
   "Switch to previous workspace. If COUNT, switch to COUNT-th workspace."
   (interactive "<c>")
-  (if count (+workspace/switch-to count) (+workspace/cycle -1)))
+  (if count (+workspace/switch-to (max (1- count) 0)) (+workspace/cycle -1)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

The workspaces in the echo area (via `+workspaces/display` for instance) are 1-indexed and I believe the intention is that `5 gt` for example, takes me to the 5th workspace rather than the 6th.

But that actually takes me to the 6th workspace since the actual internal workspace list is 0-indexed (via `+workspace-list-names` used by `+workspace/switch-to`).

The `max` here is to just avoid funny behaviour if we set the prefix-arg to <1 (i.e. 0 or negative, which is easier to just go to the first workspace) If we wanted to swap X workspaces relative to the current one then +workspace/switch-left +workspace/switch-right would be more appropriate

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [x] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
