### PR TITLE
fix(emacs-lisp): set Helpful tab-width to 8

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -299,6 +299,12 @@ current buffer."
   :config
   (setq helpful-set-variable-function #'setq!)
 
+  (setq-hook! 'helpful-mode-hook
+    ;; Elisp code using tab indentation always use a tab-width of 8. C source
+    ;; code from Emacs also use a tab-width of 8. Therefore Helpful needs a
+    ;; tab-width of 8 to display tab indentation correctly.
+    tab-width 8)
+
   (cond ((modulep! :completion ivy)
          (setq counsel-describe-function-function #'helpful-callable
                counsel-describe-variable-function #'helpful-variable


### PR DESCRIPTION
This matches the expected tab-width of Emacs code using tab indentation.

Fix: #8574

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
