### PR TITLE
fix(org): yield RET to evil-multiedit in org buffers

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -1187,6 +1187,20 @@ between the two."
             CSup     (cmd! (org-eval-in-calendar '(calendar-backward-year 1)))
             CSdown   (cmd! (org-eval-in-calendar '(calendar-forward-year 1)))))))
 
+;; HACK When iedit (default backend for evil-multiedit) is active,
+;;   `+org/dwim-at-point' (bound to RET) should yield to multiedit's
+;;   toggle-or-restrict command. Without this, evil-org-mode-map takes
+;;   precedence over evil-multiedit-mode-map, making RET unusable for
+;;   toggling marks in org buffers.
+;; REVIEW: PR this upstream!
+(when (modulep! :editor multiple-cursors)
+  (defadvice! +org--yield-to-multiedit-a (fn &rest args)
+    "Defer to `evil-multiedit-toggle-or-restrict-region' if iedit is active."
+    :around #'+org/dwim-at-point
+    (if (and (bound-and-true-p iedit-mode)
+             (iedit-current-occurrence-string))
+        (call-interactively #'evil-multiedit-toggle-or-restrict-region)
+      (apply fn args))))
 
 (use-package! evil-org-agenda
   :when (modulep! :editor evil +everywhere)


### PR DESCRIPTION
## Summary
- When `iedit-mode` (evil-multiedit's backend) is active in an org buffer, `+org/dwim-at-point` (bound to RET) now defers to `evil-multiedit-toggle-or-restrict-region`
- This fixes the keymap precedence issue where `evil-org-mode-map` takes priority over `evil-multiedit-mode-map`, making RET unusable for toggling multiedit marks in org buffers
- The advice is conditional on the `:editor multiple-cursors` module being active

## Context
As noted by @hlissner in #8369, the fix is an `:around` advice on `+org/dwim-at-point` that checks for active `iedit-mode` and defers to multiedit when the cursor is on an occurrence. This PR upstreams that workaround.

Fix: #8369

## Test plan
1. Open an org buffer
2. Select a word and press `M-d` repeatedly to add multiedit marks
3. Navigate to a mark with `C-n`/`C-p`
4. Press `RET` — it should toggle the mark on/off (previously it would invoke `+org/dwim-at-point` instead)
5. Outside of multiedit mode, `RET` should still invoke `+org/dwim-at-point` as normal

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.