### PR TITLE
fix: include -D in omit list for CLI restart

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -222,7 +222,8 @@ SEE ALSO:
       (when debug?
         (setenv "DEBUG" "1")
         (setq init-file-debug t)
-        (push "--debug" omit))
+        (push "--debug" omit)
+        (push "-D" omit))
       (when profile
         (setenv "DOOMPROFILE" profile)
         (push "--profile=" omit))


### PR DESCRIPTION
The `-D` short flag was not being omitted during restart, causing an infinite loop when using `doom sync -D`.
Only `--debug` was added to the omit list, but `-D` also triggers `debug?` and needs to be removed.

<img width="2560" height="1440" alt="2025-12-27-004417-WezTerm" src="https://github.com/user-attachments/assets/4894aa60-61df-4dd7-9c48-adb18dd036f1" />

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.