### PR TITLE
perf(unicode): drastically reduce initial startup time

### DIFF
--- a/modules/ui/unicode/autoload.el
+++ b/modules/ui/unicode/autoload.el
@@ -8,6 +8,10 @@ necessary."
     (setq-default bidi-display-reordering t)
     (+unicode-setup-fonts-h (selected-frame))))
 
+;; From font-utils.el, required by unicode-fonts.el.
+;; This only marks the variable as special locally.
+(defvar font-utils-use-memory-cache)
+
 ;;;###autoload
 (defun +unicode-setup-fonts-h (&optional frame)
   "Initialize `unicode-fonts', if in a GUI session.
@@ -20,6 +24,12 @@ If doom-symbol-font is set, add it as a preferred font for all Unicode blocks."
         (let ((doom-symbol-font-family (plist-get (font-face-attributes doom-symbol-font) :family)))
           (dolist (unicode-block unicode-fonts-block-font-mapping)
             (push doom-symbol-font-family (cadr unicode-block)))))
-      ;; NOTE: will impact startup time on first run
-      (let (inhibit-redisplay inhibit-message)
+      (let ((inhibit-redisplay nil)
+            (inhibit-message nil)
+            ;; font-utils says "`font-family-list' often gives truncated results
+            ;; before Emacs is fully initialized". That is irrelevant when
+            ;; `unicode-fonts' is testing for the existence of fonts in a loop,
+            ;; all calls during the same phase in startup and thus would see the
+            ;; same set of available fonts regardless of caching.
+            (font-utils-use-memory-cache t))
         (unicode-fonts-setup)))))


### PR DESCRIPTION
font-utils.el disable its cache on X and Windows so every check for the existence of a font recomputes the font list, which takes a non-negligible amount of time, at least on X. This default is reasonable as stated in [the docstring of font-utils-use-memory-cache](https://github.com/rolandwalker/font-utils/blob/master/font-utils.el#L175):

> Disabled on X11 and MS Windows by default, because font-family-list
> often gives truncated results before Emacs is fully initialized.

This is, however, unreasonable from unicode-fonts, where calls to check the existence of fonts happens in a loop; during the loop, Emacs is not going to suddenly become fully initialized, so each call is actually recomputing the same font list over and over again.

Enabling the font-utils memory cache, at least for the duration of unicode-fonts-setup, thus drastically reduces the initial startup time, or the startup time when the pcache store is reset for some reason.

On my device, this makes it so a fresh `unicode-fonts-setup` (delete ~/.config/emacs/.local/cache/pcache then restart Emacs) takes only about 3 seconds, instead of the 30+ seconds before.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.