### PR TITLE
fix(keybinds): ensure localleader sub-key is a prefix in leader map

### DIFF
--- a/lisp/doom-keybinds.el
+++ b/lisp/doom-keybinds.el
@@ -230,6 +230,19 @@ localleader prefix."
             (define-key map (kbd doom-leader-alt-key) 'doom/leader))
         (evil-define-key* doom-leader-key-states map (kbd doom-leader-key) 'doom/leader)
         (evil-define-key* doom-leader-alt-key-states map (kbd doom-leader-alt-key) 'doom/leader))
+      ;; HACK: When `doom-localleader-key' is a sub-key of `doom-leader-key'
+      ;;   (e.g. "S m" under "S"), intermediate minor-mode keymaps (like
+      ;;   evil-snipe binding "S" to a command) can block Emacs' prefix key
+      ;;   merging, preventing localleader bindings in mode aux keymaps from
+      ;;   being reached. Ensure the sub-key is a prefix in `doom-leader-map'
+      ;;   so the lookup always succeeds through the leader path.
+      (when (and doom-localleader-key doom-leader-key
+                 (string-prefix-p (concat doom-leader-key " ")
+                                  doom-localleader-key))
+        (let ((sub-key (substring doom-localleader-key
+                                  (1+ (length doom-leader-key)))))
+          (unless (lookup-key doom-leader-map (kbd sub-key))
+            (define-key doom-leader-map (kbd sub-key) (make-sparse-keymap)))))
       (general-override-mode +1))))
 
 


### PR DESCRIPTION
## Summary
- When `doom-localleader-key` is a sub-key of `doom-leader-key` (e.g. `"S m"` under `"S"`), pressing the localleader sequence shows "undefined" even though which-key displays the entry
- Root cause: evil-snipe binds `S` as a *command* in a minor-mode keymap that sits between the intercept keymap (leader) and mode aux keymaps (localleader). This blocks Emacs' prefix key merging — localleader bindings are never reached through `read-key-sequence`
- Fix: in `doom-init-leader-keys-h`, when localleader is a sub-key of leader, create a sparse keymap prefix for the sub-key (e.g. `"m"`) in `doom-leader-map`. This ensures the lookup path `S` → `doom-leader-map` → `m` → mode aux keymaps always works

Fix: #8562

## Test plan
- [ ] Set `doom-leader-key` to `"S"` and `doom-localleader-key` to `"S m"`
- [ ] Open a buffer with localleader bindings (e.g. a Python file with LSP)
- [ ] Press `S` — which-key should show `m : +<localleader>`
- [ ] Press `m` — localleader bindings should appear (not "S m is undefined")
- [ ] Verify default config (`SPC` / `SPC m`) still works normally

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)