### PR TITLE
fix(cc-mode): Wrap tree-sitter remap hack in conditional

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -45,8 +45,9 @@ This is ignored by ccls.")
   ;; HACK: cc-mode adds null entries to `major-mode-remap-defaults', which
   ;;   overrides our tree-sitter remappings, causing the first remap to succeed,
   ;;   but future remaps to fail.
-  (dolist (mode '(c-mode c++-mode c-or-c++-mode))
-    (cl-callf2 delete (list mode) major-mode-remap-defaults))
+  (when (modulep! +tree-sitter)
+    (dolist (mode '(c-mode c++-mode c-or-c++-mode))
+      (cl-callf2 delete (list mode) major-mode-remap-defaults)))
 
   (set-docsets! '(c-mode c-ts-mode) "C")
   (set-docsets! '(c++-mode c++-ts-mode) "C++" "Boost")


### PR DESCRIPTION
C/C++ files open in tree-sitter modes (e.g., `c++-ts-mode`) even when the `:tools tree-sitter` module is **not** enabled in `init.el`. Interestingly, this only happens for the second file (first file opens in `c++-mode`, all other in `c++-ts-mode`).

Root cause: Doom unconditionally removes cc-mode's protective "null entries" from `major-mode-remap-defaults`.

Fix: Only remove the null entries when the `+tree-sitter` flag is enabled.

This is an issue because in `c++-ts-mode`:
- CC Mode settings are ignored: `c-basic-offset`, `c-offsets-alist`, `c-default-style`,
- Custom indentation styles don't apply, and
- Hooks like `c++-mode-hook` don't run.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
