### PR TITLE
fix(rust): break Emacs 31 mode hierarchy cycle

### DIFF
--- a/modules/lang/rust/autoload/compat.el
+++ b/modules/lang/rust/autoload/compat.el
@@ -22,6 +22,22 @@
   (cl-callf2 rassq-delete-all 'rust-mode auto-mode-alist)
   (cl-callf2 rassq-delete-all 'rustic-mode auto-mode-alist)
 
+  ;; HACK: Emacs 31's built-in `rust-ts-mode' calls
+  ;;   (derived-mode-add-parents 'rust-ts-mode '(rust-mode))
+  ;;   so that hooks on `rust-mode' also fire in `rust-ts-mode' buffers. But
+  ;;   when `rust-mode-treesitter-derive' is non-nil, `rust-mode' derives FROM
+  ;;   `rust-ts-mode', creating a cycle in `derived-mode-all-parents':
+  ;;     rust-mode → rust-ts-mode → rust-mode
+  ;;   Remove the extra parent to break the cycle. The derive direction already
+  ;;   ensures `rust-mode' hooks fire (since `rust-mode' IS a `rust-ts-mode').
+  (when (and rust-mode-treesitter-derive
+             (>= emacs-major-version 31))
+    (after! rust-ts-mode
+      (put 'rust-ts-mode 'derived-mode-extra-parents
+           (remq 'rust-mode (get 'rust-ts-mode 'derived-mode-extra-parents)))
+      (put 'rust-ts-mode 'derived-mode--all-parents nil)
+      (put 'rust-mode 'derived-mode--all-parents nil)))
+
   ;; HACK: If rustic isn't loaded *after* `rust-mode' is defined, chaos and
   ;;   errors can ensue, but `rust-mode' is defined *after* it `provide's the
   ;;   `rust-mode' package, so (after! rust-mode ...) isn't sufficient. Sigh.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

**DISCLAIMER**: The patch has been vibecoded. I don’t like the nested remq/get calls tbh. So the comment in the patch is more interesting than the patch

But at the very least the commit message needs editing anyway.

Another human message: apparently the issue is not Emacs 31 specific, since Github tells me that
the commit that [made the change](https://github.com/emacs-mirror/emacs/commit/c79a509384d33dab6a964ef9a97cbc9a1f1b5bf7) is already in Emacs 30 since release-candidate stage.

---

Issue was: This causes `derived-mode-all-parents` to emit in `*Messages*`:
  Inconsistent hierarchy: ((rust-mode rust-ts-mode prog-mode
  rust-mode fundamental-mode) (fundamental-mode))
---

**Emacs 31**'s built-in `rust-ts-mode` calls
`(derived-mode-add-parents 'rust-ts-mode '(rust-mode))` so that hooks
on `rust-mode` also trigger in `rust-ts-mode` buffers. However, when
`rust-mode-treesitter-derive` is non-nil (set by Doom when +tree-sitter
is enabled), `rust-mode` derives FROM `rust-ts-mode`, creating a cycle:

  rust-mode → rust-ts-mode → rust-mode

Fix by removing `rust-mode` from `rust-ts-mode`s extra parents after
it loads. The derive direction already ensures `rust-mode` hooks fire
in the right buffers.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] ~~I am blindly checking these off.~~
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] ~~This a draft PR; I need more time to finish it.~~

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
