### PR TITLE
fix(agda): preserve input method in evil normal mode

### DIFF
--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -13,6 +13,21 @@
 
   ;; TODO: agda2-ts-mode
 
+  ;; Fix #5711: Evil clears `current-input-method' in normal state, which
+  ;; prevents agda's `read-string' (with INHERIT-INPUT-METHOD) from inheriting
+  ;; the agda input method. Restore it from `evil-input-method'.
+  (when (modulep! :editor evil)
+    (defadvice! +agda--preserve-input-method-in-minibuffer-a (fn &rest args)
+      "Preserve the input method in evil normal mode for minibuffer prompts."
+      :around '(read-from-minibuffer read-string)
+      (if (and evil-input-method
+               (bound-and-true-p evil-local-mode)
+               (evil-normal-state-p))
+          (with-temp-buffer
+            (activate-input-method evil-input-method)
+            (apply fn args))
+        (apply fn args))))
+
   (map! :map agda2-mode-map
         :localleader
         "?"   #'agda2-show-goals


### PR DESCRIPTION
## Summary

- Advise `read-from-minibuffer` and `read-string` to restore the input method from `evil-input-method` when in evil normal state
- No-op when no input method is configured (checks `evil-input-method` first)
- Guarded by `(modulep! :editor evil)`

## Context

Fixes #5711. Evil clears `current-input-method` in normal state by design, storing the real method in `evil-input-method`. When agda2-mode calls `read-string` with INHERIT-INPUT-METHOD=t (e.g. for typecheck prompts), it inherits nil instead of the agda input method. Users must switch to insert mode first as a workaround.

Based on the [workaround posted by @fdeitylink](https://github.com/doomemacs/doomemacs/issues/5711#issuecomment-2086116025) in the issue thread.

## Test plan

- [ ] Enable agda module with evil mode
- [ ] Open an agda file, load it with `agda2-load`
- [ ] In normal mode, invoke a command that opens a minibuffer prompt (e.g. refine, give)
- [ ] Verify agda's quail input method translations work in the prompt
- [ ] Verify normal buffers without input methods are unaffected

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)