### PR TITLE
tweak: disable line numbers in minimal-UI buffers

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -562,6 +562,8 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 (add-hook 'completion-list-mode-hook #'mode-line-invisible-mode)
 (add-hook 'Man-mode-hook #'mode-line-invisible-mode)
 
+(add-hook 'completion-list-mode-hook #'doom-disable-line-numbers-h)
+(add-hook 'Man-mode-hook #'doom-disable-line-numbers-h)
 
 ;;
 ;;; Third party packages

--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -68,6 +68,7 @@
 
   (add-hook 'calfw-calendar-mode-hook #'doom-mark-buffer-as-real-h)
   (add-hook 'calfw-calendar-mode-hook #'mode-line-invisible-mode)
+  (add-hook 'calfw-calendar-mode-hook #'doom-disable-line-numbers-h)
 
   (advice-add #'calfw-render-button :override #'+calendar-calfw-render-button-a))
 

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -30,6 +30,12 @@
   ;; back to when killing other buffers.
   (add-hook 'mu4e-main-mode-hook #'doom-mark-buffer-as-real-h)
 
+  ;; Line numbers add nothing to mu4e's read-only views (excluding compose).
+  (add-hook! '(mu4e-main-mode-hook
+               mu4e-headers-mode-hook
+               mu4e-view-mode-hook)
+             #'doom-disable-line-numbers-h)
+
   ;; Ensures backward/forward compatibility for mu4e, which is prone to breaking
   ;; updates, and also cannot be pinned, because it's bundled with mu (which you
   ;; must install via your OS package manager).

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -106,7 +106,8 @@ to update the notmuch-saved-searches variable accordingly."
   (add-hook! '(notmuch-show-mode-hook
                notmuch-tree-mode-hook
                notmuch-search-mode-hook)
-             #'mode-line-invisible-mode)
+             #'mode-line-invisible-mode
+             #'doom-disable-line-numbers-h)
 
   (map! :localleader
         :map (notmuch-hello-mode-map notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)

--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -126,6 +126,7 @@ You should use `set-eshell-alias!' to change this.")
       (set-display-table-slot standard-display-table 0 ?\ )))
 
   (add-hook 'eshell-mode-hook #'mode-line-invisible-mode)
+  (add-hook 'eshell-mode-hook #'doom-disable-line-numbers-h)
 
   ;; Remove hscroll-margin in shells, otherwise you get jumpiness when the
   ;; cursor comes close to the left/right edges of the window.

--- a/modules/term/shell/config.el
+++ b/modules/term/shell/config.el
@@ -2,3 +2,4 @@
 
 ;;;###package shell
 (add-hook 'shell-mode-hook #'mode-line-invisible-mode)
+(add-hook 'shell-mode-hook #'doom-disable-line-numbers-h)

--- a/modules/term/term/config.el
+++ b/modules/term/term/config.el
@@ -2,6 +2,7 @@
 
 ;;;###package term
 (add-hook 'term-mode-hook #'mode-line-invisible-mode)
+(add-hook 'term-mode-hook #'doom-disable-line-numbers-h)
 
 
 ;;;###package multi-term

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -3,7 +3,8 @@
 (use-package! vterm
   :when (bound-and-true-p module-file-suffix)  ; requires dynamic-modules support
   :commands vterm-mode
-  :hook (vterm-mode . mode-line-invisible-mode) ; modeline serves no purpose in vterm
+  :hook ((vterm-mode . mode-line-invisible-mode) ; modeline serves no purpose in vterm
+         (vterm-mode . doom-disable-line-numbers-h))
   :preface
   ;; HACK: Because vterm clusmily forces vterm-module.so's compilation on us
   ;;   when the package is loaded, this is necessary to prevent it when

--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -21,6 +21,7 @@
 
   ;; Mode-line serves no purpose in REPL window.
   (add-hook 'dape-repl-mode-hook #'mode-line-invisible-mode)
+  (add-hook 'dape-repl-mode-hook #'doom-disable-line-numbers-h)
 
   ;; Persist breakpoints after closing DAPE.
   (dape-breakpoint-global-mode +1)

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -143,6 +143,10 @@ FUNCTION
   ;; estate, so free it up.
   (add-hook 'magit-popup-mode-hook #'mode-line-invisible-mode)
 
+  ;; Line numbers add nothing to magit's status/log/diff/refs buffers
+  (add-hook 'magit-popup-mode-hook #'doom-disable-line-numbers-h)
+  (add-hook 'magit-mode-hook #'doom-disable-line-numbers-h)
+
   ;; Add additional switches that seem common enough
   (transient-append-suffix 'magit-fetch "-p"
     '("-t" "Fetch all tags" ("-t" "--tags")))

--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -58,6 +58,7 @@
 
   ;; The mode-line does serve any useful purpose is annotation windows
   (add-hook 'pdf-annot-list-mode-hook #'mode-line-invisible-mode)
+  (add-hook 'pdf-annot-list-mode-hook #'doom-disable-line-numbers-h)
 
   ;; HACK: Fix #1107: flickering pdfs when evil-mode is enabled
   ;; We need (list nil) as a workaround for emacs-evil/evil#2016.

--- a/modules/ui/minimap/config.el
+++ b/modules/ui/minimap/config.el
@@ -1,4 +1,5 @@
 ;;; ui/minimap/config.el -*- lexical-binding: t; -*-
 
 (use-package! demap
-  :hook (demap-minimap-window-set-hook . mode-line-invisible-mode))
+  :hook ((demap-minimap-window-set-hook . mode-line-invisible-mode)
+         (demap-minimap-window-set-hook . doom-disable-line-numbers-h)))


### PR DESCRIPTION
According to [doom-ui.el#L598](https://github.com/doomemacs/doomemacs/blob/master/lisp/doom-ui.el#L598) Doom only enables `display-line-numbers-mode` for `prog-mode`, `text-mode`, and `conf-mode`. So in theory the gutter is never enabled in them yet it is displayed when entering from a line-numbered buffer, and it persists until the next input event triggers a redisplay.

I think this is a redisplay artifact: when a window transitions to a buffer whose `display-line-numbers` is nil, Emacs doesn't always recompute the window's left margin in time, and the previous buffer's gutter pixels stays. 

To be honest, I'm not sure this is the cleanest fix but I started by adding something like this to my config.el and it worked :)
```elisp
  ;; config.el
  (add-hook! '(vterm-mode-hook eshell-mode-hook magit-mode-hook term-mode-hook)
    #'doom-disable-line-numbers-h)
```


So I think the hooks in this commit are meaningful even for buffers that derive from `special-mode` and would never have enabled line numbers in the first place. I've followed the following criterion: if modeline is hidden here [bead7a](https://github.com/doomemacs/doomemacs/commit/bead7a77483d4b11404f408c4b218f6dc7c220ee) then line numbers are also useless. I hope I haven't left anyone out


<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
