### PR TITLE
fix(modules): clean up stale module flags

### DIFF
--- a/modules/config/default/autoload/default.el
+++ b/modules/config/default/autoload/default.el
@@ -33,7 +33,7 @@ generate `completing-read' candidates."
 (defun +default/new-buffer ()
   "TODO"
   (interactive)
-  (if (modulep! +evil)
+  (if (modulep! :editor evil)
       (call-interactively #'evil-buffer-new)
     (let ((buffer (generate-new-buffer "*new*")))
       (set-window-buffer nil buffer)

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -21,7 +21,7 @@ Through LSP, this module offers:
 [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-- lsp ::
+- +lsp ::
   Enable LSP support for ~c-mode~, ~c++-mode~, and ~objc-mode~. Requires [[doom-module::tools lsp]]
   and a langserver (supports clangd, ccls, and cquery).
 - +tree-sitter ::

--- a/modules/lang/ess/README.org
+++ b/modules/lang/ess/README.org
@@ -11,6 +11,9 @@ SAS, Julia and Stata.
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
+- +lsp ::
+  Enable LSP support for ~ess-r-mode~. Requires [[doom-module::tools lsp]] and the
+  [[https://github.com/REditorSupport/languageserver][languageserver]] R package.
 - +stan ::
   Enable support for ~stan-mode~, including code completion and syntax checking.
 

--- a/modules/lang/ess/doctor.el
+++ b/modules/lang/ess/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/ess/doctor.el
+
+(assert! (or (not (modulep! +lsp))
+             (modulep! :tools lsp))
+         "This module requires (:tools lsp)")

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -41,10 +41,6 @@
   (unless (executable-find "cython")
     (warn! "Couldn't find cython. cython-mode will not work.")))
 
-(when (modulep! +ipython)
-  (unless (executable-find "ipython")
-    (warn! "Couldn't find ipython in your PATH")))
-
 (unless (executable-find "pytest")
   (warn! "Couldn't find pytest. Running tests through pytest will not work."))
 

--- a/modules/tools/collab/README.org
+++ b/modules/tools/collab/README.org
@@ -6,7 +6,7 @@
 * Table of Contents :TOC_3:noexport:
 - [[#description][Description]]
   - [[#maintainers][Maintainers]]
-  - [[#module-flags][Module Flags]]
+  - [[#module-flags][Module flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
   - [[#with-tunnel][With =+tunnel=]]
@@ -24,15 +24,16 @@
 This module adds collaborative editing via the [[https://code.librehq.com/qhong/crdt.el][crdt]] plugin.
 
 ** Maintainers
-+ [[https://github.com/artenator][@artenator]]
-+ [[https://github.com/jming422][@jming422]]
+- [[https://github.com/artenator][@artenator]]
+- [[https://github.com/jming422][@jming422]]
 
-** Module Flags
-+ =+tunnel= Enables TCP forwarding over the [[https://tox.chat/][Tox]] protocol so that a collaborative
+** Module flags
+- +tunnel ::
+  Enables TCP forwarding over the [[https://tox.chat/][Tox]] protocol so that a collaborative
   editing session can be established between machines that are behind a NAT.
 
 ** Plugins
-+ [[https://code.librehq.com/qhong/crdt.el][crdt]]
+- [[https://code.librehq.com/qhong/crdt.el][crdt]]
 
 * Prerequisites
 With no flags, this module requires nothing else to work. The =+tunnel= flag has one dependency:
@@ -57,26 +58,26 @@ Tuntox is currently not supported on Windows, so Windows users cannot use the
 more options, see [[*People outside my LAN can't connect to the collab session I'm hosting][this Troubleshooting entry]].
 
 * Features
-+ Start a collaborative editing session in one of your buffers with =M-x
+- Start a collaborative editing session in one of your buffers with =M-x
   crdt-share-buffer= and following the prompts.
-+ If you're using =+tunnel=, get the sharable URL of your session using =M-x
+- If you're using =+tunnel=, get the sharable URL of your session using =M-x
   crdt-copy-url=. If not using =+tunnel=, then instead of a URL, others can
   connect using your public IP address and chosen TCP port number (default port
   is 6530)
-+ Others can connect to your session using =M-x crdt-connect= and following the
+- Others can connect to your session using =M-x crdt-connect= and following the
   prompts to pass in your tunnel URL or IP address and port
-+ Once connected, some commands you can use are:
-  + =crdt-list-buffers= to list shared buffers. Use this after =crdt-connect= to
+- Once connected, some commands you can use are:
+  - =crdt-list-buffers= to list shared buffers. Use this after =crdt-connect= to
     open shared buffers for editing!
-  + =crdt-share-buffer= Start a new collaboration session, or add more buffers
+  - =crdt-share-buffer= Start a new collaboration session, or add more buffers
     to an existing session. Once a session has started, both the host and
     clients can use this function to share buffers!
-  + =crdt-goto-user= to jump to another collaborator
-  + =crdt-follow-user= / =crdt-stop-follow= to toggle following another
+  - =crdt-goto-user= to jump to another collaborator
+  - =crdt-follow-user= / =crdt-stop-follow= to toggle following another
     collaborator
-  + =crdt-visualize-author-mode= to add colors to regions of the buffer,
+  - =crdt-visualize-author-mode= to add colors to regions of the buffer,
     visualizing who most recently edited each part of the buffer
-  + =crdt-stop-session= (host) / =crdt-disconnect= (client) to exit the collab
+  - =crdt-stop-session= (host) / =crdt-disconnect= (client) to exit the collab
     session
 
 ** Keybindings
@@ -122,13 +123,13 @@ Without =+tunnel= enabled, on most home/work networks you will be unable to have
 others join you from across the Internet unless you set something up to
 facilitate the connection between collaborators.
 You have a lot of options here, but some of the most common are:
-+ Enable the =+tunnel= flag to tunnel your traffic using the [[https://tox.chat/][Tox]] peer-to-peer
+- Enable the =+tunnel= flag to tunnel your traffic using the [[https://tox.chat/][Tox]] peer-to-peer
   networking protocol
-+ Use a VPN
-+ Use a non-peer-to-peer tunneling method, such as Teredo. One free software
+- Use a VPN
+- Use a non-peer-to-peer tunneling method, such as Teredo. One free software
   implementation of this method is called [[https://www.remlab.net/miredo/][Miredo]]
-+ Use a TCP reverse proxy server, such as [[https://ngrok.com/][ngrok]]
-+ Use SSH port forwarding, if you have access to a server with a public network
+- Use a TCP reverse proxy server, such as [[https://ngrok.com/][ngrok]]
+- Use SSH port forwarding, if you have access to a server with a public network
   address
 
 ** I got an error saying something including "crdt.el protocol"

--- a/modules/tools/debugger/doctor.el
+++ b/modules/tools/debugger/doctor.el
@@ -1,4 +1,0 @@
-;;; tools/debugger/doctor.el -*- lexical-binding: t; -*-
-
-(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
-  (warn! "+lsp flag is not compatible with :tools (lsp +eglot). Choose only one of (eglot or dap-mode) please"))

--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -27,6 +27,8 @@ or synonyms.
   Enable integration with Dash.app docsets.
 - +offline ::
   Install and prefer offline dictionary/thesaurus (with [[doom-module:+dictionary]]).
+- +yandex ::
+  Add Yandex, Yandex Images, and Yandex Maps to [[var:+lookup-provider-url-alist]].
 
 ** Packages
 - [[doom-package:dumb-jump]]


### PR DESCRIPTION
Remove stale flag checks for module flags that no longer have any runtime effect, and document flags that are already used by module code.

- Remove stale :lang python +ipython doctor checks.
- Remove the stale :tools debugger +lsp doctor check.
- Fix :config default's evil check to test :editor evil.
- Document existing +lsp flags for :lang cc and :lang ess.
- Document :tools lookup +yandex.
- Normalize :tools collab README list/flag formatting.


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
