### PR TITLE
fix(python): disable pyrepl to fix C-c C-c interrupt in REPL

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -70,6 +70,13 @@
              (executable-find "python3"))
     (setq python-shell-interpreter "python3"))
 
+  ;; HACK: Python 3.13's pyrepl mishandles SIGINT under Emacs's comint
+  ;;   (TERM=dumb), particularly on macOS. The ^C character is treated as
+  ;;   literal input rather than triggering an interrupt signal. Disabling
+  ;;   pyrepl forces the classic readline-based REPL which handles signals
+  ;;   correctly. See #8391, also used by VS Code's Python extension.
+  (add-to-list 'python-shell-process-environment "PYTHON_BASIC_REPL=1")
+
   (add-hook! '(python-mode-hook python-ts-mode-hook)
     (defun +python-use-correct-flycheck-executables-h ()
       "Use the correct Python executables for Flycheck."


### PR DESCRIPTION
## Summary
- `C-c C-c` (`comint-interrupt-subjob`) fails to interrupt running Python code in the inferior REPL on Python 3.13+, particularly on macOS
- Root cause: Python 3.13's pyrepl mishandles SIGINT under `TERM=dumb` (which comint sets). The `^C` character is treated as literal input rather than triggering an interrupt, causing `SyntaxError: invalid non-printable character U+0003`
- Fix: set `PYTHON_BASIC_REPL=1` in `python-shell-process-environment` to disable pyrepl and use the classic readline-based REPL. This is the same approach VS Code uses ([vscode-python#25164](https://github.com/microsoft/vscode-python/issues/25164))
- Safe to apply universally — on systems where pyrepl works fine, the classic REPL is functionally equivalent under `TERM=dumb`

Fix: #8391

## Test plan
- [ ] Open a Python file, run `M-x run-python`
- [ ] Execute an infinite loop: `while True: print(1)`
- [ ] Press `C-c C-c` — the loop should be interrupted
- [ ] Verify normal REPL usage works (eval region, send buffer, etc.)

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)