### PR TITLE
feat(racket): add smart bracket mode toggle

### DIFF
--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -62,13 +62,19 @@ Formatting is handled using the [[doom-module::editor format]] module via [[http
 #+end_quote
 
 ** racket-smart-open-bracket-mode
-~racket-smart-open-bracket-mode~ gets turned off automatically if you use
-~parinfer~, ~lispy~. If you wish to enable it:
+~racket-smart-open-bracket-mode~ is enabled by default (mimicking DrRacket's
+behavior). It automatically inserts ~(~ or ~[~ based on the surrounding
+syntactic context when you press ~[~. It is disabled automatically if you use
+~parinfer~ or ~lispy~.
+
+To disable it, set ~+racket-smart-open-bracket-mode~ to nil before racket-mode
+loads:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
-(with-eval-after-load 'racket-mode
-  (add-hook 'racket-mode-hook #'racket-smart-open-bracket-mode))
+(setq +racket-smart-open-bracket-mode nil)
 #+end_src
+
+To force a literal ~[~ without disabling the mode, use =C-q [=.
 
 ** Unicode Input
 The optional ~racket-unicode~ input method lets you type unicode characters such

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -4,6 +4,16 @@
 (after! projectile
   (add-to-list 'projectile-project-root-files "info.rkt"))
 
+(defvar +racket-smart-open-bracket-mode t
+  "If non-nil, enable `racket-smart-open-bracket-mode'.
+
+This mode, inspired by DrRacket, automatically inserts `(' or `[' based on
+the surrounding syntactic context when you press `['. It is disabled
+automatically if `:editor parinfer' or `:editor lispy' is active.
+
+Set this to nil to always insert the bracket you type. You can also use
+`C-q [' to force a literal `[' without disabling this mode.")
+
 
 ;;
 ;;; Packages
@@ -58,7 +68,8 @@
             (cl-pushnew 'racket flycheck-disabled-checkers)))))
 
     (unless (or (modulep! :editor parinfer)
-                (modulep! :editor lispy))
+                (modulep! :editor lispy)
+                (not +racket-smart-open-bracket-mode))
       (add-hook mode-hook #'racket-smart-open-bracket-mode))
 
     (map! (:map racket-xp-mode-map


### PR DESCRIPTION
Fixes #1452 — `racket-smart-open-bracket-mode` converts `[` to `(` with no way to disable it.

Adds `+racket-smart-open-bracket-mode` defvar (default `t`). Set to `nil` in `$DOOMDIR/config.el` to disable. Also fixes README which incorrectly documented the default. Acknowledges draft PR #8367.

**Verified** on Emacs 30.2: reproduced bracket conversion, confirmed `[` preserved when mode disabled.

---

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.