### PR TITLE
feat: hook hl-todo-mode into yaml-ts-mode

### DIFF
--- a/modules/ui/hl-todo/config.el
+++ b/modules/ui/hl-todo/config.el
@@ -2,7 +2,7 @@
 
 (use-package! hl-todo
   :hook (prog-mode . hl-todo-mode)
-  :hook (yaml-mode . hl-todo-mode)
+  :hook (yaml-mode yaml-ts-mode)
   :config
   (setq hl-todo-highlight-punctuation ":"
         hl-todo-keyword-faces


### PR DESCRIPTION
`yaml-mode` was already hooked into `hl-todo-mode`,
but its built-in Tree-sitter counterpart `yaml-ts-mode` was missing the same hook.
This PR adds it.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [ ] ~~This PR contains AI-generated work.~~
- [x] Any relevant issues or PRs have been linked to.
- [ ] ~~This a draft PR; I need more time to finish it.~~
