### PR TITLE
fix(evil): reference correct kill-buffer function in :kill ex command

### DIFF
--- a/modules/editor/evil/+commands.el
+++ b/modules/editor/evil/+commands.el
@@ -42,7 +42,7 @@
 (evil-ex-define-cmd "grevert"     #'+vc-gutter/revert-hunk)
 
 ;;; Dealing with buffers
-(evil-ex-define-cmd "k[ill]"      #'doom/kill-current-buffer)
+(evil-ex-define-cmd "k[ill]"      #'kill-current-buffer)
 (evil-ex-define-cmd "k[ill]all"   #'+evil:kill-all-buffers)
 (evil-ex-define-cmd "k[ill]m"     #'+evil:kill-matching-buffers)
 (evil-ex-define-cmd "k[ill]o"     #'doom/kill-other-buffers)


### PR DESCRIPTION
## Summary
The `:k(ill)` ex command references `doom/kill-current-buffer`, which doesn't exist. This causes `:k` and `:kill` to fail with "Unknown command: 'kill'".

Replace with `kill-current-buffer` (Emacs built-in), which is what every other kill-buffer binding in the codebase uses (`zx`, `SPC b k`, `q` in various modes).

## Context
`doom/kill-current-buffer` was likely renamed at some point; only this one reference was left behind. The other `:kill*` ex commands (`:killall`, `:killm`, `:killo`, `:killb`) correctly reference existing functions in `lisp/lib/buffers.el`.

Fix: #6341

## Test plan
- Open a buffer, run `:k` or `:kill` — buffer should be killed
- Verify `:killall`, `:killm`, `:killo`, `:killb` still work

---
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)