### PR TITLE
Fix two tree-sitter grammars

### DIFF
--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -118,7 +118,9 @@
                  (bibtex "https://github.com/latex-lsp/tree-sitter-bibtex" nil nil nil nil)
                  (blueprint "https://github.com/huanie/tree-sitter-blueprint" nil nil nil nil)
                  (commonlisp "https://github.com/tree-sitter-grammars/tree-sitter-commonlisp" nil nil nil nil)
-                 (latex "https://github.com/latex-lsp/tree-sitter-latex" nil nil nil nil)
+                 (latex "https://github.com/latex-lsp/tree-sitter-latex" nil nil nil
+                        ;; Pinned due to latex-lsp/tree-sitter-latex#172
+                        "a6c812704b3d3e1541b0853aa0d6d561301320e1")
                  (make "https://github.com/tree-sitter-grammars/tree-sitter-make" nil nil nil nil)
                  (nu "https://github.com/nushell/tree-sitter-nu" nil nil nil nil)
                  (org "https://github.com/milisims/tree-sitter-org" nil nil nil nil)

--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -131,7 +131,7 @@
                  (surface "https://github.com/connorlay/tree-sitter-surface" nil nil nil nil)
                  (toml "https://github.com/tree-sitter/tree-sitter-toml" nil nil nil nil)
                  (typst "https://github.com/uben0/tree-sitter-typst" "master" "src" nil nil)
-                 (verilog "https://github.com/gmlarumbe/tree-sitter-systemverilog" nil nil nil nil)
+                 (systemverilog "https://github.com/gmlarumbe/tree-sitter-systemverilog" nil nil nil nil)
                  (vhdl "https://github.com/alemuller/tree-sitter-vhdl" nil nil nil nil)
                  (vue "https://github.com/tree-sitter-grammars/tree-sitter-vue" nil nil nil nil)
                  (wast "https://github.com/wasm-lsp/tree-sitter-wasm" nil "wast/src" nil nil)


### PR DESCRIPTION
Fixes the LaTeX and verilog grammars. See individual commits for rationale. 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.