### PR TITLE
fix(org): correct table.el edit exit hint to C-c '

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -211,6 +211,13 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
   ;; I prefer C-c C-c over C-c ' (more consistent)
   (define-key org-src-mode-map (kbd "C-c C-c") #'org-edit-src-exit)
 
+  (defadvice! +org--fix-table-edit-hint-a (&rest _)
+    "Show correct exit key hint for table.el editing.
+table.el uses `table-cell-map' (a text property keymap) which captures C-c C-c
+as a prefix for table operations, so the actual exit key is C-c '."
+    :after #'org-edit-table.el
+    (message "Edit, then exit with `C-c '' or abort with `C-c C-k'"))
+
   ;; Don't process babel results asynchronously when exporting org, as they
   ;; won't likely complete in time, and will instead output an ob-async hash
   ;; instead of the wanted evaluation results.


### PR DESCRIPTION
## Summary

When editing a table.el table in org-mode via `C-c '`, the hint message says "exit with `C-c C-c`". However, `table-cell-map` (a text property keymap with higher priority than `org-src-mode-map`) captures `C-c C-c` as a prefix key for table operations. The actual exit key is `C-c '`.

This adds `:after` advice on `org-edit-table.el` to display the correct hint.

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

Fix: #7073

🤖 Generated with [Claude Code](https://claude.com/claude-code)