### PR TITLE
fix(clojure): Enable CIDER for clojurec and clojurescript

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -88,6 +88,8 @@
 (use-package! cider-mode
   ;; NOTE if `org-directory' doesn't exist, `cider-jack' in won't work
   :hook (clojure-mode-local-vars . cider-mode)
+  :hook (clojurec-mode-local-vars . cider-mode)
+  :hook (clojurescript-mode-local-vars . cider-mode)
   :hook (clojure-ts-mode-local-vars . cider-mode)
   :init
   (after! clojure-mode


### PR DESCRIPTION

<!-- ⚠️ Please do not ignore this template! -->

Extends CIDER support to `clojurec-mode` and `clojurescript-mode` by matching the existing behavior for `clojure-mode`.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
