### PR TITLE
fix(evil): clean isearch overlays after ex-search navigation

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -67,6 +67,15 @@ directives. By default, this only recognizes C directives.")
   :config
   (evil-select-search-module 'evil-search-module 'evil-search)
 
+  ;; HACK: `evil-ex-search' (used by `n'/`N') calls `isearch-range-invisible'
+  ;;   which temporarily opens fold overlays, but never calls
+  ;;   `isearch-clean-overlays' to restore them. This corrupts org-fold
+  ;;   overlay state, making subtrees permanently unfoldable with TAB.
+  ;;   See emacs-evil/evil#1630, doomemacs/doomemacs#8625.
+  (defadvice! +evil--clean-isearch-overlays-a (&rest _)
+    :after #'evil-ex-search
+    (isearch-clean-overlays))
+
   ;; PERF: Stop copying the selection to the clipboard each time the cursor
   ;; moves in visual mode. Why? Because on most non-X systems (and in terminals
   ;; with clipboard plugins like xclip.el active), Emacs will spin up a new


### PR DESCRIPTION
## Summary
- After evil-search (`/asd`) then repeating with `n`/`N`, org subtrees become permanently unfoldable with TAB
- Root cause: `evil-ex-search` calls `isearch-range-invisible` which temporarily opens fold overlays to check visibility, but never calls `isearch-clean-overlays` to restore them. The initial `/` search cleans up via `evil-ex-search-stop-session`, but `n`/`N` skip this step
- This is an upstream evil bug ([emacs-evil/evil#1630](https://github.com/emacs-evil/evil/issues/1630), open since 2022)
- Fix: add `:after` advice on `evil-ex-search` that calls `(isearch-clean-overlays)` — idempotent, safe, and matches what `evil-ex-search-stop-session` already does

Ref: emacs-evil/evil#1630
Fix: #8625
Also fixes: #6478

## Test plan
- [ ] Create an org file with nested headings containing searchable text
- [ ] Search with `/asd`, fold everything with Shift+TAB, press `n` to find next
- [ ] Go up one line and press TAB — subtree should fold/unfold normally
- [ ] Verify evil-search (`/`, `n`, `N`) still works correctly in all buffer types

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)