### PR TITLE
fix(vterm): buffer read-only error after compiling

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -34,6 +34,9 @@ Returns the vterm buffer."
                                               buffer-name)
                                     return buf)
                            (get-buffer-create buffer-name))))
+           ;; Explicitly require vterm before `with-current-buffer', since
+           ;; loading vterm can change the current buffer
+           (require 'vterm)
            (with-current-buffer buffer
              (unless (eq major-mode 'vterm-mode)
                (vterm-mode))


### PR DESCRIPTION
The first time I run `+vterm/toggle`, if I say yes to vterm's offer to compile libvterm for me, then after it compiles successfully, I get this error: `vterm-mode: Buffer is read-only: #<buffer  *Install vterm* >`. That's because when vterm is autoloaded, it changes the current buffer to the compilation buffer, which is read-only. If I actually want a vterm buffer, I need to run `+vterm/toggle` a second time.

Instead, we can explicitly require vterm *before* `with-current-buffer` so it's already loaded before we call `vterm-mode`.

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
