### PR TITLE
tweak: remove ligatures from Elixir

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -9,19 +9,6 @@
 ;;; Packages
 
 (defun +elixir-common-config (mode)
-  (set-ligatures! mode
-    ;; Functional
-    :def "def"
-    :lambda "fn"
-    ;; :src_block "do"
-    ;; :src_block_end "end"
-    ;; Flow
-    :not "!"
-    :in "in" :not-in "not in"
-    :and "and" :or "or"
-    :for "for"
-    :return "return" :yield "use")
-
   ;; ...and only complete the basics
   (sp-with-modes mode
     (sp-local-pair "do" "end"


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

This removes default settings for extra ligatures in Elixir module.

The choice of the ligatures here feels quite arbitrary and sometimes wrong. For example:
* `def` is covered, but `defp` is not
* `use` has a special ligature, but it does not have any special meaning in Elixir that would justify that
* `return` has a ligature, but there is no `return` in Elixir
* these ligatures also show up in comments and doc strings, making them less readable
<img width="684" height="206" alt="Screenshot 2025-12-23 at 21 59 54" src="https://github.com/user-attachments/assets/ed2e6804-8835-43dd-a0e7-9716ce780430" />

In general, I don't feel like these ligatures from "hard" functional programming are establish enough to warrant having them as a default config. Anyone interested can set them themselves.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
