### PR TITLE
fix(indent-guides): Activating in org agenda messes up colors

### DIFF
--- a/modules/ui/indent-guides/config.el
+++ b/modules/ui/indent-guides/config.el
@@ -59,6 +59,9 @@ be enabled. If any function returns non-nil, the mode will not be activated."
     ;; Org's virtual indentation messes up indent-guides.
     (defun +indent-guides-in-org-indent-mode-p ()
       (bound-and-true-p org-indent-mode))
+    ;; Indent-bars messes up faces in agenda buffer.
+    (defun +indent-guides-in-org-agenda-indent-mode-p ()
+      (eq major-mode 'org-agenda-mode))
     ;; Fix #6438: indent-guides prevent inline images from displaying in ein
     ;; notebooks.
     (defun +indent-guides-in-ein-notebook-p ()


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
My agenda without this fix:
<img width="1427" height="256" alt="image" src="https://github.com/user-attachments/assets/3f87a2ee-b225-41da-9a0f-fcf8503048b0" />

and with it:

<img width="1409" height="262" alt="image" src="https://github.com/user-attachments/assets/fda4da08-8463-46da-aeb0-8b1ab0d45d2b" />
