### PR TITLE
fix: require ring in doom-ui.el

### DIFF
--- a/lisp/doom-ui.el
+++ b/lisp/doom-ui.el
@@ -2,6 +2,8 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 'ring)  ; for `ring-insert', `make-ring' (not preloaded in Emacs 30+)
+
 ;;
 ;;; Variables
 


### PR DESCRIPTION
## Problem

`doom-ui.el` uses `ring-insert` and `make-ring` (both from `ring.el`) inside `doom-enable-theme-h`, but never `(require 'ring)`.

`ring.el` is **not** preloaded in a bare Emacs 30 session:

```elisp
;; Emacs 30.2.50 --batch -Q
(featurep 'ring)       ;; => nil
(fboundp 'ring-insert) ;; => nil
```

`ring` only becomes available after something like `comint` loads it transitively. In a clean Doom startup the theme is applied early — before any such package is required — so `doom-enable-theme-h` fires with `ring` absent:

```
Error: (void-function ring-insert)
```

## Fix

Add `(require 'ring)` at the top of `doom-ui.el`.

## Environment

| | |
|---|---|
| Emacs | 30.2.50 (native-comp, macOS arm64) |
| Doom  | 2.1.1, master `a7c7dcd` |