### PR TITLE
fix(ocaml): don't prefix comment continuation lines with *

### DIFF
--- a/modules/lang/ocaml/autoload.el
+++ b/modules/lang/ocaml/autoload.el
@@ -1,11 +1,1 @@
 ;;; lang/ocaml/autoload.el -*- lexical-binding: t; -*-
-
-;;;###autoload
-(defun +ocaml/comment-indent-new-line (&optional _)
-  "Break line at point and indent, continuing comment if within one."
-  (interactive)
-  (comment-indent-new-line)
-  (when (eq (char-before) ?*)
-    (just-one-space))
-  (unless (eq (char-after) 32)
-    (save-excursion (insert " "))))

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -28,7 +28,7 @@
   (setq tuareg-prettify-symbols-full t)
 
   (setq-hook! 'tuareg-mode-hook
-    comment-line-break-function #'+ocaml/comment-indent-new-line)
+    comment-continue nil)
 
   (map! :localleader
         :map tuareg-mode-map


### PR DESCRIPTION
## Summary

- tuareg sets `comment-continue` to `" * "`, causing `comment-indent-new-line` to insert `**` on new lines inside comments
- OCaml convention is to not prefix continuation lines with `*`
- Set `comment-continue` to nil and remove the now-unnecessary `+ocaml/comment-indent-new-line` wrapper

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

Fix: #5194

🤖 Generated with [Claude Code](https://claude.com/claude-code)