### PR TITLE
fix(mu4e): org-msg signature advice

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -443,11 +443,13 @@ This should already be the case yet it does not always seem to be."
       (org-msg-mode (if org-msg-mode -1 1))
       (cl-callf not +mu4e-compose-org-msg-toggle-next)))
 
-  ;; HACK: ...
-  (defadvice! +mu4e-draft-open-signature-a (fn &rest args)
-    "Prevent `mu4e-compose-signature' from being used with `org-msg-mode'."
-    :around #'mu4e-draft-open
-    (let ((mu4e-compose-signature (unless org-msg-mode mu4e-compose-signature)))
+  ;; HACK: Suppress `message-signature' while a draft is being prepared with
+  ;;   `org-msg-mode' active, so it doesn't get inserted alongside
+  ;;   `org-msg-signature' and produce two signatures in the buffer.
+  (defadvice! +mu4e--draft-signature-a (fn &rest args)
+    "Prevent `message-signature' from being used with `org-msg-mode'."
+    :around #'mu4e--draft
+    (let ((message-signature (unless org-msg-mode message-signature)))
       (apply fn args)))
 
   (defvar +org-msg-accent-color "#c01c28"


### PR DESCRIPTION
TL;DR email composes a draft with 2 signatures in org-msg mode

Added `+org` into my init.el and a new `org-msg-signature` in my config to auto-generate my favorite signature.
Then I realized **when I compose a new email I see both signatures**: the one from `mu4e-compose-signature` (that I had previously) and the new one from `org-msg-signature`

It seems `mu4e-draft-open ` was removed in v1.12.0: https://github.com/emacsmirror/mu4e/commit/85bfe7633
and `mu4e--draft` was later introduced in v1.12.5: https://github.com/emacsmirror/mu4e/commit/6a4d6a49c

So Doom's `+mu4e-draft-open-signature-a` advice has been silently broken since mu4e 1.12.0 (Oct 2023)... not so many people using the combo mu4e + org, uh?

<!-- ⚠️ Please do not ignore this template! -->


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
