### PR TITLE
module(auto-dark): add :ui auto-dark module

### DIFF
--- a/modules/ui/auto-dark/config.el
+++ b/modules/ui/auto-dark/config.el
@@ -1,0 +1,32 @@
+;;; ui/auto-dark/config.el -*- lexical-binding: t; -*-
+
+(use-package! auto-dark
+  :hook (doom-load-theme . auto-dark-mode)
+  :config
+  ;; HACK: `auto-dark--enable-themes' disables all current themes then loads
+  ;;   the target themes from scratch via `load-theme'. Doom's `load-theme'
+  ;;   advice already handles enabling themes and running hooks, so this causes
+  ;;   redundant work and can flash. Override to only disable non-target themes
+  ;;   and enable (not reload) themes that are already loaded.
+  (defadvice! +auto-dark--use-doom-theme-loading-a (&optional themes)
+    "Use Doom's theme infrastructure when switching themes."
+    :override #'auto-dark--enable-themes
+    (let ((target-themes (remq 'user (delete-dups (or themes custom-enabled-themes)))))
+      ;; Disable themes not in the target set
+      (dolist (theme custom-enabled-themes)
+        (unless (memq theme target-themes)
+          (disable-theme theme)))
+      ;; Enable target themes, loading if necessary
+      (dolist (theme (reverse target-themes))
+        (if (custom-theme-p theme)
+            (enable-theme theme)
+          (load-theme theme t)))))
+
+  ;; Sync `doom-theme' when auto-dark switches themes, so that
+  ;; `doom/reload-theme' reloads the correct (current) theme.
+  (add-hook! '(auto-dark-dark-mode-hook auto-dark-light-mode-hook)
+    (defun +auto-dark-sync-doom-theme-h ()
+      "Update `doom-theme' to reflect auto-dark's current theme set."
+      (when-let* ((themes (auto-dark--themes-for-mode
+                           auto-dark--last-dark-mode-state)))
+        (setq doom-theme (if (cdr themes) themes (car themes)))))))

--- a/modules/ui/auto-dark/packages.el
+++ b/modules/ui/auto-dark/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/auto-dark/packages.el
+
+(package! auto-dark :pin "a71e791e47d09c5bf4bcbc2bbd7300b71ff72f1a")


### PR DESCRIPTION
## Summary

- Add new `:ui auto-dark` module that integrates the [`auto-dark`](https://github.com/LionyxML/auto-dark-emacs) package with Doom's theme system
- Enables automatic light/dark theme switching based on OS appearance settings
- Supports Linux (D-Bus/xdg-desktop-portal), macOS (AppleScript), Windows (registry), and Android (Termux)

## Context

When the OS dark mode preference changes (e.g. GNOME/KDE scheduled dark mode, macOS auto-appearance), Emacs doesn't react — `doom-theme` is set once and never changes. The `auto-dark` package handles cross-platform detection with real-time D-Bus signal listeners on Linux, but needs integration glue to work properly with Doom's theme infrastructure.

The module overrides `auto-dark--enable-themes` to use `enable-theme` (faster, no flash) instead of `load-theme` (full reload) for already-loaded themes, and syncs `doom-theme` on switches so `doom/reload-theme` stays correct.

### Usage

Enable in `init.el`:
```elisp
(doom! ...
       :ui
       auto-dark
       ...)
```

Configure in `config.el`:
```elisp
(setq auto-dark-themes '((doom-one)          ;; dark theme(s)
                          (doom-one-light)))   ;; light theme(s)
```

Fix: #6027

## Test plan

- [ ] Enable `:ui auto-dark` module, set `auto-dark-themes` with a dark/light pair
- [ ] On Linux: toggle system dark mode via `gsettings set org.gnome.desktop.interface color-scheme prefer-dark` / `prefer-light` — Emacs should switch in real-time
- [ ] `doom/reload-theme` reloads the correct (auto-selected) theme
- [ ] `doom-theme` variable reflects the active theme after each switch
- [ ] `solaire-mode` and other `doom-load-theme-hook` subscribers fire on each switch
- [ ] Daemon mode: new frames get the correct theme

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)