### PR TITLE
fix(llm): autoload gptel-org commands bound at leader

### DIFF
--- a/modules/tools/llm/config.el
+++ b/modules/tools/llm/config.el
@@ -1,5 +1,9 @@
 ;;; tools/llm/config.el -*- lexical-binding: t; -*-
 
+(autoload 'gptel-org-set-topic "gptel-org" nil t)
+(autoload 'gptel-org-set-properties "gptel-org" nil t)
+
+
 (use-package! gptel
   :defer t
   :config


### PR DESCRIPTION
## Summary

`SPC o l o` and `SPC o l O` in `:config default` are bound to `gptel-org-set-topic` and `gptel-org-set-properties`, which live in `gptel-org.el`. Those commands carry no autoload cookies upstream, and nothing in `:tools llm` requires the file, so pressing either key raises `Wrong type argument: commandp, gptel-org-set-topic` until `gptel-org` happens to have been loaded some other way.

This PR adds two `autoload` declarations to `modules/tools/llm/config.el` so the leader bindings resolve on first use. It follows the same idiom already used for `org-capture-goto-target` in `modules/config/default/+emacs-bindings.el:16`.

Placing the autoloads in `modules/tools/llm/config.el` (rather than in each of `+evil-bindings.el` and `+emacs-bindings.el`) keeps them scoped by `(modulep! :tools llm)` — the same guard used by the bindings themselves — and covers both evil and non-evil users from one place.

## Reproduction

Before the fix, from the dashboard in an otherwise normal Doom session:

```
SPC o l o  →  Wrong type argument: commandp, gptel-org-set-topic
SPC o l O  →  Wrong type argument: commandp, gptel-org-set-properties
```

After the fix:

```
SPC o l o  →  gptel-org-set-topic runs; in a non-org buffer returns the
              user-error "Support for multiple topics per buffer is only
              implemented for `org-mode'" (expected runtime guard).
SPC o l O  →  gptel-org-set-properties runs. It then hits a separate
              upstream bug (void-variable gptel--preset), filed at
              karthink/gptel#1370 with a proposed fix at
              karthink/gptel#1371. Out of scope here.
```

## Related

- Upstream gptel issue: karthink/gptel#1370
- Upstream gptel fix: karthink/gptel#1371

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.