### PR TITLE
fix(web): use new set-indent-vars! API

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -25,10 +25,10 @@
   :config
   (set-docsets! 'web-mode "HTML" "CSS" "Twig" "WordPress")
   (set-indent-vars! 'web-mode
-                    'web-mode-code-indent-offset
-                    'web-mode-css-indent-offset
-                    'web-mode-markup-indent-offset
-                    'web-mode-sql-indent-offset)
+                      '(web-mode-code-indent-offset
+                        web-mode-css-indent-offset
+                        web-mode-markup-indent-offset
+                        web-mode-sql-indent-offset))
 
   ;; tidy is already defined by the format-all package. We redefine it to add
   ;; more sensible arguments to the tidy command.


### PR DESCRIPTION
The `set-indent-vars!` macro was recently updated to expect a single list of variables (modes vars), but the web module was still passing 5 separate arguments. This caused a `wrong-number-of-arguments` error on startup. Wrapped the indent variables in a list to match the new signature.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
