### PR TITLE
fix(evil): make cc/S respect visual-line-mode

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -128,7 +128,10 @@ directives. By default, this only recognizes C directives.")
       [up]   #'evil-previous-visual-line
       [down] #'evil-next-visual-line
       [home] #'evil-beginning-of-visual-line
-      [end]  #'evil-end-of-visual-line))
+      [end]  #'evil-end-of-visual-line)
+    (evil-define-minor-mode-key 'normal 'visual-line-mode
+      "cc" #'+evil:change-whole-visual-line
+      "S"  #'+evil:change-whole-visual-line))
 
 
   ;; --- evil hacks -------------------------


### PR DESCRIPTION
## Summary

- Add `+evil:change-whole-visual-line` operator that correctly handles visual lines when `evil-respect-visual-line-mode` is enabled
- Remap `cc` and `S` to the new operator in `visual-line-mode` normal state
- Fixes the long-standing issue where `cc` on a wrapped visual line deletes the newline, collapsing the next physical line

## Context

When `evil-respect-visual-line-mode` is `t`, `cc` (`evil-change-whole-line`) deletes the entire physical line **including its newline**, because `evil-change-whole-line` has `:type line` which re-expands visual line boundaries to physical lines. This makes the setting unusable — it's been toggled on/off multiple times and currently defaults to `nil`.

The new operator detects whether the visual line spans a full physical line:
- **Full physical line(s):** delegates to `evil-change` with `'line` type (preserving normal `cc` behavior with auto-indent)
- **Visual line subset of a wrapped line:** uses `'inclusive` type to delete only the visual line content without eating the newline
- **Empty line:** falls through to `evil-insert`

Related upstream evil issues: emacs-evil/evil#188, emacs-evil/evil#1168

Fix: #2447

## Test plan

- [ ] Set `evil-respect-visual-line-mode` to `t`
- [ ] Open a file with a long wrapped line — `cc` on a visual line should clear only that visual line, not the entire physical line
- [ ] On a non-wrapped line — `cc` should work normally (clear line, enter insert with indentation)
- [ ] On an empty line — `cc` should enter insert mode
- [ ] Count prefix (`3cc`) should change 3 visual lines
- [ ] Register support (`"acc`) should yank deleted text into register `a`
- [ ] `S` should behave identically to `cc`

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)