### PR TITLE
fix(bin): org-capture uses Wayland when available

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -16,6 +16,11 @@ cleanup() {
 # If emacs isn't running, we start a temporary daemon, solely for this window.
 if ! emacsclient --suppress-output --eval nil 2>/dev/null; then
   echo "No Emacs daemon/server is available! Starting one..."
+  # FIX(#8601): Ensure PGTK Emacs uses Wayland when available, rather than
+  #   falling back to X11 via XWayland (which triggers incompatibility warnings).
+  if [ -n "$WAYLAND_DISPLAY" ]; then
+    export GDK_BACKEND=wayland
+  fi
   emacs --daemon
   trap cleanup EXIT INT TERM
 fi


### PR DESCRIPTION
## Summary
- Set `GDK_BACKEND=wayland` before starting the temporary Emacs daemon when `WAYLAND_DISPLAY` is set
- Without this, PGTK Emacs falls back to X11 via XWayland when `DISPLAY` is also present, triggering the "pure-GTK interface under X Window System" incompatibility warning

## Approach
- Only applies when the script starts its own temporary daemon (not when connecting to an existing one)
- Only activates on Wayland (`$WAYLAND_DISPLAY` check)
- Does **not** `unset DISPLAY`, which could break XWayland apps launched from Emacs

Fix: #8601

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)