### PR TITLE
fix: haskell-indent-offset is nil problem

### DIFF
--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -24,7 +24,6 @@
   ;; Don't kill REPL popup on ESC/C-g
   (set-popup-rule! "^\\*haskell\\*" :quit nil)
   (set-indent-vars! 'haskell-mode
-                    'haskell-indent-offset
                     'haskell-indentation-layout-offset
                     'haskell-indentation-starter-offset
                     'haskell-indentation-left-offset
@@ -54,6 +53,9 @@
         "h" #'haskell-hide-toggle
         "H" #'haskell-hide-toggle-all))
 
+(after! haskell-indent-mode
+  (set-indent-vars! 'haskell-indent-mode
+                    'haskell-indent-offset))
 
 (use-package! haskell-ts-mode
   :when (modulep! +tree-sitter)


### PR DESCRIPTION
Fix 'the value of haskell-indent-offset is nil' problem: 
Before:

(after! haskell-mode
  ...
  (set-indent-vars! 'haskell-mode
                    'haskell-indent-offset
                    ...)
  ...)

After:

(after! haskell-mode)
  ...
  (set-indent-vars! 'haskell-mode
                    ...)
  ...)
(after! haskell-indent-mode
  (set-indent-vars! 'haskell-offset-mode
                    'haskell-indent-offset))

* module/lang/haskell/config.el(haskell-mode, haskell-indent-mode):
  - Do modification like above.

<!-- ⚠️ Please do not ignore this template! -->

{{Summarize here what you've changed and why. Any extra commentary may go here as well, including references to any issues/PRs related to it. If your changes are visual, include before and after screenshots please!}}
After today's upgrade operation, I found that the highlight for my Haskell code disappeared and I realized there must be something goes wrong and I finally found that the nearest change to indention contributes to the problem.
I deleted all relative files and reinstall doom emacs to ensure it is not my fault.
And after made those modification, it works as my expectation.
Then I check whether there are any relative issue and found nothing, thus I make this pr.

I have tried my best to fit git commit convention.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
