### PR TITLE
fix(dired): prevent dirvish from killing root buffers on quit

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -82,12 +82,10 @@ Fixes #3939: unsortable dired entries on Windows."
   (set-popup-rule! "^ ?\\*\\(?:[Dd]irvish\\|SIDE :: \\).*" :ignore t)
 
   ;; Fixes #8038. This setting is for folks who expect to be able to switch back
-  ;; to dired buffers where the file is opened from.  In other cases, don't
-  ;; recycle sessions. We don't want leftover buffers lying around, especially
-  ;; if users are reconfiguring Dirvish or trying to recover from an error. It's
-  ;; too easy to accidentally break Dirvish (e.g. by focusing the header window)
-  ;; at the moment.  Starting from scratch isn't even that expensive, anyway.
-  (setq dirvish-reuse-session 'open)
+  ;; to dired buffers where the file is opened from. Doom's cleanup hook
+  ;; (`+dired--cleanup-dirvish-h') handles killing sessions on project/workspace
+  ;; switches, so `t' is safe here.
+  (setq dirvish-reuse-session t)
 
   (if (modulep! +dirvish)
       (setq dirvish-attributes '(file-size)


### PR DESCRIPTION
## Summary
- When using `dirvish-fd` and navigating through subdirectories, the original dirvish buffer is killed on quit
- Root cause: `dirvish--clear-session` kills non-visible root buffers unconditionally, and `dirvish-reuse-session` set to `open` also kills the index buffer on quit. All navigation history is destroyed.
- Fix: change `dirvish-reuse-session` from `open` to `t` so root buffers survive both file opening and quit operations
- Doom's existing `+dired--cleanup-dirvish-h` hook already handles killing sessions on project/workspace switches, so stale buffers are still cleaned up

Fix: #8591

## Test plan
- [ ] Run `dirvish-fd` on a directory with nested subdirectories
- [ ] Navigate into subdirectories by pressing return
- [ ] Press `q` to quit — the original dirvish buffer should still exist
- [ ] Switch projects/workspaces — dirvish sessions should be cleaned up
- [ ] Opening files from dirvish should still work correctly (#8038 regression check)

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)