### PR TITLE
fix(cc): typo in +cc-lineup-arglist-close

### DIFF
--- a/modules/lang/cc/autoload.el
+++ b/modules/lang/cc/autoload.el
@@ -25,14 +25,14 @@
        '++))
 
 ;;;###autoload
-(defun +cc-lineup-arglist-close (langlem)
+(defun +cc-lineup-arglist-close (langelem)
   "Line up the closing brace in an arglist with the opening brace IF cursor is
 preceded by the opening brace or a comma (disregarding whitespace in between)."
   (when (save-excursion
           (save-match-data
             (skip-chars-backward " \t\n" (c-langelem-pos langelem))
             (memq (char-before) (list ?, ?\( ?\;))))
-    (c-lineup-arglist langlem)))
+    (c-lineup-arglist langelem)))
 
 (defun +cc--re-search-for (regexp)
   (save-excursion


### PR DESCRIPTION
Fix: #7165

<!-- ⚠️ Please do not ignore this template! -->

This fixes a void-variable error.

I came across this while investigating [this post in doom-help](https://discord.com/channels/406534637242810369/1447565778491539477), though I don't think this fully solves that poster's problem.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
