### PR TITLE
fix(macos): fullscreen correctly

### DIFF
--- a/modules/os/macos/config.el
+++ b/modules/os/macos/config.el
@@ -11,10 +11,6 @@
 ;;
 ;;; Compatibilty fixes
 
-;; Curse Lion and its sudden but inevitable fullscreen mode!
-;; This is meaningless to railwaycat's emacs-mac build though.
-(setq ns-use-native-fullscreen nil)
-
 ;; Visit files opened outside of Emacs in existing frame, not a new one
 (setq ns-pop-up-frames nil)
 


### PR DESCRIPTION
This setting makes Emacs behave [differently from every other app](https://github.com/d12frosted/homebrew-emacs-plus/issues/861#issue-3739702257) on macOS and it has been annoying me for 5 years.

If the issue is that you don't want emacs to start in fullscreen (which in my opinion is good behavior, when have you ever wanted to use a little 56x24 character box to edit text

<img width="692" height="652" alt="Screenshot 2025-12-29 at 22 12 17" src="https://github.com/user-attachments/assets/07c03bce-fa96-4987-a07c-20c88cf7da5a" />

instead of your full screen? I have had this in my config.el

```emacs
;; start in fullscreen
(add-to-list 'initial-frame-alist '(fullscreen . fullboth))
```

since a few months after you added this line 5 years ago) then this is surely not the way to configure this.