### PR TITLE
docs(evil): fix stale repository link in module README

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -71,7 +71,7 @@ The following vim plugins have been ported to evil:
 | vim-lion              | evil-lion                      | omap [[kbd:][gl]] / [[kbd:][gL]]                   |
 | vim-seek or vim-sneak | evil-snipe                     | mmap [[kbd:][s]] / [[kbd:][S]], omap [[kbd:][z]] / [[kbd:][Z]] & [[kbd:][x]] / [[kbd:][X]] |
 | vim-surround          | evil-embrace and evil-surround | vmap [[kbd:][S]], omap [[kbd:][ys]]                |
-| vim-unimpaired        | (provided by Doom)             | [[https://github.com/hlissner/doom-emacs/blob/develop/modules/editor/evil/config.el#L413-L460][see the list]]                   |
+| vim-unimpaired        | (provided by Doom)             | [[https://github.com/doomemacs/doomemacs/blob/master/modules/editor/evil/config.el#L413-L460][see the list]]                   |
 
 This module has also ported vim-unimpaired keybinds to Emacs.
 


### PR DESCRIPTION
## Summary
Fix a stale link in `modules/editor/evil/README.org` by replacing the legacy `hlissner/doom-emacs` + `develop` URL with the canonical `doomemacs/doomemacs` + `master` URL.

## Details
- Updated the "see the list" link in the vim-unimpaired row.
- Docs-only change; no behavior changes.

Closes #2116