### PR TITLE
fix(clojure): jank mode inherits keybindings

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -91,6 +91,7 @@
   :hook (clojure-ts-mode-local-vars . cider-mode)
   :hook (clojure-ts-clojurescript-mode-local-vars . cider-mode)
   :hook (clojure-ts-clojurec-mode-local-vars . cider-mode)
+  :hook (clojure-ts-jank-mode . cider-mode)
   :init
   (after! clojure-mode
     (set-repl-handler! '(clojure-mode clojurec-mode)


### PR DESCRIPTION
At some point, Jank lost the keybindings otherwise inherited from Clojure. This PR restores them.

NOTE: It may be incorrect that this only accounts for TreeSitter. There is currently no `+jank` flag on the Clojure module, it's just included automatically, so this fix silently requires `+tree-sitter` to be active on this module.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.


