### PR TITLE
fix(org): use new :preview param for remote images

### DIFF
--- a/modules/lang/org/autoload/org-link.el
+++ b/modules/lang/org/autoload/org-link.el
@@ -337,17 +337,28 @@ exist, and `org-link' otherwise."
   (base64-decode-string link))
 
 ;;;###autoload
-(defun +org-http-image-data-fn (protocol link _description)
+(defun +org-http-image-data-fn (ov _link elem)
   "Interpret LINK as an URL to an image file."
-  (when (and (image-type-from-file-name link)
-             (not (eq org-display-remote-inline-images 'skip)))
-    (if-let* ((buf (url-retrieve-synchronously (concat protocol ":" link))))
-        (with-current-buffer buf
-          (goto-char (point-min))
-          (re-search-forward "\r?\n\r?\n" nil t)
-          (buffer-substring-no-properties (point) (point-max)))
-      (message "Download of image \"%s\" failed" link)
-      nil)))
+  ;; _link is the link sans http or https,
+  ;; e.g. http://somesite.com/someimage.png will be passed as
+  ;; _link = //somesite.com/someimage.png
+  ;; so we just get the raw link from the org element isntead
+  (when-let* ((link (org-element-property :raw-link elem))
+              (cache-file (and (image-supported-file-p link)
+                               (not (eq org-display-remote-inline-images 'skip))
+                               (concat temporary-file-directory
+                                       "org-preview/"
+                                       (buffer-name (overlay-buffer ov)) "/"
+                                       (file-name-nondirectory link)))))
+    ;; cache a local copy of the file
+    (when (or (eq org-display-remote-inline-images 'download)
+              (not (file-exists-p cache-file)))
+      (make-directory (file-name-directory cache-file) t)
+      (url-copy-file link cache-file t))
+
+    ;; preview
+    (when (file-exists-p cache-file)
+      (org-link-preview-file ov cache-file link))))
 
 (defvar +org--gif-timers nil)
 ;;;###autoload

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -609,8 +609,8 @@ relative to `org-directory', unless it is an absolute path."
   ;; Allow inline image previews of http(s)? urls or data uris.
   ;; `+org-http-image-data-fn' will respect `org-display-remote-inline-images'.
   (setq org-display-remote-inline-images 'download) ; TRAMP urls
-  (org-link-set-parameters "http"  :image-data-fun #'+org-http-image-data-fn)
-  (org-link-set-parameters "https" :image-data-fun #'+org-http-image-data-fn)
+  (org-link-set-parameters "http"  :preview #'+org-http-image-data-fn)
+  (org-link-set-parameters "https" :preview #'+org-http-image-data-fn)
   (org-link-set-parameters "img"   :image-data-fun #'+org-inline-image-data-fn))
 
 


### PR DESCRIPTION
Related to https://github.com/doomemacs/doomemacs/issues/8164

`:preview:` is now in the released org used by doom--- I've been using it for ~1 yr now with good results.

This PR implements image preview for http and https links using the new `:preview` parameter.

I mocked up something for base64 encoded images also---it works ok for small images but I run into a lot of performance problems and issues e.g. "Stack overflow in regexp matcher" that have made me give up on hacking base64 images into org mode. It works ok for simple images but didn't seem worthwhile to me to pursue further. The code does work but seems very rough around the edges and I'm not sure its worth sharing, so is not included in this PR.

Thank you!

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.