### PR TITLE
fix(java): update projectile root indicators

### DIFF
--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -19,7 +19,7 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
 
 (after! projectile
   (add-to-list 'projectile-project-root-files "gradlew")
-  (add-to-list 'projectile-project-root-files "build.gradle"))
+  (add-to-list 'projectile-project-root-files "settings.gradle"))
 
 
 ;;


### PR DESCRIPTION
In multimodule projects, the `build.gradle` file is not a safe indicator of root, making unreliable assumptions and creating individual `projectile` entries for submodules.

`settings.gradle` has been recommended as a root-level Gradle configuration that should work better for both scenarios.

## References

- [Settings File Basics](https://docs.gradle.org/current/userguide/settings_file_basics.html)
- [Structuring and Organizing Gradle Projects](https://docs.gradle.org/current/userguide/organizing_gradle_projects.html)
- [Original Commit adding build.gradle](https://github.com/doomemacs/doomemacs/commit/9b25582be1c9f0ace2e3ed161705e66943ba4587)

-----
- [x] I searched the issue tracker, and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off (I loved this check 👀)
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This is a draft PR; I need more time to finish it.