### PR TITLE
Docs(org) : Add note on guix emacs-vterm package

### DIFF
--- a/modules/term/vterm/README.org
+++ b/modules/term/vterm/README.org
@@ -98,6 +98,13 @@ variable ([[kbd:][SPC h v system-configuration-options]]).
   =emacsPackagesFor= from =unstable= or another channel. Otherwise arbitrary
   functionality of =vterm= might not work.
 
+- Guix: ~guix install emacs-vterm~
+
+  =emacs-vterm= contains a version of vterm-module.so, so you don't need to
+  compile it.
+  You can also install this package through system packages or home packages
+  and it will work.
+
 ** Compilation tools for vterm-module.so
 When you first load vterm, it will compile =vterm-module.so= for you. For this
 to succeed, you need the following:


### PR DESCRIPTION
- Building libvterm on guix is complicated and may require setting $LD_LIBRARY_PATH variable which may break other programs on the system
- Guix has a emacs-vterm package with a prebuilt vterm-module.so and it works with vterm in doom
- This will save people some time in figuring this out on guix

<!-- ⚠️ Please do not ignore this template! -->

{{Summarize here what you've changed and why. Any extra commentary may go here as well, including references to any issues/PRs related to it. If your changes are visual, include before and after screenshots please!}}

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project. I am not sure because this is about documentation, but it is a simple addition that will be helpful for guix users
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
