### PR TITLE
fix(swift): tree-sitter-swift missing parser.c

### DIFF
--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -5,7 +5,8 @@
   :init
   (when (modulep! +tree-sitter)
     (set-tree-sitter! 'swift-mode 'swift-ts-mode
-      '((swift :url "https://github.com/alex-pinkus/tree-sitter-swift"))))
+      '((swift :url "https://github.com/alex-pinkus/tree-sitter-swift"
+               :rev "0.7.1-with-generated-files"))))
 
   :config
   (set-repl-handler! 'swift-mode #'run-swift)


### PR DESCRIPTION
The current HEAD on https://github.com/alex-pinkus/tree-sitter-swift does not include generated files. Use a tag that does.

The solution proposed in the repository of downloading artifacts from an action is not feasible as they expire and become unavailable.

There is a tag that has the generated files. This change uses that instead.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
