### PR TITLE
fix: projectile: guard projectile-files-to-ensure against nil project root

### DIFF
--- a/lisp/doom-projects.el
+++ b/lisp/doom-projects.el
@@ -124,6 +124,17 @@ Must end with a slash.")
       (cond ((file-exists-p! (or projectile-dirconfig-file ".project") proot))
             ((expand-file-name ".project" proot)))))
 
+  ;; HACK: `projectile-files-to-ensure' binds `default-directory' to the result
+  ;;   of `projectile-project-root', which returns nil when called from a buffer
+  ;;   outside of a project, poisoning the entire downstream call chain with a
+  ;;   wrong-type-argument error.
+  (defadvice! doom--projectile-files-to-ensure-a ()
+    :override #'projectile-files-to-ensure
+    (when-let* ((root (projectile-project-root)))
+      (let ((default-directory root))
+        (flatten-tree (mapcar #'file-expand-wildcards
+                              (projectile-patterns-to-ensure))))))
+
   ;; Disable commands that won't work, as is, and that Doom already provides a
   ;; better alternative for.
   (put 'projectile-ag 'disabled "Use +default/search-project instead")


### PR DESCRIPTION
a55d6ad95813e7de297b5820789014182425c651 bumped `projectile` to https://github.com/bbatsov/projectile/commit/4469d33f4921432e67b98151eeb6b4c2a17d648e, which brought in commit https://github.com/bbatsov/projectile/commit/f51621adcee087c01262164d1fa32580030fc6e1d.

The aforementioned commit changes `projectile-files-to-ensure` to bind `default-directory` to the result of `projectile-project-root` before calling `file-expand-wildcards`.  When invoked from a buffer outside of any project, `projectile-project-root` returns `nil`, poisoning `default-directory` for the entire downstream call chain.

This is harmless in vanilla `projectile`, but `doom--projectile-dirconfig-file-a` overrides `projectile-dirconfig-file` with an implementation that calls `projectile-project-root` again with no arguments.  With `default-directory` already `nil`, that call reaches `file-remote-p(nil)`, producing:

    Wrong type argument: stringp, nil

Override `projectile-files-to-ensure` to short-circuit cleanly when no project root is found, and otherwise ensure `default-directory` is bound to a valid root before the downstream call chain is entered.

Fix: #8747
Amend: a55d6ad95813e7de297b5820789014182425c651
Ref: bbatsov/projectile@f51621adcee087c01262164d1fa32580030fc6e1d

<!-- ⚠️ Please do not ignore this template! -->
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly (deafly?) checking these off.
- [x] This PR contains AI-generated work¹.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

¹: I did a `git bisect` on the Doom repo to identify the commit that introduced the breakage, and then another `git bisect` on the projectile repo to identify the precise commit that changed the behavior. Then I run `doom --debug-init` to be able to extract the backtrace, and finally Claude helped me to undestand it as well as to provide a fix.
<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->