### PR TITLE
fix: save recentf-list to disk after cleanup on exit

### DIFF
--- a/lisp/doom-editor.el
+++ b/lisp/doom-editor.el
@@ -291,8 +291,7 @@ tell you about it. Very annoying. This prevents that."
   :commands recentf-open-files
   :custom (recentf-save-file (file-name-concat doom-profile-cache-dir "recentf"))
   :config
-  (setq recentf-auto-cleanup nil     ; Don't. We'll auto-cleanup on shutdown
-        recentf-max-saved-items 200) ; default is 20
+  (setq recentf-max-saved-items 200) ; default is 20
 
   ;; Anything in runtime folders
   (add-to-list 'recentf-exclude
@@ -319,7 +318,7 @@ tell you about it. Very annoying. This prevents that."
 
   ;; The most sensible time to clean up your recent files list is when you quit
   ;; Emacs (unless this is a long-running daemon session).
-  (setq recentf-auto-cleanup (if (daemonp) 300))
+  (setq recentf-auto-cleanup (if (daemonp) 300 'never))
   ;; Use a negative depth value because we need `recentf-cleanup' to run before
   ;; `recentf-save-list' to be effective, which `recentf-mode' will only add to
   ;; `kill-emacs-hook' once it is enabled.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Save `recentf-list` to disk on shutdown after cleaning it up, not before.

As far as I can tell, `recentf-list` was not cleaned up for non-daemon users before this change: Doom only cleans it up on exit, but the result of that cleanup was not saved to disk.

Slightly clean up handling of `recentf-auto-cleanup` while I'm there.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
