### PR TITLE
tweak(python): use toml mode for uv.lock files

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -220,6 +220,13 @@
   :when (modulep! +uv)
   :after python
   :config
+  ;; open uv.lock files in toml-mode
+  (add-to-list 'auto-mode-alist
+               (cons "/uv\\.lock\\'"
+                     (if (and (modulep! :tools tree-sitter)
+                              (fboundp 'toml-ts-mode))
+                         'toml-ts-mode
+                       'conf-toml-mode)))
   ;; HACK: A faster (cached) version of the mode-line segment. See
   ;;   `+python-uv-mode-set-auto-h'.
   (setq uv-mode-mode-line-format '(+python--uv-version ("UV:" +python--uv-version " ")))


### PR DESCRIPTION
When +uv is set, find the right toml mode for the configuration and use that.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
