### PR TITLE
fix(whitespace): defer to editorconfig for correct indent-tabs-mode

### DIFF
--- a/modules/editor/whitespace/config.el
+++ b/modules/editor/whitespace/config.el
@@ -35,9 +35,8 @@ successfully sets indent_style/indent_size.")
 (use-package! whitespace
   :defer t
   :init
-  (add-hook! 'after-change-major-mode-hook :append
-    (defun +whitespace-highlight-incorrect-indentation-h ()
-      "Highlight whitespace at odds with `indent-tabs-mode'.
+  (defun +whitespace-highlight-incorrect-indentation-h (&rest _)
+    "Highlight whitespace at odds with `indent-tabs-mode'.
 
 That is, highlight tabs if `indent-tabs-mode' is `nil', and highlight spaces at
 the beginnings of lines if `indent-tabs-mode' is `t'. The purpose is to make
@@ -46,19 +45,28 @@ and corrected.
 
 Does nothing if `whitespace-mode' or `global-whitespace-mode' is already active
 or if the current buffer is read-only or not file-visiting."
-      (unless (or (eq major-mode 'fundamental-mode)
-                  (bound-and-true-p global-whitespace-mode)
-                  (null buffer-file-name)
-                  buffer-read-only)
-        (require 'whitespace)
-        (set (make-local-variable 'whitespace-style)
-             (cl-union (if indent-tabs-mode
-                           '(indentation)
-                         '(tabs tab-mark))
-                       (when whitespace-mode
-                         (remq 'face whitespace-active-style))))
-        (cl-pushnew 'face whitespace-style) ; must be first
-        (whitespace-mode +1))))
+    (unless (or (eq major-mode 'fundamental-mode)
+                (bound-and-true-p global-whitespace-mode)
+                (null buffer-file-name)
+                buffer-read-only)
+      (require 'whitespace)
+      (set (make-local-variable 'whitespace-style)
+           (cl-union (if indent-tabs-mode
+                         '(indentation)
+                       '(tabs tab-mark))
+                     (when whitespace-mode
+                       (remq 'face whitespace-active-style))))
+      (cl-pushnew 'face whitespace-style) ; must be first
+      (whitespace-mode +1)))
+  ;; FIX(#8573): When editorconfig is active, run after it applies so we read
+  ;;   the correct `indent-tabs-mode'. Otherwise editorconfig sets it on
+  ;;   `find-file-hook' (after `after-change-major-mode-hook' already fired).
+  (if (modulep! :tools editorconfig)
+      (add-hook 'editorconfig-after-apply-functions
+                #'+whitespace-highlight-incorrect-indentation-h)
+    (add-hook 'after-change-major-mode-hook
+              #'+whitespace-highlight-incorrect-indentation-h
+              'append))
 
   :config
   (setq whitespace-line-column nil


### PR DESCRIPTION
## Summary
- `+whitespace-highlight-incorrect-indentation-h` ran on `after-change-major-mode-hook`, but the editorconfig package applies settings later on `find-file-hook` — so `indent-tabs-mode` still had its default value when whitespace style was configured
- When `:tools editorconfig` is active, hook into `editorconfig-after-apply-functions` instead, so we read the correct `indent-tabs-mode` after editorconfig has applied
- When editorconfig is not active, keep the original `after-change-major-mode-hook` behavior
- Runs exactly once — no redundant re-runs

Fix: #8573

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)