### PR TITLE
fix(lib): use `boundp` instead of `intern-soft` in `doom-indent-var-for-mode`

### DIFF
--- a/lisp/lib/indent.el
+++ b/lisp/lib/indent.el
@@ -42,7 +42,8 @@ with `set-indent-vars!'."
                          -tab-width
                          -basic-offset)))
         (cl-loop for suffix in suffixes
-                 if (intern-soft (format "%s%s" mode** suffix))
+                 if (let ((sym (intern-soft (format "%s%s" mode** suffix))))
+                      (and sym (boundp sym) sym))
                  return it))))
 
   (defun doom-indent-vars-for-mode (mode)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

TLDR;
Check `boundp` in addition to `intern-soft`.

Currently `doom-indent-var-for-mode` uses `intern-soft` to find candidate indent variables.
`typescript-indent-level` comes from `typescript-mode`, and if the user enables `+tree-sitter`, then `typescript-mode` will not be loaded, which means `typescript-indent-level` has no value. Then `doom-set-indent` blows up with `void-variable` on `change-major-mode-after-body-hook`, aborting mode init before `font-lock-mode` gets enabled.

fixes #8714 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->