### PR TITLE
feat(scratch): add toggle commands for scratch buffers

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -89,7 +89,7 @@
        :desc "Sudo find file"              "U"   #'doom/sudo-find-file
        :desc "Yank file path"              "y"   #'+default/yank-buffer-path
        :desc "Yank file path from project" "Y"   #'+default/yank-buffer-path-relative-to-project
-       :desc "Open scratch buffer"         "x"   #'doom/open-scratch-buffer
+       :desc "Toggle scratch buffer"       "x"   #'doom/toggle-scratch-buffer
        :desc "Switch to scratch buffer"    "X"   #'doom/switch-to-scratch-buffer)
 
       ;;; <leader> r --- remote
@@ -286,7 +286,7 @@
        :desc "Search project for symbol"   "." #'+default/search-project-for-symbol-at-point
        :desc "Find file in other project"  "F" #'doom/find-file-in-other-project
        :desc "Search project"              "s" #'+default/search-project
-       :desc "Open project scratch buffer" "x" #'doom/open-project-scratch-buffer
+       :desc "Toggle project scratch buffer" "x" #'doom/toggle-project-scratch-buffer
        :desc "Switch to project scratch buffer" "X" #'doom/switch-to-project-scratch-buffer
        ;; later expanded by projectile
        (:prefix ("4" . "in other window"))

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -337,7 +337,7 @@
 (map! :leader
       :desc "Eval expression"       ";"    #'pp-eval-expression
       :desc "M-x"                   ":"    #'execute-extended-command
-      :desc "Pop up scratch buffer" "x"    #'doom/open-scratch-buffer
+      :desc "Toggle scratch buffer" "x"    #'doom/toggle-scratch-buffer
       :desc "Org Capture"           "X"    #'org-capture
       ;; C-u is used by evil
       :desc "Universal argument"    "u"    #'universal-argument
@@ -770,7 +770,7 @@
        :desc "Run project"                  "R" #'projectile-run-project
        :desc "Save project files"           "s" #'projectile-save-project-buffers
        :desc "Test project"                 "T" #'projectile-test-project
-       :desc "Pop up scratch buffer"        "x" #'doom/open-project-scratch-buffer
+       :desc "Toggle scratch buffer"        "x" #'doom/toggle-project-scratch-buffer
        :desc "Switch to scratch buffer"     "X" #'doom/switch-to-project-scratch-buffer)
 
       ;;; <leader> q --- quit/session


### PR DESCRIPTION
## Summary

- Add `doom/toggle-scratch-buffer` and `doom/toggle-project-scratch-buffer` commands that toggle scratch buffer visibility, consistent with how `SPC o t` toggles the terminal popup
- Extract mode determination logic into `doom--scratch-buffer-initial-mode` helper to ensure toggle commands respect `doom-scratch-initial-major-mode` configuration
- Update keybindings to use toggle variants:
  - `SPC x` (evil) / `C-c f x` (emacs) for scratch buffer
  - `SPC p x` (evil) / `C-c p x` (emacs) for project scratch buffer

## Test plan

- [x] Set `doom-scratch-initial-major-mode` to `t`
- [x] Open a buffer with a specific major mode (e.g., `python-mode`)
- [x] Press `SPC x` - scratch buffer opens inheriting the major mode
- [x] Press `SPC x` again - scratch buffer closes
- [x] Verify `doom doctor` runs without errors related to these changes

Fixes #8604