### PR TITLE
fix(mu4e): Column misalignment in headers view

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -279,7 +279,7 @@ is non-nil."
 
   ;; Fix columns misalignment in Headers buffers
   (add-hook! 'mu4e-headers-mode-hook
-    (defun +mu4e-headers-alignment ()
+    (defun +mu4e-headers-fix-alignment-h ()
       "Header line face inherits from the default face"
       (header-line-indent-mode 1)
       (push (propertize " " 'display '(space :align-to header-line-indent-width)) header-line-format)


### PR DESCRIPTION

<!-- ⚠️ Please do not ignore this template! -->

In headers view, the header values are misaligned with the column headings.

See `Account (blue color), Date, Flags, From/To and Subject` headings, they are not aligned with below values...
<img width="987" height="266" alt="before" src="https://github.com/user-attachments/assets/06e9f09c-7e73-4fe9-a884-73b38ff7e23f" />

It seems it's a [known issue](https://www.djcbsoftware.nl/code/mu/mu4e/Known-issues.html#Headers_002dbuffer-can-get-mis_002daligned).
After applying the changes, column headings are aligned again:
<img width="987" height="266" alt="after" src="https://github.com/user-attachments/assets/e9c5e43c-292f-4e5d-86eb-5e4b47727f10" />

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
