### PR TITLE
fix(vertico): compatibility shim for removed consult-preview-at-point…

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -106,6 +106,11 @@ orderless."
 (use-package! consult
   :defer t
   :preface
+  ;; Compatibility shim for consult >= 3.5 where
+  ;; `consult-preview-at-point-mode' was removed.
+  (unless (fboundp 'consult-preview-at-point-mode)
+    (defalias 'consult-preview-at-point-mode #'ignore))
+
   (define-key!
     [remap bookmark-jump]                 #'consult-bookmark
     [remap evil-show-marks]               #'consult-mark


### PR DESCRIPTION
Fresh installs with newer consult versions fail during `doom doctor` with:

```text
Symbol's function definition is void:
consult-preview-at-point-mode
```

This appears to happen because upstream consult removed the obsolete function in:

```text
5cd9646 Remove obsolete consult-preview-at-point
```

However, Doom still indirectly expects the symbol during vertico/consult initialization.

This patch adds a small compatibility shim:

```elisp
(unless (fboundp 'consult-preview-at-point-mode)
  (defalias 'consult-preview-at-point-mode #'ignore))
```

which restores compatibility with newer consult versions and prevents fresh installs from crashing.

I reproduced this on:

* Doom 2.1.0
* Emacs 30.2
* NixOS

without the patch:

* `doom doctor` crashes

with the patch:

* `doom doctor` completes successfully
* latest consult works correctly

---

* [x] I searched the issue tracker and this hasn't been PRed before.
* [x] My changes are not on the do-not-PR list for this project.
* [x] My commits conform to Doom's git conventions.
* [ ] I am blindly checking these off.
* [x] This PR contains AI-generated work.
* [ ] Any relevant issues or PRs have been linked to.
* [ ] This a draft PR; I need more time to finish it.
