### PR TITLE
fix(cli) properly escape ' in zsh completion help strings

### DIFF
--- a/lisp/cli/make/completions.el
+++ b/lisp/cli/make/completions.el
@@ -93,9 +93,24 @@
                                 (if (and args (string-prefix-p "--" (caar switches)))
                                     "=" "")))
                       (format "'[%s]%s'"
-                              (replace-regexp-in-string "'" "''" (cdr option))
+                              (escape-help-string (cdr option))
                               (or argspec "")))
               (or cr "\n")))))
+
+(defun escape-help-string (str)
+  " escape a string for use as an optname, explanation or action.
+    NOTE: this function's output is expected to be used inside single quotes "
+  ;; - literal backslashes are backslash escaped.
+  ;; - zshcompsys(1) explains that colons in optname, explanation, or action must
+  ;;   be backslash escaped.
+  ;; - from testing, square braces [] can also be backslash escaped to permit
+  ;;   them inside [explanations]
+  ;; - finally, single quotes are escaped as double quoted strings
+  (string-replace "'" "\'\"\'\"\'"
+  (string-replace ":" "\\:"
+  (string-replace "[" "\\["
+  (string-replace "]" "\\]"
+  (string-replace "\\" "\\\\" str))))))
 
 (defun doom-make-completions--zsh-insert-command (command)
   (let* ((commandstr (doom-cli-command-string command))
@@ -114,8 +129,9 @@
                       unless (string-prefix-p ":" (car command))
                       collect (format "'%s[%s]' "
                                       (car (last command))
-                                      (or (doom-cli-short-docs (doom-cli-get command))
-                                          "TODO")))
+                                      (escape-help-string
+                                       (or (doom-cli-short-docs (doom-cli-get command))
+                                          "TODO"))))
              " \\\n          ")
             "\n      ;;\n"
             "    args)\n"


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

help strings in zsh completions are not properly escaped, leading to errors. 

for example typing `doom -` and pressing <kbd>tab</kbd> prints:

```
_doom:351: unmatched `
```

this change escapes `'` as well as backslashing `[]:\` following
recommendations in zshcompsys(1) and empirical observations.

...i didn't actually notice any of these latter characters in doom's current
help strings, but i did add some to confirm the this change causes zsh to
render them as expected.

**future**: newlines in these strings are also not desirable, but this change
makes no attempt to address that  (zsh renders them as a literal `\n`).

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
