### PR TITLE
revert: fix(lispy): evil-escape keybind collision on j

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -47,7 +47,4 @@
           additional
           additional-insert))
   :config
-  (lispyville-set-key-theme)
-  (add-hook! 'evil-escape-inhibit-functions
-    (defun +lispy-inhibit-evil-escape-fn ()
-      (and lispy-mode (evil-insert-state-p)))))
+  (lispyville-set-key-theme))


### PR DESCRIPTION
evil-escape had been disabled in lispy because of a key binding conflict involving the evil-escape-key-sequence "jk". But the latter is nil since 68ec9e9c8600, so we can re-enable evil-escape.

Ref: 68ec9e9c8600
Revert: ccd20847c7ce

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
