### PR TITLE
fix: =calendar to go to current date

### DIFF
--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -8,7 +8,8 @@
   (require 'calfw)
   (if-let* ((win (get-buffer-window calfw-calendar-buffer-name)))
       (select-window win)
-    (call-interactively +calendar-open-function)))
+    (call-interactively +calendar-open-function)
+    (calfw-navi-goto-today-command)))
 
 ;;;###autoload
 (defun =calendar ()


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Issue: https://github.com/doomemacs/doomemacs/issues/8719

Ever since an upstream calfw update, =calendar does not automatically go to the current date after calling the function. This aims to fix that by calling `calfw-navi-goto-today-command` in `+calendar--init` defined in `emacs/modules/app/calendar/autoload.el`.

This is my first PR, please do give feedback if something is not up to standards.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
