### PR TITLE
fix(magit): load transient before git-commit in incremental loader

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -40,7 +40,7 @@ FUNCTION
 
 (use-package! magit
   :commands magit-file-delete
-  :defer-incrementally (dash f s with-editor git-commit package eieio transient)
+  :defer-incrementally (dash f s with-editor package eieio transient git-commit)
   :init
   (setq magit-auto-revert-mode nil)  ; we do this ourselves further down
   ;; Must be set early to prevent ~/.config/emacs/transient from being created


### PR DESCRIPTION
## Summary
- On certain macOS Emacs builds, starting Doom (especially in daemon mode) throws `(void-function transient--set-layout)`
- Root cause: the `:defer-incrementally` list loads `git-commit` before `transient`. When `git-commit` is required, it pulls in `transient` as a dependency, but if the macOS Emacs build has injected built-in package paths before straight.el's paths in `load-path`, the old built-in transient (v0.7.x, missing `transient--set-layout`) loads instead of Doom's pinned version (v0.12.x)
- Fix: reorder the `:defer-incrementally` list to load `transient` before `git-commit`, ensuring the correct version is already in memory
- This is a partial mitigation — the root cause is macOS-specific `load-path` pollution from certain Emacs builds (Homebrew emacs-mac, emacs-plus). Users on those builds should switch to `jimeh/emacs-builds` as hlissner recommends

Fix: #8541

## Test plan
- [ ] Start Doom in daemon mode (`emacs --daemon`)
- [ ] Verify no `void-function transient--set-layout` error
- [ ] Open magit (`SPC g g`) — should work normally
- [ ] Verify `git-commit` mode works when committing

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)