### PR TITLE
fix(help): resolve Codeberg package repo path in doom/help-packages

### DIFF
--- a/lisp/lib/packages.el
+++ b/lisp/lib/packages.el
@@ -247,7 +247,7 @@ processed."
   "Resolve and return PACKAGE's (symbol) local-repo property."
   (if-let* ((recipe (copy-sequence (doom-package-recipe package)))
             (recipe (if (and (not (plist-member recipe :type))
-                             (memq (plist-get recipe :host) '(github gitlab bitbucket)))
+                             (memq (plist-get recipe :host) '(github gitlab bitbucket codeberg)))
                         (plist-put recipe :type 'git)
                       recipe))
             (repo (if-let* ((local-repo (plist-get recipe :local-repo)))


### PR DESCRIPTION
  Treat `codeberg` recipes like other git hosts when inferring local repo names in `doom-package-recipe-repo`. This makes `doom/help-packages` show the correct "Repo location" (e.g. for `eat`) instead of `n/a`.


```elisp
(package! eat
  :recipe (:host codeberg
           :repo "akib/emacs-eat"
           :files ("*.el" ("term" "term/*.el") "*.texi" "*.ti"
                   ("terminfo/e" "terminfo/e/*")
                   ("terminfo/65" "terminfo/65/*")
                   ("integration" "integration/*")
                   (:exclude ".dir-locals.el" "*-tests.el")))) 
```

then run `doom/help-packages` you will get "Repo location: n/a"

```txt
    Package: eat
     Source: Straight
     Pinned: unpinned
      Build: n/a
             Build location: ~/.emacs.d/.local/straight/build-31.0.50/eat/
             Repo location: n/a
     Recipe: (:host codeberg :repo "akib/emacs-eat" :files
                    ("*.el" ("term" "term/*.el") "*.texi" "*.ti"
                     ("terminfo/e" "terminfo/e/*") ("terminfo/65" "terminfo/65/*")
                     ("integration" "integration/*") (:exclude ".dir-locals.el" "*-tests.el"))
                    :package "eat" :type git :local-repo "emacs-eat")
                Homepage: https://codeberg.org/akib/emacs-eat
    Modules: Declared by the following Doom modules:
             :user  (no readme)
             :user modules (no readme)
    Configs: This package is not configured anywhere
```