### PR TITLE
fix(cli): doomscript: end-of-file error

### DIFF
--- a/bin/doomscript
+++ b/bin/doomscript
@@ -35,18 +35,6 @@ case "$EMACS" in
        ;;
 esac
 
-# Careful not to use -Q! It implies --no-site-lisp; it omits the site-lisp
-# directory from `load-path' which prevent Doom from manually loading the site
-# files later. Site files are important on some systems or deployment methods
-# (like Snap or NixOS).
-emacs="$EMACS -q --no-site-file --batch"
-
-# Emacs complains about missing lexical-binding settings in elisp files, but
-# this warning is unhelpful to end users, polluting the output of any shell
-# script derived from this script, so silence it (it's not enough to set it *in*
-# lisp/doom.el, unfortunately).
-emacs="$emacs --eval \"(setq warning-inhibit-types '((files missing-lexbind-cookie)))\" "
-
 # The emacs-plus formula on homebrew will inject redundant/extra entries into
 # $PATH, causing issues. This suppresses that behavior, and does nothing
 # everywhere else.
@@ -81,9 +69,21 @@ export __DOOMPIPE=
 # loaded first.
 script="$1"
 shift
-$emacs --load "$EMACSDIR/early-init" \
-       --load "$script" \
-       -- "$@"
+# Careful not to use -Q! It implies --no-site-lisp; it omits the site-lisp
+# directory from `load-path' which prevent Doom from manually loading the site
+# files later. Site files are important on some systems or deployment methods
+# (like Snap or NixOS).
+
+# Emacs complains about missing lexical-binding settings in elisp files, but
+# this warning is unhelpful to end users, polluting the output of any shell
+# script derived from this script, so silence it (it's not enough to set it *in*
+# lisp/doom.el, unfortunately).
+"$EMACS" \
+    -q --no-site-file --batch \
+    --eval "(setq warning-inhibit-types '((files missing-lexbind-cookie)))" \
+    --load "$EMACSDIR/early-init" \
+    --load "$script" \
+    -- "$@"
 exit=$?
 
 # bin/doom can request the caller emulate an execve syscall by returning a 254
@@ -92,7 +92,7 @@ if [ "${exit:-0}" -eq 254 ]; then
     # $TMPDIR (or $TEMP and $TMP on Windows) aren't guaranteed to have values,
     # and mktemp isn't available on all systems, but you know what is? Emacs! So
     # I rely on it to provide TMPDIR.
-    export TMPDIR="${TMPDIR:-${TMP:-${TEMP:-$($emacs -Q --eval '(princ (temporary-file-directory))' 2>/dev/null)}}}"
+    export TMPDIR="${TMPDIR:-${TMP:-${TEMP:-$($EMACS -Q --batch --eval '(princ (temporary-file-directory))' 2>/dev/null)}}}"
 
     # /tmp may be mounted with the noexec flag, so the exit-script can't be
     # executed directly.


### PR DESCRIPTION
534b6403508136e6667a26b43c12c63f053f9b35 introduced the same regression previously introduced in bac90c0 (see #8362): it adds a quoted argument including whitespace to `$emacs`, but the contents of that variable are not evaluated by the shell. This means the quotes do not prevent word splitting and are not removed, resulting in Emacs getting invoked with separate arguments like `"(setq` and `warning-inhibit-types`:

```
$ bin/doomscript /tmp/doomscript

Error: end-of-file nil
  command-line-1(("--eval" "\"(setq" "warning-inhibit-types" "'((files" "missing-lexbind-cookie)))\"" "--load" "/home/marienz/src/doomemacs/early-init" "--load"
 "/tmp/doomscript" "--"))
  command-line()
  normal-top-level()
End of file during parsing
```

If we were using Bash we could fix this by using an array, but in portable shell our options are more limited.

Fortunately, `$emacs` is only used twice, and one of them does not need most of the arguments we are adding because it adds `-Q` and does not load Doom. So fix it by replacing that one with `$EMACS --batch` and inlining the rest of `$emacs` into its only remaining user.

Amend: 534b6403508136e6667a26b43c12c63f053f9b35

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
