### PR TITLE
fix(workspaces): update persp-mode & adapt to API changes

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -156,7 +156,7 @@ Otherwise return t on success, nil otherwise."
         (persp-delete-other-windows))
       (switch-to-buffer (doom-fallback-buffer))
       (setf (persp-window-conf persp)
-            (funcall persp-window-state-get-function (selected-frame))))
+            (persp-window-state-get (selected-frame))))
     persp))
 
 ;;;###autoload

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -210,7 +210,12 @@ stored in `persp-save-dir'.")
   (advice-add #'persp-asave-on-exit :around #'+workspaces-autosave-real-buffers-a)
 
   ;; Fix #1973: visual selection surviving workspace changes
-  (add-hook 'persp-before-deactivate-functions #'deactivate-mark)
+  ;; `persp-before-deactivate-functions' calls its hooks with three arguments,
+  ;; but `deactivate-mark' only accepts an optional FORCE argument, so passing
+  ;; it directly throws (wrong-number-of-arguments deactivate-mark 3). Wrap it.
+  (add-hook! 'persp-before-deactivate-functions
+    (defun +workspaces-deactivate-mark-h (&rest _)
+      (deactivate-mark)))
 
   ;; Fix #1017: stop session persistence from restoring broken childframes.
   (add-hook 'persp-after-load-state-functions #'doom-kill-childframes-h)

--- a/modules/ui/workspaces/packages.el
+++ b/modules/ui/workspaces/packages.el
@@ -1,6 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/workspaces/packages.el
 
-;; REVIEW: persp-mode introduced breaking changes in later commits, but will be
-;;   replaced soon; this is frozen in the meantime.
-(package! persp-mode :pin "40e9993a9711cba5fb56dfec81a507fabeba9668" :freeze t)
+;; REVIEW: persp-mode will be replaced soon; pinned in the meantime.
+(package! persp-mode :pin "fab4bf76927445d2e431f06e74572acba81f47d5" :freeze t)


### PR DESCRIPTION
Ok. This fixes some errors in bumping persp-mode that are caused by minor changes in the functions.