### PR TITLE
fix(python): use Scripts/ for venv executables on Windows

### DIFF
--- a/modules/lang/python/autoload/python.el
+++ b/modules/lang/python/autoload/python.el
@@ -8,7 +8,7 @@ falling back on searching your PATH."
   (if (file-name-absolute-p exe)
       (and (file-executable-p exe)
            exe)
-    (let ((exe-root (format "bin/%s" exe)))
+    (let ((exe-root (format (if (featurep :system 'windows) "Scripts/%s" "bin/%s") exe)))
       (cond ((when python-shell-virtualenv-root
                (let ((bin (expand-file-name exe-root python-shell-virtualenv-root)))
                  (if (file-exists-p bin) bin))))


### PR DESCRIPTION
## Summary
- `+python-executable-find` hardcodes `bin/` as the virtualenv executable subdirectory
- On Windows, Python virtualenvs use `Scripts/` instead of `bin/`
- This breaks virtualenv, conda, and project-local executable resolution for all Windows users
- Uses `(featurep :system 'windows)` (Doom 3.0+ convention)

Note: this addresses the executable path aspect of #5826. The broader poetry venv reuse issue reported there is likely upstream in poetry.el (see galaunay/poetry.el#35).

Ref: #5826

## Test plan
- [ ] On Windows: `+python-executable-find` resolves executables via `Scripts/` in a virtualenv
- [ ] On Linux/macOS: `+python-executable-find` continues to resolve via `bin/` as before

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)