### PR TITLE
fix(lib): use git symbolic-ref instead of branch -m for empty repos

### DIFF
--- a/lisp/lib/packages.el
+++ b/lisp/lib/packages.el
@@ -111,7 +111,11 @@ package's name as a symbol, and whose CDR is the plist supplied to its
                   (make-directory repo-dir 'recursive)
                   (let ((default-directory repo-dir))
                     (funcall call "git" "init")
-                    (funcall call "git" "branch" "-m" straight-repository-branch)
+                    ;; HACK: `git branch -m' fails on empty repos with git
+                    ;;   < 2.28. `git symbolic-ref' is a portable alternative
+                    ;;   that works on all git versions. See #8538.
+                    (funcall call "git" "symbolic-ref" "HEAD"
+                             (format "refs/heads/%s" straight-repository-branch))
                     (funcall call "git" "remote" "add" "origin" repo-url
                              "--master" straight-repository-branch)
                     (funcall call "git" "fetch" "origin" pin


### PR DESCRIPTION
## Summary
- `doom install` fails on git < 2.28 when cloning straight.el with a pinned commit, because `git branch -m` does not work on empty (no commits) repositories until git 2.28
- Affected versions include git 2.24.3 (macOS Apple Git), 2.25.1 (Ubuntu 20.04), 2.27 (RHEL 8) — all above Doom's 2.23 minimum but below 2.28
- Fix: replace `git branch -m` with `git symbolic-ref HEAD refs/heads/<branch>` which is a portable plumbing command that works on all git versions
- This fixes the Doom bootstrap path. The same issue exists in straight.el's `straight-vc-git--clone-internal` but that is an upstream fix

Note: the downstream `git fetch` + `git reset --hard` that follows will establish the correct branch state regardless, so the symbolic-ref is sufficient.

Fix: #8538

## Test plan
- [ ] On a system with git < 2.28, run `doom install` — should succeed
- [ ] On git >= 2.28, verify `doom install`/`doom sync` still works
- [ ] Verify `git symbolic-ref HEAD` correctly sets the branch name in a fresh `git init` repo

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)