### PR TITLE
fix(default): +default/diagnostics project-wise diagnostics when usin…

### DIFF
--- a/modules/config/default/autoload/default.el
+++ b/modules/config/default/autoload/default.el
@@ -66,7 +66,7 @@ current project. Otherwise list them for the current buffer"
            (flycheck-list-errors)))
         ((bound-and-true-p flymake-mode)
          (if (modulep! :completion vertico)
-             (consult-flymake)
+             (consult-flymake t)
            (flymake-show-diagnostics-buffer)))
         (t
          (user-error "No diagnostics backend detected. Enable flycheck or \


### PR DESCRIPTION
…g eglot + vertico

If the vertico and lsp modules are active, +default/diagnostics lists lsp diagnostics for the current project

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
