### PR TITLE
feat(vterm): add eshell-like keybindings

### DIFF
--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -16,7 +16,21 @@
   :config
   (set-popup-rule! "^\\*vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
 
-  (map! :map vterm-mode-map "C-q" #'vterm-send-next-key)
+  (map! :map vterm-mode-map "C-q" #'vterm-send-next-key
+        :n "0"  (cmd! (vterm-send-key "a" nil nil t)
+                      (evil-refresh-cursor))
+
+        :n "dd" (cmd! (vterm-send-key "e" nil nil t)
+                      (vterm-send-key "u" nil nil t)
+                      (evil-refresh-cursor))
+
+        :n "V"  (cmd! (let* ((beg (save-excursion
+                                    (beginning-of-line)
+                                    (re-search-forward "\\$ " (line-end-position) t)
+                                    (point)))
+                             (end (save-excursion (vterm-end-of-line) (point))))
+                        (evil-visual-make-region beg end))))
+
 
   ;; Once vterm is dead, the vterm buffer is useless. Why keep it around? We can
   ;; spawn another if want one.


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Currently in vterm module:
- "d d" clears the tty input
- "V" highlights the whole line, including tty data
- "0" goes to the beginning of the line, past the tty data
<img width="1280" height="720" alt="2026-04-24-22-30-42" src="https://github.com/user-attachments/assets/95689658-9c21-431b-b2c3-49b1f058266f" />

Eshell seems to have a more intuitive behaviour, which is to avoid highlighting/going backwards past the tty/lambda data and "d d" clears the input, and this PR tries to port that to the vterm module:

<img width="1280" height="720" alt="2026-04-24-22-14-33" src="https://github.com/user-attachments/assets/fd322712-4512-4bae-9999-53caa14679a9" />

I haven't found a way to do it with evil-collection, `(evil-collection-vterm-setup)` does not create this behaviour. Also, [evil-mode isn't yet supported in vterm upstream](https://github.com/akermu/emacs-libvterm/issues/313). #4373 was never merged but evil-collection does include most of those bindings.  

edit: add evil-collection and other PR linking paragraph

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
