### PR TITLE
fix(clojure): disable cider-auto-mode to preserve keybindings on REPL quit

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -119,7 +119,8 @@
       ("^\\*cider-repl" :quit nil :ttl nil)
       ("^\\*cider-repl-history" :vslot 2 :ttl nil)))
 
-  (setq nrepl-hide-special-buffers t
+  (setq cider-auto-mode nil
+        nrepl-hide-special-buffers t
         nrepl-log-messages nil
         cider-font-lock-dynamically '(macro core function var deprecated)
         cider-overlays-use-font-lock t


### PR DESCRIPTION
## Summary
- Set `cider-auto-mode` to `nil` in the `cider-mode` `:config` block to prevent CIDER from disabling `cider-mode` in all Clojure buffers when the last REPL disconnects
- This preserves all localleader keybindings (bound to `cider-mode-map`) after `cider-quit`
- Doom's existing hooks (`clojure-mode-local-vars`, `clojure-ts-mode-local-vars`) remain in control of `cider-mode` activation

## Context
Commit `d887b721d` moved CIDER keybindings from major-mode maps to `cider-mode-map` to support tree-sitter modes. However, `cider-mode` is a minor mode that CIDER automatically disables in all Clojure buffers when the last REPL disconnects (via `cider-auto-mode` → `cider-possibly-disable-on-existing-clojure-buffers`). This causes all localleader keybindings to vanish.

`cider-auto-mode` is the [CIDER-documented](https://docs.cider.mx/cider/config/basic_config.html) way to disable this behavior.

See also PR #8586, which addresses the same issue (#8537) with a different approach (moving keybindings back to major-mode maps and removing Doom's `cider-mode` hooks). This PR takes a simpler approach: keep Doom's existing hook-based activation and disable CIDER's auto-toggling.

Fix: #8537

## Test plan
- [ ] Open a Clojure file — `cider-mode` should be active, localleader bindings available
- [ ] `cider-jack-in-clj` to connect a REPL
- [ ] `cider-quit` to disconnect
- [ ] Verify localleader bindings (`, e b`, `, '`, `, R`, etc.) are still present
- [ ] Verify CIDER commands invoked without a REPL show clear error messages

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)