### PR TITLE
fix: use relative :height for non-default faces in doom-init-fonts-h

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -633,7 +633,20 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
                 (when (display-multi-font-p frame)
                   (set-face-attribute face frame
                                       :width 'normal :weight 'normal
-                                      :slant 'normal :font font))
+                                      :slant 'normal :font font)
+                  ;; Setting :font above bakes in an absolute :height from the
+                  ;; font-spec's :size.  Non-default faces should use a relative
+                  ;; :height so they scale with `doom/increase-font-size' (which
+                  ;; only adjusts `doom-font' for the default face, then calls
+                  ;; `doom-init-fonts-h' to propagate).  Convert now, before
+                  ;; `custom-push-theme' snapshots the value.
+                  (unless (eq face 'default)
+                    (let ((default-height (face-attribute 'default :height frame)))
+                      (when (and (integerp default-height) (> default-height 0))
+                        (set-face-attribute
+                         face frame :height
+                         (/ (float (face-attribute face :height frame))
+                            default-height))))))
                 (custom-push-theme
                  'theme-face face 'user 'set
                  (let* ((base-specs (cadr (assq 'user (get face 'theme-face))))


### PR DESCRIPTION
`set-face-attribute ... :font font` bakes in an absolute :height from the font-spec's :size. This means fixed-pitch, fixed-pitch-serif, and variable-pitch all get absolute heights (e.g. 160 for a 16pt font).

In practice it means that  `doom/increase|decrease-font-size` won't scale things properly - most visible in Org-mode buffers with source blocks (org-block-begin-line typically inherits from 'fixed-pitch face) - increase/decrease wouldn't scale different faces proportionally.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.


Local workaround for until the fix is merged (if ever)

```elisp
;; Workaround: place in your config.el
(defadvice! keep-fixed-pitch-height-relative-a (&optional _reload)
  "Reset fixed-pitch faces to relative :height after Doom sets fonts."
  :after #'doom-init-fonts-h
  (dolist (face '(fixed-pitch fixed-pitch-serif))
    (set-face-attribute face nil :height 1.0)
    (when-let* ((theme-specs (get face 'theme-face))
                (user-entry (assq 'user theme-specs))
                (face-specs (cadr user-entry)))
      (dolist (spec face-specs)
        (when-let* ((plist (cadr spec)))
          (when (plist-member plist :height)
            (plist-put plist :height 1.0)))))))
```

This covers `fixed-pitch` and `fixed-pitch-serif` only (hardcoded to 1.0 since they use the same font as default). The upstream fix is more general - it computes the actual ratio for all non-default faces, so `variable-pitch` with a different size also gets a correct relative value.

