### PR TITLE
fix(electric): reorder electric-quote hook to run before smartparens

### DIFF
--- a/modules/emacs/electric/config.el
+++ b/modules/emacs/electric/config.el
@@ -15,4 +15,13 @@ current line.")
       (when (and (eolp) +electric-indent-words)
         (save-excursion
           (backward-word)
-          (looking-at-p (concat "\\<" (regexp-opt +electric-indent-words))))))))
+          (looking-at-p (concat "\\<" (regexp-opt +electric-indent-words)))))))
+
+  ;; Fix #5051: Ensure electric-quote's handler runs before smartparens' on
+  ;; `post-self-insert-hook', so that `electric-quote-inhibit-functions'
+  ;; (e.g. `org-in-src-block-p') is respected in org src blocks.
+  (add-hook! 'electric-quote-mode-hook
+    (defun +electric-quote-reorder-post-self-insert-h ()
+      (when electric-quote-mode
+        (remove-hook 'post-self-insert-hook #'electric-quote-post-self-insert-function)
+        (add-hook 'post-self-insert-hook #'electric-quote-post-self-insert-function -50)))))


### PR DESCRIPTION
## Summary

- Re-add `electric-quote-post-self-insert-function` at depth -50 on `post-self-insert-hook` so it runs before smartparens' handler (depth 0)
- This ensures `electric-quote-inhibit-functions` (e.g. `org-in-src-block-p`) is checked before smartparens modifies buffer state

## Context

Fixes #5051. When `electric-quote-mode` is enabled alongside smartparens (Doom's default), the `electric-quote-inhibit-functions` check fails in org src blocks because smartparens' `sp--post-self-insert-hook-handler` runs first on `post-self-insert-hook` and interferes with the buffer state that electric-quote inspects.

The reporter [confirmed](https://github.com/doomemacs/doomemacs/issues/5051) that adjusting hook depth fixes the issue, and hlissner [approved the approach](https://github.com/doomemacs/doomemacs/issues/5051#issuecomment-843671498) but couldn't use `add-hook`'s DEPTH argument at the time (Emacs 26.3 support). Since Doom now requires Emacs 27.1+, the DEPTH argument is available.

## Test plan

- [ ] Enable `electric-quote-mode` and add `(add-hook 'electric-quote-inhibit-functions 'org-in-src-block-p)`
- [ ] Open an org file with a src block
- [ ] Type quotes inside src block — should remain straight quotes
- [ ] Type quotes outside src block — should convert to curly quotes

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)