### PR TITLE
docs(org): +roam: update outdated docstring

### DIFF
--- a/modules/lang/org/autoload/contrib-roam.el
+++ b/modules/lang/org/autoload/contrib-roam.el
@@ -71,7 +71,7 @@ If there's none, return an empty string."
   "Open or close roam backlinks buffer depending on visible org-roam buffers.
 
 Intended to be added to `doom-switch-buffer-hook' in `org-roam-find-file-hook'.
-Controlled by `+org-roam-open-buffer-on-find-file'."
+Controlled by `+org-roam-auto-backlinks-buffer'."
   (when (and +org-roam-auto-backlinks-buffer
              (not org-roam-capture--node)  ; not for roam capture buffers
              (not org-capture-mode)        ; not for capture buffers

--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -92,7 +92,7 @@ inserting the link."
     org-id-link-to-org-use-id +org-roam-link-to-org-use-id)
 
   ;; Normally, the org-roam buffer won't open until `org-roam-buffer-toggle' is
-  ;; explicitly called. If `+org-roam-open-buffer-on-find-file' is non-nil, the
+  ;; explicitly called. If `+org-roam-auto-backlinks-buffer' is non-nil, the
   ;; org-roam buffer will automatically open whenever a file in
   ;; `org-roam-directory' is visited and closed when no org-roam buffers remain.
   (add-hook! 'org-roam-find-file-hook :append


### PR DESCRIPTION
Amend: d92883bff8ff

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

----

By the way, my plan is to change that variable into a global minor mode so that the behavior can be easily toggled on and off. But until I find the time to do this, this doc fix will help any confused users. 