### PR TITLE
fix(cli): show all commands in `doom --help` output

### DIFF
--- a/lisp/doom-cli.el
+++ b/lisp/doom-cli.el
@@ -1432,7 +1432,13 @@ ARGS are options passed to less. If DOOMPAGER is set, ARGS are ignored."
   (or (when-let* ((path (doom-cli-autoload cli))
                   (path (locate-file-internal path doom-cli-load-path load-suffixes)))
         (doom-log "load: autoload %s" path)
-        (let ((doom-cli--group-plist (doom-cli-plist cli)))
+        (let ((doom-cli--group-plist
+               ;; FIX(#8560): Don't inherit :hide from the autoload stub's
+               ;;   plist, because alias stubs have :hide t, and that would
+               ;;   propagate to the primary command when the file is loaded.
+               (let ((p (copy-sequence (doom-cli-plist cli))))
+                 (cl-remf p :hide)
+                 p)))
           (doom-load path))
         (let* ((key (doom-cli-key cli))
                (cli (gethash key doom-cli--table)))


### PR DESCRIPTION
## Summary

- `doom --help` was missing `sync`, `upgrade`, `doctor`, and `profile` from the command listing
- Root cause: `doom-cli-load-all` iterates the CLI hash table in non-deterministic order. When an alias stub (e.g. `("doom" "s")` for `sync`) is processed before its primary command, `doom-cli-load` used the alias's plist — which includes `:hide t` — as `doom-cli--group-plist`. The loaded file's `defcli!` then inherited `:hide t`, incorrectly marking the primary command as hidden.
- Fix: strip `:hide` from the plist before passing it as the group plist, and `copy-sequence` to prevent structural mutation of stored plists.

Ref: #8560

## Test plan

- [ ] Run `doom --help` and verify `sync`, `upgrade`, `doctor`, `profile` all appear in the command listing
- [ ] Run `doom help sync`, `doom help upgrade`, `doom help doctor` to verify commands still work
- [ ] Run `doom sync` to verify the command itself still functions

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)