### PR TITLE
fix(lib): don't shell-quote EMACS env var

### DIFF
--- a/lisp/lib/config.el
+++ b/lisp/lib/config.el
@@ -46,7 +46,7 @@
      (with-current-buffer
          (with-environment-variables
              (("PATH" (string-join exec-path path-separator))
-              ("EMACS" (shell-quote-argument emacs-bin))
+              ("EMACS" emacs-bin)
               ("EMACSDIR" doom-emacs-dir)
               ("DOOMDIR" doom-user-dir)
               ("DOOMLOCALDIR" doom-local-dir)


### PR DESCRIPTION
## Summary
- Remove `shell-quote-argument` from the `EMACS` environment variable in `doom-run-doom-command!`
- `shell-quote-argument` produces cmd.exe-style quoting on Windows, but env vars are raw strings — PowerShell can't parse the quoted path, breaking `doom/reload` (SPC h r r) and other commands that invoke `bin/doom`
- The other env vars in the same block (`EMACSDIR`, `DOOMDIR`, `DOOMLOCALDIR`) are already unquoted

Fix: #8572

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)