### PR TITLE
fix(magit): wait for code-review before applying evil keybindings

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -226,7 +226,7 @@ FUNCTION
   :when (modulep! +forge)
   :after magit
   :init
-  (after! evil-collection-magit
+  (after! (evil-collection-magit code-review)
     (dolist (binding evil-collection-magit-mode-map-bindings)
       (pcase-let* ((`(,states _ ,evil-binding ,fn) binding))
         (dolist (state states)


### PR DESCRIPTION
## Problem

The `code-review` use-package block applies evil-collection-magit
keybindings to `code-review-mode-map` inside an `(after! evil-collection-magit ...)` form. If `evil-collection-magit` loads before `code-review`, the mode map doesn't exist yet and the keybinding setup fails silently.

## Solution

Change `(after! evil-collection-magit ...)` to `(after! (evil-collection-magit code-review) ...)` so the body runs only after **both** packages are loaded.

## Checklist

- [x] Commit messages follow Doom's [conventions](https://discourse.doomemacs.org/git-conventions)