### PR TITLE
fix(rss): bind elfeed-tube-mpv commands in show mode

### DIFF
--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -97,9 +97,9 @@ easier to scroll through.")
   :config (elfeed-tube-setup)
   (map! (:map elfeed-show-mode-map
          [remap save-buffer] #'elfeed-tube-save
-         "F" #'elfeed-tube-fetch)
-        (:map elfeed-search-mode-map
-         [remap save-buffer] #'elfeed-tube-save
          "F" #'elfeed-tube-fetch
          "C-c C-f" #'elfeed-tube-mpv-follow-mode
-         "C-c C-w" #'elfeed-tube-mpv-where)))
+         "C-c C-w" #'elfeed-tube-mpv-where)
+        (:map elfeed-search-mode-map
+         [remap save-buffer] #'elfeed-tube-save
+         "F" #'elfeed-tube-fetch)))


### PR DESCRIPTION
Previously these commands were bound in search mode, which is incorrect according to the project docs and my own experience.

Ref: https://github.com/karthink/elfeed-tube/tree/99e55a?tab=readme-ov-file#set-up-with-use-package

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.