### PR TITLE
fix(mu4e): guard frame-width resize behind display-graphic-p

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -271,11 +271,12 @@ is non-nil."
   (add-hook! 'mu4e-headers-mode-hook
     (defun +mu4e-widen-frame-maybe ()
       "Expand the mu4e-headers containing frame's width to `+mu4e-min-header-frame-width'."
-      (dolist (frame (frame-list))
-        (when (and (string= (buffer-name (window-buffer (frame-selected-window frame)))
-                            mu4e-headers-buffer-name)
-                   (< (frame-width) +mu4e-min-header-frame-width))
-          (set-frame-width frame +mu4e-min-header-frame-width)))))
+      (when (display-graphic-p)
+        (dolist (frame (frame-list))
+          (when (and (string= (buffer-name (window-buffer (frame-selected-window frame)))
+                              mu4e-headers-buffer-name)
+                     (< (frame-width) +mu4e-min-header-frame-width))
+            (set-frame-width frame +mu4e-min-header-frame-width))))))
 
   ;; Fix columns misalignment in Headers buffers
   (add-hook! 'mu4e-headers-mode-hook


### PR DESCRIPTION
## Summary
- Wrap `+mu4e-widen-frame-maybe` body in `(display-graphic-p)` check
- `set-frame-width` corrupts terminal Emacs (`-nw`); this guard pattern is already used elsewhere in the same file (line 168, icon initialization)
- Reporter confirmed `(remove-hook 'mu4e-headers-mode-hook #'+mu4e-widen-frame-maybe)` fixes the corruption

Fix: #5870

## Test plan
- [ ] Open mu4e headers view in terminal Emacs (`emacs -nw`) -- no display corruption
- [ ] Open mu4e headers view in GUI Emacs with a narrow frame -- frame widens to 120 columns as before

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)