### PR TITLE
fix(rss): off-by-one error in elfeed-search-selected

### DIFF
--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -52,6 +52,23 @@ easier to scroll through.")
       shr-put-image-function #'+rss-put-sliced-image-fn
       shr-external-rendering-functions '((img . +rss-render-image-tag-without-underline-fn))))
 
+  (defadvice! +rss--elfeed-search-selected-fix-a (fn &optional ignore-region-p)
+    "Prevent off-by-one when region ends at the beginning of the next line"
+    :around #'elfeed-search-selected
+    (if (and (not ignore-region-p)
+             (use-region-p)
+             (let ((end (region-end)))
+               (and (> end (region-beginning))
+                    (= end (save-excursion
+                             (goto-char end)
+                             (line-beginning-position))))))
+        (let ((orig-region-end (symbol-function 'region-end))
+              (fixed-end (1- (region-end))))
+          (fset 'region-end (lambda () fixed-end))
+          (unwind-protect (funcall fn ignore-region-p)
+            (fset 'region-end orig-region-end)))
+      (funcall fn ignore-region-p)))
+
   ;; Keybindings
   (after! elfeed-show
     (define-key! elfeed-show-mode-map


### PR DESCRIPTION

<!-- ⚠️ Please do not ignore this template! -->
Hello, 
  
This is a bug I'm experiencing as evil user when I visual-select some entries. I didn't reproduce it in regular emacs using mark regions, sorry.
  
1. In evil visual line mode, when you select lines 5-7, emacs sets `region-end` to the beginning of line 8
  (the character after the newline of line 7).
2. elfeed-search-selected does [this](https://github.com/skeeto/elfeed/blob/master/elfeed-search.el#L756C8-L756C30)
3. Since `region-end` is at the beginning of line 8, `line-number-at-pos end` returns 8, so the loop iterates over lines 5, 6, 7 **and 8**

If I operate on selected lines, i.e marking them as read (u), I'd expect to operate on entries at lines 5-7 but it actually operates on entries at lines 5-**8**

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
