### PR TITLE
fix(dired): +dired/dirvish-side-and-follow errors

### DIFF
--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -31,21 +31,5 @@ sidebars)."
         (setq win nil))
       (unless win
         (call-interactively #'dirvish-side))
-      (when-let* (((not (dirvish-curr)))
-                  ((not (active-minibuffer-window)))
-                  (win (dirvish-side--session-visible-p))
-                  (dv (with-selected-window win (dirvish-curr)))
-                  (dir (or (dirvish--get-project-root) default-directory))
-                  (prev (with-selected-window win (dirvish-prop :index)))
-                  (curr buffer-file-name)
-                  ((not (string-suffix-p "COMMIT_EDITMSG" curr)))
-                  ((not (equal prev curr))))
-        (with-selected-window win
-          (when dir
-            (setq dirvish--this dv)
-            (let (buffer-list-update-hook) (dirvish-find-entry-a dir))
-            (if dirvish-side-auto-expand (dirvish-subtree-expand-to file)
-              (dired-goto-file curr))
-            (dirvish-prop :cus-header 'dirvish-side-header)
-            (dirvish-update-body-h))))))
+      (dirvish-side--auto-jump)))
   (select-window (dirvish-side--session-visible-p)))

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -70,7 +70,7 @@ Fixes #3939: unsortable dired entries on Windows."
 
 
 (use-package! dirvish
-  :commands dirvish-find-entry-a dirvish-dired-noselect-a
+  :commands dirvish-dired-noselect-a
   :general (dired-mode-map "C-c C-r" #'dirvish-rsync)
   :init
   (setq dirvish-cache-dir (file-name-concat doom-cache-dir "dirvish/"))


### PR DESCRIPTION
`+dired/dirvish-side-and-follow` was referring to several private dirvish functions that no longer exist. Because `dirvish-side--auto-jump` no longer sets a timer before running, we can now just call `dirvish-side--auto-jump` directly instead of copying from its body.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
