### PR TITLE
tweak(tree-sitter): use maintained systemverilog grammar

### DIFF
--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -129,7 +129,7 @@
                  (surface "https://github.com/connorlay/tree-sitter-surface" nil nil nil nil)
                  (toml "https://github.com/tree-sitter/tree-sitter-toml" nil nil nil nil)
                  (typst "https://github.com/uben0/tree-sitter-typst" "master" "src" nil nil)
-                 (verilog "https://github.com/gmlarumbe/tree-sitter-verilog" nil nil nil nil)
+                 (verilog "https://github.com/gmlarumbe/tree-sitter-systemverilog" nil nil nil nil)
                  (vhdl "https://github.com/alemuller/tree-sitter-vhdl" nil nil nil nil)
                  (vue "https://github.com/tree-sitter-grammars/tree-sitter-vue" nil nil nil nil)
                  (wast "https://github.com/wasm-lsp/tree-sitter-wasm" nil "wast/src" nil nil)


### PR DESCRIPTION
[tree-sitter-verilog](https://github.com/gmlarumbe/tree-sitter-verilog) has unfortunately not been maintained for years.

Gonzalo maintains [tree-sitter-systemverilog](https://github.com/gmlarumbe/tree-sitter-systemverilog) which boasts

- Full implementation of the latest SystemVerilog standard (IEEE 1800-2023)
- Robust and reliable: sv-tests results
- Actively maintained
- Implements node fields
- Supports parsing of code snippets (e.g., always block outside of a module)
- Basic preprocessing capabilities
- Thoroughly tested (~3000 tests) including:

verilog is strictly a subset of systemverilog so the systemverilog grammar is backwards compatible with verilog features. The same emacs major mode is used for both verilog and systemverilog.

tree-sitter-verilog has significant issues and fails parsing many basic verilog files.

I use tree-sitter-systemverilog daily and have had no issues since switching.

I'm not 100% sure if tweak is the right category for this commit; please let me know if that should change.

Thank you!

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.