### PR TITLE
fix(keybinds): map! which-key descriptions for minor mode keymaps

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -199,12 +199,10 @@ localleader prefix."
       ;; emacs state)
       `(general-define-key
         :states '(normal visual motion emacs insert)
-        :major-modes t
         :prefix doom-localleader-key
         :non-normal-prefix doom-localleader-alt-key
         ,@args)
     `(general-define-key
-      :major-modes t
       :prefix doom-localleader-alt-key
       ,@args)))
 


### PR DESCRIPTION
## Summary
- `define-localleader-key!` unconditionally set `:major-modes t`, which makes general.el use `which-key-add-major-mode-key-based-replacements` for descriptions
- This only works for major mode keymaps — minor mode keymaps (like `cider-mode-map`) get their `:prefix ("R" . "refactor")` descriptions silently dropped
- Remove `:major-modes t` so general.el uses `which-key-add-keymap-based-replacements` instead, which works for all keymaps
- The `:keymaps` property (always provided by `map!`) already scopes bindings to the correct keymap, making `:major-modes` redundant for activation

Fix: #8539

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)