### PR TITLE
fix(vertico): stop using deprecated consult sources

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -154,7 +154,7 @@ orderless."
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep
    consult-bookmark consult-recent-file
-   consult--source-recent-file consult--source-project-recent-file consult--source-bookmark
+   consult-source-recent-file consult-source-project-recent-file consult-source-bookmark
    :preview-key "C-SPC")
   (when (modulep! :config default)
     (consult-customize


### PR DESCRIPTION
This allows a smoother bump of consult later

Ref: <https://github.com/minad/consult/commit/3a8ac46916c0699f0905ac4fe65d72768add3efb>
