### PR TITLE
feat(vterm): add split commands for vterm popups

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -59,6 +59,22 @@ Returns the vterm buffer."
      (let (display-buffer-alist)
        (vterm vterm-buffer-name)))))
 
+;;;###autoload
+(defun +vterm/split-below ()
+  "Create a new vterm window below the current one."
+  (interactive)
+  (let ((ignore-window-parameters t))
+    (select-window (split-window-vertically))
+    (+vterm/here t)))
+
+;;;###autoload
+(defun +vterm/split-right ()
+  "Create a new vterm window to the right of the current one."
+  (interactive)
+  (let ((ignore-window-parameters t))
+    (select-window (split-window-horizontally))
+    (+vterm/here t)))
+
 (defun +vterm--configure-project-root-and-display (arg display-fn)
   "Sets the environment variable PROOT and displays a terminal using `display-fn`.
 

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -16,7 +16,15 @@
   :config
   (set-popup-rule! "^\\*vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
 
-  (map! :map vterm-mode-map "C-q" #'vterm-send-next-key)
+  (map! :map vterm-mode-map
+        "C-q" #'vterm-send-next-key
+        ;; Tmux-esque prefix keybinds
+        "C-c s" #'+vterm/split-below
+        "C-c v" #'+vterm/split-right
+        [remap split-window-below]  #'+vterm/split-below
+        [remap split-window-right]  #'+vterm/split-right
+        [remap evil-window-split]   #'+vterm/split-below
+        [remap evil-window-vsplit]  #'+vterm/split-right)
 
   ;; Once vterm is dead, the vterm buffer is useless. Why keep it around? We can
   ;; spawn another if want one.

--- a/modules/term/vterm/test/test-vterm.el
+++ b/modules/term/vterm/test/test-vterm.el
@@ -1,0 +1,28 @@
+;; -*- no-byte-compile: t; -*-
+;;; term/vterm/test/test-vterm.el
+
+(require 'buttercup)
+
+(describe "term/vterm"
+  (describe "split commands"
+    (it "defines +vterm/split-below"
+      (expect (fboundp '+vterm/split-below) :to-be t))
+
+    (it "defines +vterm/split-right"
+      (expect (fboundp '+vterm/split-right) :to-be t))
+
+    (it "remaps split-window-below in vterm-mode-map"
+      (expect (lookup-key vterm-mode-map [remap split-window-below])
+              :to-equal '+vterm/split-below))
+
+    (it "remaps split-window-right in vterm-mode-map"
+      (expect (lookup-key vterm-mode-map [remap split-window-right])
+              :to-equal '+vterm/split-right))
+
+    (it "remaps evil-window-split in vterm-mode-map"
+      (expect (lookup-key vterm-mode-map [remap evil-window-split])
+              :to-equal '+vterm/split-below))
+
+    (it "remaps evil-window-vsplit in vterm-mode-map"
+      (expect (lookup-key vterm-mode-map [remap evil-window-vsplit])
+              :to-equal '+vterm/split-right))))


### PR DESCRIPTION
## Summary
- Adds `+vterm/split-below` and `+vterm/split-right` commands, mirroring the existing eshell split commands (`+eshell/split-below`, `+eshell/split-right`)
- Binds `ignore-window-parameters` to `t` to bypass the popup system's `+popup--split-window` redirect, allowing the vterm popup itself to be split
- Remaps `split-window-below`/`split-window-right` and `evil-window-split`/`evil-window-vsplit` in `vterm-mode-map`
- Adds tmux-esque `C-c s` / `C-c v` bindings (matching eshell)

Without this, `C-x 3` from a vterm popup splits a background window instead of the popup itself.

Fix: #3910

## Test plan (verified)
- [x] Verify `+vterm/split-below` and `+vterm/split-right` are defined
- [x] Verify `split-window-below` is remapped to `+vterm/split-below` in `vterm-mode-map`
- [x] Verify `split-window-right` is remapped to `+vterm/split-right` in `vterm-mode-map`
- [x] Verify `evil-window-split`/`evil-window-vsplit` are remapped
- [x] Verify `C-c s` / `C-c v` tmux-style bindings are set

All steps verified via `emacsclient -e` against a running Doom Emacs daemon.

Buttercup unit test included and passes.

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
