### PR TITLE
feat(lean): add Lean 4 support via nael

### DIFF
--- a/modules/lang/lean/README.org
+++ b/modules/lang/lean/README.org
@@ -4,16 +4,19 @@
 #+since:    21.12.0 (#1759)
 
 * Description :unfold:
-This module adds support for the [[https://leanprover.github.io/about/][Lean programming language]] to Doom Emacs.
+This module adds support for the [[https://leanprover.github.io/about/][Lean programming language]] to Doom Emacs. It supports Lean 4 by default using [[https://codeberg.org/mekeor/nael][nael]], with optional support for Lean 3.
 
 ** Maintainers
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-/This module has no flags./
+- +v3 ::
+  Enable legacy support for Lean 3 via [[doom-package:lean-mode]].
 
 ** Packages
-- [[doom-package:lean-mode]]
+- [[doom-package:nael]]
+- [[doom-package:nael-lsp]] (if [[doom-module::tools lsp]] is enabled)
+- [[doom-package:lean-mode]] (if [[doom-module:+v3]] is enabled)
 
 ** TODO Hacks
 #+begin_quote
@@ -21,25 +24,49 @@ This module adds support for the [[https://leanprover.github.io/about/][Lean pro
 #+end_quote
 
 ** TODO Changelog
-# This section will be machine generated. Don't edit it by hand.
-/This module does not have a changelog yet./
+- *Dec 30, 2025*:
+  - Refactored module to support Lean 4 as the primary version using ~nael~.
+  - Added ~nael-lsp~ for ~lsp-mode~ integration.
+  - Introduced ~+v3~ flag for legacy Lean 3 support via ~lean-mode~.
+  - Automatically enabled ~abbrev-mode~ for Lean 4 buffers.
 
-* TODO Installation
+* Installation
 [[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
 
-#+begin_quote
- 󱌣 /This module's prerequisites are not documented./ [[doom-contrib-module:][Document them?]]
-#+end_quote
+#+begin_src elisp
+:lang
+(lean +v3) ; +v3 is optional for Lean 3 support
+#+end_src
 
-* TODO Usage
-#+begin_quote
- 󱌣 This module has no usage documentation yet. [[doom-contrib-module:][Write some?]]
-#+end_quote
+** Prerequisites
+- **Lean 4**: Requires ~lean4~ and ~lake~ to be installed and available in your ~$PATH~.
+- **Lean 3**: If using ~+v3~, requires ~lean3~ and ~leanpkg~.
+- **LSP**: It is highly recommended to enable either ~:tools (lsp +eglot)~ (default) or ~:tools lsp~ for a productive environment.
 
-* TODO Configuration
-#+begin_quote
- 󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
-#+end_quote
+* Usage
+** Lean 4 (nael-mode)
+By default, opening a ~.lean~ file triggers ~nael-mode~.
+- **View Goals**: Press ~<localleader> e~ (~eldoc-doc-buffer~) to see the tactic state and goals.
+- **Build Project**: Press ~<localleader> b~ (~project-compile~) to run ~lake build~.
+- **Abbreviations**: Lean 4 uses ~abbrev-mode~ for unicode symbols. Press ~<localleader> a~ (~nael-abbrev-help~) to see available abbreviations for the symbol at point.
+- **Restart Server**: Press ~<localleader> s r~ to restart the LSP server.
+
+** Lean 3 (lean-mode)
+If ~+v3~ is enabled, Lean 3 projects can still use the legacy ~lean-mode~.
+- **Toggle Goal**: ~<localleader> g~.
+- **Server Commands**: Restart the server with ~<localleader> s r~.
+
+* Configuration
+** LSP Client
+This module detects which LSP client you have enabled in your ~:tools lsp~ block:
+- If ~+eglot~ is enabled, it uses ~eglot~.
+- Otherwise, it uses ~lsp-mode~ via the ~nael-lsp~ bridge.
+
+** Customizing nael-mode
+You can add your own hooks to ~nael-mode-hook~:
+#+begin_src elisp
+(add-hook 'nael-mode-hook #'your-favorite-minor-mode)
+#+end_src
 
 * Troubleshooting
 /There are no known problems with this module./ [[doom-report:][Report one?]]

--- a/modules/lang/lean/config.el
+++ b/modules/lang/lean/config.el
@@ -1,28 +1,67 @@
 ;;; lang/lean/config.el -*- lexical-binding: t; -*-
 
-(after! lean-mode
-  (set-lookup-handlers! 'lean-mode
-    :definition #'lean-find-definition)
-  (sp-with-modes 'lean-mode
+(use-package! nael
+  :defer t
+  :init
+  (add-to-list 'auto-mode-alist '("\.lean\'" . nael-mode))
+  (add-hook 'nael-mode-hook #'abbrev-mode)
+  :config
+  (when (featurep! :tools lsp +eglot)
+    (add-hook 'nael-mode-hook #'eglot-ensure))
+
+  (sp-with-modes 'nael-mode
     (sp-local-pair "/-" "-/")
     (sp-local-pair "`" "`")
     (sp-local-pair "{" "}")
     (sp-local-pair "«" "»")
     (sp-local-pair "⟨" "⟩")
     (sp-local-pair "⟪" "⟫"))
-  (map! :map lean-mode-map
+
+  (map! :map nael-mode-map
         :localleader
-        "g" #'lean-toggle-show-goal
-        "n" #'lean-toggle-next-error
+        "a" #'nael-abbrev-help
+        "b" #'project-compile
+        "e" #'eldoc-doc-buffer
         (:prefix ("s" . "server")
-          "r" #'lean-server-restart
-          "s" #'lean-server-stop
-          "v" #'lean-server-switch-version)
-        (:prefix ("p" . "leanpkg")
-          "t" #'lean-leanpkg-test
-          "b" #'lean-leanpkg-build
-          "c" #'lean-leanpkg-configure)
-        "f" #'lean-fill-placeholder
-        "h" #'lean-hole
-        "m" #'lean-message-boxes-toggle
-        "e" #'lean-execute))
+          "r" (cond ((featurep! :tools lsp +eglot) #'eglot-reconnect)
+                    ((featurep! :tools lsp) #'lsp-workspace-restart)))))
+
+(use-package! nael-lsp
+  :when (and (featurep! :tools lsp) (not (featurep! :tools lsp +eglot)))
+  :after nael
+  :init
+  (add-hook 'nael-mode-hook #'lsp-deferred)
+  :config
+  (add-hook 'nael-mode-hook #'nael-lsp-configure-when-managed))
+
+
+;; 
+;;; Lean 3
+
+(when (featurep! +v3)
+  (after! lean-mode
+    (set-lookup-handlers! 'lean-mode
+      :definition #'lean-find-definition)
+    (sp-with-modes 'lean-mode
+      (sp-local-pair "/-" "-/")
+      (sp-local-pair "`" "`")
+      (sp-local-pair "{" "}")
+      (sp-local-pair "«" "»")
+      (sp-local-pair "⟨" "⟩")
+      (sp-local-pair "⟪" "⟫"))
+    (map! :map lean-mode-map
+          :localleader
+          "g" #'lean-toggle-show-goal
+          "n" #'lean-toggle-next-error
+          (:prefix ("s" . "server")
+            "r" #'lean-server-restart
+            "s" #'lean-server-stop
+            "v" #'lean-server-switch-version)
+          (:prefix ("p" . "leanpkg")
+            "t" #'lean-leanpkg-test
+            "b" #'lean-leanpkg-build
+            "c" #'lean-leanpkg-configure)
+          "f" #'lean-fill-placeholder
+          "h" #'lean-hole
+          "m" #'lean-message-boxes-toggle
+          "e" #'lean-execute)))

--- a/modules/lang/lean/packages.el
+++ b/modules/lang/lean/packages.el
@@ -1,4 +1,9 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/lean/packages.el
 
-(package! lean-mode :pin "99d6a34dc5b12f6e996e9217fa9f6fe4a6af037a")
+(package! nael)
+(when (featurep! :tools lsp)
+  (package! nael-lsp))
+
+(when (featurep! +v3)
+  (package! lean-mode :pin "99d6a34dc5b12f6e996e9217fa9f6fe4a6af037a"))


### PR DESCRIPTION
This is a yet another pull request related #7439 .

This refactors the `:lang` lean module to support Lean 4 as the primary version using the `nael` and `nael-lsp` packages, which are available on MELPA. It also introduces the `+v3` flag for legacy Lean 3 support.

- Added nael and nael-lsp (conditional on :tools lsp).
- Made lean-mode conditional on the `+v3` flag.
- Configured nael-mode as the default for .lean files with abbrev-mode.
- Implemented LSP integration for both Eglot and lsp-mode.
- Updated README.org with installation, usage, and configuration details.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
