### PR TITLE
tweak(goggles): disable non-evil goggles delete-region hinting

### DIFF
--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -67,6 +67,7 @@
   :unless (modulep! :editor evil)
   :hook ((prog-mode text-mode) . goggles-mode)
   :config
+  (goggles-delete 'disable) ; Consistent with `evil-goggles-enable-delete' setting
   (goggles-define +goggles-general-undo undo) ; goggles only supports `primitive-undo' by default
   (goggles-define +goggles-register-paste insert-register)
   (goggles-define +goggles-kill-word backward-kill-word kill-word)


### PR DESCRIPTION
This makes non-evil goggles consistent with the `evil-goggles-enable-delete` setting.  Additionally, having `delete-region` hinting enabled is a nuisance for commands which utilize `delete-region` internally.  For example, pressing `RET` on an indented empty line will cause pulsing.  This happens because `newline-and-indent` will remove the empty line's indentation (using `delete-horizontal-space` which ends up using `delete-region`) before inserting a newline and indenting that line.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
