### PR TITLE
fix(clojure): fix keybinding and evil-snipe issues

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -41,8 +41,17 @@
       :init
       (map! :map ,keymaps
             :localleader
-            "j" #'jet))))
+            "j" #'jet))
 
+    (use-package! cider-mode
+      :defer t
+      :init
+      (map! :map ,keymaps
+            :localleader
+            "'"  #'cider-jack-in-clj
+            "\"" #'cider-jack-in-cljs
+            "c"  #'cider-connect-clj
+            "C"  #'cider-connect-cljs))))
 
 
 (defun +clojure-disable-lsp-indentation-h ()
@@ -86,8 +95,6 @@
 ;; reconfiguration in many cases.
 (use-package! cider-mode
   ;; NOTE if `org-directory' doesn't exist, `cider-jack' in won't work
-  :hook (clojure-mode-local-vars . cider-mode)
-  :hook (clojure-ts-mode-local-vars . cider-mode)
   :init
   (after! clojure-mode
     (set-repl-handler! '(clojure-mode clojure-ts-mode
@@ -184,8 +191,19 @@
 
           ;; Prevent evil-snipe from overriding evil-collection
           (add-hook! 'cider--debug-mode-hook
-                     #'turn-off-evil-snipe-mode
-                     #'turn-off-evil-snipe-override-mode))
+            (defun +clojure-toggle-evil-snipe-in-debug-mode-h ()
+              "Disable evil-snipe in cider-debug-mode, and restore it when disabling the mode."
+              (if cider--debug-mode
+                  (progn
+                    (when (bound-and-true-p evil-snipe-local-mode)
+                      (evil-snipe-local-mode -1))
+                    (when (bound-and-true-p evil-snipe-override-local-mode)
+                      (evil-snipe-override-local-mode -1)))
+                (progn
+                  (when (bound-and-true-p evil-snipe-mode)
+                    (evil-snipe-local-mode 1))
+                  (when (bound-and-true-p evil-snipe-override-mode)
+                    (evil-snipe-override-local-mode 1)))))))
 
       ;; When in cider-debug-mode, override evil keys to not interfere with debug keys
       (add-hook! 'cider--debug-mode-hook
@@ -241,12 +259,20 @@
   ;; supposed to be make visible.
   (setq cider-repl-display-help-banner nil)
 
+  (after! which-key
+    (which-key-add-key-based-replacements
+      (concat doom-localleader-key " d") "debug"
+      (concat doom-localleader-key " e") "eval"
+      (concat doom-localleader-key " g") "goto"
+      (concat doom-localleader-key " h") "help"
+      (concat doom-localleader-key " i") "inspect"
+      (concat doom-localleader-key " n") "namespace"
+      (concat doom-localleader-key " p") "print"
+      (concat doom-localleader-key " r") "repl"
+      (concat doom-localleader-key " t") "test"))
+
   (map! (:localleader
           (:map cider-mode-map
-            "'"  #'cider-jack-in-clj
-            "\"" #'cider-jack-in-cljs
-            "c"  #'cider-connect-clj
-            "C"  #'cider-connect-cljs
             "m"  #'cider-macroexpand-1
             "M"  #'cider-macroexpand-all
             (:prefix ("d" . "debug")


### PR DESCRIPTION
This PR addresses several issues in the Clojure module related to keybinding persistence, `which-key` descriptions, and `evil-snipe` conflicts.

### Changes

1.  **Fix Keybinding Persistence**: Moved CIDER connection keybindings (`'`, `"`, `c`, `C`) from `cider-mode-map` to the major mode keymaps. Previously, these bindings would disappear after quitting a CIDER REPL because `cider-mode` would disable. (Fixes #8537)
2.  **Fix `which-key` Descriptions**: Explicitly registered descriptions for CIDER prefixes (`debug`, `eval`, `repl`, etc.) using `which-key-add-key-based-replacements`. This resolves an issue where prefixes appeared as "+prefix" in the popup.
3.  **Fix `evil-snipe` Conflict**: Replaced the unconditional disabling of `evil-snipe` in `cider-debug-mode` with a toggle function defined via `add-hook!`. This ensures `evil-snipe` is correctly restored when debugging ends.
4.  **Disable Auto-Activation**: Removed hooks that automatically enabled `cider-mode` on file open. `cider-mode` now activates only when a REPL connection is established, which is cleaner and prevents premature activation.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.