### PR TITLE
docs: use dynamic Homebrew prefix for macOS symlinks

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -294,7 +294,7 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
   brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  ln -s "$(brew --prefix)/opt/emacs-mac/Emacs.app" /Applications/Emacs.app
   #+END_SRC
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]].  Some users have
@@ -302,7 +302,7 @@ to least recommended for Doom (based on compatibility).
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
   brew install emacs-plus
-  ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  ln -s "$(brew --prefix)/opt/emacs-plus/Emacs.app" /Applications/Emacs.app
   #+END_SRC
 
 - [[https://formulae.brew.sh/formula/emacs][emacs]] is another acceptable option, **but does not provide a Emacs.app**:


### PR DESCRIPTION
## Summary
- Updated symlink commands for `emacs-mac` and `emacs-plus` to use `$(brew --prefix)` 
- Works on both Intel (`/usr/local`) and Apple Silicon (`/opt/homebrew`) Macs

## Context
The hardcoded `/usr/local/opt/` path only works on Intel Macs. Apple Silicon Macs use `/opt/homebrew/opt/` instead. Using `$(brew --prefix)` dynamically resolves to the correct path on any architecture.

## Note
The contributing guide (`docs/contributing.org`) mentions targeting `rewrite-docs` branch for `.org` file changes, but that branch no longer exists. Targeting `master` instead.

## Test plan
- [x] Verified `$(brew --prefix)` returns `/opt/homebrew` on Apple Silicon Mac
- [x] Verified the symlink command works correctly