### PR TITLE
fix(doom): quote 'package-archives in add-to-list

### DIFF
--- a/modules/doom/init.el
+++ b/modules/doom/init.el
@@ -258,8 +258,8 @@ Otherwise, `en/disable-command' (in novice.el.gz) is hardcoded to write them to
   (let ((s (if (gnutls-available-p) "s" "")))
     ;; I omit Marmalade because its packages are manually submitted rather than
     ;; pulled, and so often out of date.
-    (add-to-list package-archives `("melpa" . ,(format "http%s://melpa.org/packages/" s)))
-    (add-to-list package-archives `("org"   . ,(format "http%s://orgmode.org/elpa/"   s))))
+    (add-to-list 'package-archives `("melpa" . ,(format "http%s://melpa.org/packages/" s)))
+    (add-to-list 'package-archives `("org"   . ,(format "http%s://orgmode.org/elpa/"   s))))
   ;; Refresh package.el the first time you call `package-install', so it's still
   ;; trivially usable. Remember to run 'doom sync' to purge them; they can
   ;; conflict with packages installed via straight!


### PR DESCRIPTION
`add-to-list` takes a symbol as its first argument, not a value, so the calls in `with-eval-after-load 'package` break.

Regression from 6d55751441.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
