### PR TITLE
fix(default): use Emacs regexp for 'SPC s s' selections (vertico)

### DIFF
--- a/modules/config/default/autoload/search.el
+++ b/modules/config/default/autoload/search.el
@@ -63,7 +63,7 @@ input and search the whole buffer for it."
                  (consult-line
                   (replace-regexp-in-string
                    " " "\\\\ "
-                   (doom-pcre-quote
+                   (regexp-quote
                     (buffer-substring-no-properties start end))))
                (call-interactively #'consult-line)))))))
 


### PR DESCRIPTION
Doom's `+default/search-buffer` (SPC s s) tries to escape any selected text in order to search regions literally, but `consult` expects Emacs regexp, not PCRE.

Selecting text with eg. `evil-visual-state`  and then trying to pass that text to `SPC s s` was erroneously escaping characters like `(` `)`, `{` `}` and `|` with `vertico` completion enabled. This was especially bad for searching for anything with parens, since escaping the parens turns them into grouping characters.

Fix: https://github.com/doomemacs/doomemacs/issues/7583

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ? Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->