### PR TITLE
fix(dired): Use new name of renamed function

### DIFF
--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -24,7 +24,7 @@ sidebars)."
   (interactive "P")
   (require 'dirvish-side)
   (save-selected-window
-    (let ((win (dirvish-side--session-visible-p)))
+    (let ((win (dirvish-side-session-visible-p)))
       (when (and win arg)
         (with-selected-window win
           (dirvish-quit))
@@ -32,4 +32,4 @@ sidebars)."
       (unless win
         (call-interactively #'dirvish-side))
       (dirvish-side--auto-jump)))
-  (select-window (dirvish-side--session-visible-p)))
+  (select-window (dirvish-side-session-visible-p)))


### PR DESCRIPTION
Renamed all instances of `dirvish-side--session-visible-p` to `dirvish-side-session-visible-p`

In commit https://github.com/latiagertrutis/dirvish/commit/0238cba662f977ac7766a4183c46176180909bce the function `dirvish-side--session-visible-p` was renamed to `dirvish-side-session-visible-p`, as it is no longer a private function. The function `+dired/dirvish-side-and-follow` used the old name, and so therefore this change broke that function. Since this commit is the version that doom currently uses as of https://github.com/iT-Boyer/doomemacs/commit/dbeab878589364bad852aaff667086b970a30820, the function needs to be renamed. A fix that provides an alias for the old name has been made in the following pull request: https://github.com/latiagertrutis/dirvish/pull/10.

This has not yet been merged into the main branch of dirvish. Because of this, `dirvish-side--session-visible-p` needs to be renamed in all instances within doom, otherwise `+dired/dirvish-side-and-follow` breaks. There are no other functions within doom that use the renamed function.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
