### PR TITLE
bump: :lang coq

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -55,6 +55,7 @@
       (:prefix ("i" . "insert")
         "c" #'coq-insert-command
         "e" #'coq-end-Section
+        "g" #'coq-insert-named-goal-selectors
         "i" #'coq-insert-intros
         "r" #'coq-insert-requires
         "s" #'coq-insert-section-or-module

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/coq/packages.el
 
 (package! proof-general
-  :pin "d60382db080370501bfe81d2a4f069035c8372a7"
+  :pin "6946aa5bebbd5dbbb2985d22325a03290fb6b79f"
   ;; REVIEW: Remove when ProofGeneral/PG#771 is fixed. Also see #8169.
   :recipe (:build (:not autoloads)))
 (package! company-coq :pin "78ed04ce39e925232a556d2077718cc7b215469c")


### PR DESCRIPTION
ProofGeneral/PG@d60382db0803 -> ProofGeneral/PG@6946aa5bebbd

In particular I want to pick up ProofGeneral/PG#854 (authored by me) to fix an issue when using Rocq via Nix and direnv. Also adds a keybind for ProofGeneral/PG#856

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.