### PR TITLE
fix(evil): make ]e/[e cycle errors in current buffer first

### DIFF
--- a/modules/editor/evil/autoload/unimpaired.el
+++ b/modules/editor/evil/autoload/unimpaired.el
@@ -75,6 +75,24 @@ See `+evil/next-preproc-directive' for details."
   (interactive "p")
   (+evil/next-comment (- count)))
 
+;;; ]e / [e
+;;;###autoload
+(defun +evil/next-error (count)
+  "Jump to the next error in the current buffer.
+Falls back to `next-error' if the current buffer has no error source."
+  (interactive "p")
+  (if next-error-function
+      (next-error count)
+    (save-selected-window
+      (next-error count))))
+
+;;;###autoload
+(defun +evil/previous-error (count)
+  "Jump to the previous error in the current buffer.
+Falls back to `previous-error' if the current buffer has no error source."
+  (interactive "p")
+  (+evil/next-error (- count)))
+
 ;;; ] SPC / [ SPC
 ;;;###autoload
 (defun +evil/insert-newline-below (count)

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -479,8 +479,8 @@ don't offer any/enough real value to users.")
       :m  "[a"    #'evil-backward-arg
       :m  "]c"    #'+evil/next-comment
       :m  "[c"    #'+evil/previous-comment
-      :m  "]e"    #'next-error
-      :m  "[e"    #'previous-error
+      :m  "]e"    #'+evil/next-error
+      :m  "[e"    #'+evil/previous-error
       :n  "]F"    #'+evil/next-frame
       :n  "[F"    #'+evil/previous-frame
       :m  "]h"    #'outline-next-visible-heading


### PR DESCRIPTION
## Summary

- Add `+evil/next-error` and `+evil/previous-error` wrappers that cycle errors within the current buffer when `next-error-function` is set (flycheck, flymake, compilation), and fall back to cross-buffer `next-error` wrapped in `save-selected-window` to prevent cursor from jumping to another window
- Rebind `]e` / `[e` to use these new wrappers instead of raw `next-error` / `previous-error`

Fix: #1908

## Context

Currently `]e` / `[e` map directly to `next-error` / `previous-error`, which has two problems:
1. `next-error` may jump the cursor to a different window if that window's buffer has errors
2. There's no way to cycle errors only in the current buffer

The new wrappers check `next-error-function` — when set (by flycheck, flymake, or compilation-mode), errors cycle within the current buffer. When unset, the default cross-buffer behavior is preserved but wrapped in `save-selected-window` to prevent window-jumping.

## Test plan

- [ ] Open a file with flycheck/flymake errors — `]e` / `[e` cycles through errors in that buffer
- [ ] Open a compilation buffer in a split — `]e` from a non-error buffer shows the error but does NOT move cursor to the compilation window
- [ ] Verify count prefix works (e.g. `3]e` jumps 3 errors ahead)
- [ ] Verify `[e` navigates in reverse direction

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.