### PR TITLE
fix(java): activate lsp under java-ts-mode as well

### DIFF
--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -6,6 +6,7 @@
   :preface
   (setq lsp-java-workspace-dir (file-name-concat doom-profile-data-dir "java-workspace"))
   (add-hook 'java-mode-local-vars-hook #'lsp! 'append)
+  (add-hook 'java-ts-mode-local-vars-hook #'lsp! 'append)
   :config
   (when (modulep! :tools debugger +lsp)
     (setq lsp-jt-root (concat lsp-java-server-install-dir "java-test/server/")


### PR DESCRIPTION
Otherwise, with :lang java +lsp +tree-sitter lsp-mode won't activate on its own.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to. (None exist AFAICT)
- [ ] This a draft PR; I need more time to finish it.