### PR TITLE
fix(default): don't enable evil in non-evil buffers on newline

### DIFF
--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -4,7 +4,7 @@
 (defun +default/newline-above ()
   "Insert an indented new line before the current one."
   (interactive)
-  (if (featurep 'evil)
+  (if (and (featurep 'evil) evil-local-mode)
       (call-interactively 'evil-open-above)
     (beginning-of-line)
     (save-excursion (newline))
@@ -14,7 +14,7 @@
 (defun +default/newline-below ()
   "Insert an indented new line after the current one."
   (interactive)
-  (if (featurep 'evil)
+  (if (and (featurep 'evil) evil-local-mode)
       (call-interactively 'evil-open-below)
     (end-of-line)
     (newline-and-indent)))


### PR DESCRIPTION
Calling `+default/newline-above` or `+default/newline-below` in a buffer where evil mode is intentionally not enabled (e.g. the minibuffer) would initialize `evil-local-mode` and drop the buffer into evil insert state. I do NOT want Evil to be enabled in the minibuffer or magit, etc.

## How to reproduce

Invoke `+default/newline-below`/`+default/newline-above` in the minibuffer or magit, etc., any such buffer. It's bound to `C-RET` globally.