### PR TITLE
fix(popup): +popup/toggle restores last quit popup

### DIFF
--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -44,6 +44,10 @@ buffer that shouldn't be in a popup. We prevent that by remapping `quit-window'
 to this commmand."
   (interactive "P")
   (let ((orig-buffer (current-buffer)))
+    ;; FIX(#8650): Remember the popup window before `quit-window' destroys it,
+    ;;   so `+popup/toggle' can restore it later.
+    (when (and +popup--remember-last (+popup-buffer-p))
+      (+popup--remember (list (selected-window))))
     (quit-window arg)
     (when (and (eq orig-buffer (current-buffer))
                (+popup-buffer-p))


### PR DESCRIPTION
## Summary
- `+popup/quit-window` (bound to `q`) calls `quit-window`, which destroys the popup window before `+popup/close` can save its state via `+popup--remember`
- This means `+popup/toggle` can never restore the last closed popup and always falls back to `*Messages*`
- Fix: call `+popup--remember` **before** `quit-window` runs, so the window state is saved while the window is still live

## How it works
1. `+popup/quit-window` → `quit-window` deletes the window → `+popup/close` fallback condition is false → state never saved
2. With this fix: save state first → `quit-window` → `+popup/toggle` can now restore

Fix: #8650

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)