### PR TITLE
fix: org-roam-node-insert - prevent extra space added in visual mode

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -51,6 +51,7 @@ inserting the link."
     :around #'org-roam-node-insert
     (if (and (bound-and-true-p evil-local-mode)
              (not (evil-insert-state-p))
+             (not (evil-visual-state-p))
              (or (looking-at-p "[[:blank:]]")
                  (evil-eolp)))
         (evil-with-state 'insert


### PR DESCRIPTION
I like to visually select text, then org-roam-node-insert. This has been broken for my usage for a while, finally tracked it down today.

The fix from https://github.com/doomemacs/doomemacs/issues/8513 causes an extra space to be added on every visual-mode org-roam-node-insert, so this commit just adds another guard.

~I was a bit lazy and committed this via github's UI before reading the commit standards. sorry! happy to rewrite/amend it if you prefer. Or feel free to make the change elsewhere and close this PR 🤷~ Updated the commit to hopefully fit the standard better!

Thanks for maintaining Doom! It's been excellent for many years!!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.
