### PR TITLE
fix(cli): stringify upgrade job count on restart

### DIFF
--- a/lisp/cli/upgrade.el
+++ b/lisp/cli/upgrade.el
@@ -55,7 +55,7 @@ libraries. It is the equivalent of the following shell commands:
       (exit! "doom" "sync" "-u"
              (if aot? '("--aot"))
              (if nobuild? '("-B"))
-             (if jobs `("-j" ,jobs))))
+             (if jobs `("-j" ,(number-to-string jobs)))))
 
      ((doom-cli-upgrade context force? force?)
       ;; Reload Doom's CLI & libraries, in case there were any upstream changes.


### PR DESCRIPTION
## Summary

- Convert parsed numeric `jobs` to a string before passing it to `exit!` in `doom upgrade -p`
- Prevent `combine-and-quote-strings` from receiving a number when restarting into `doom sync -u -j N`
- Fixes #8818

## Details

`jobs` is parsed as a number, but `exit!` eventually calls `combine-and-quote-strings`, which expects every argument to be a string. When `doom upgrade --aot -j 20 --force` updates core and restarts into the package-upgrade phase, the package branch builds:

```elisp
("doom" "sync" "-u" "--aot" "-j" 20)
```

This crashes with:

```elisp
wrong-type-argument (stringp 20)
combine-and-quote-strings(("sync" "-u" "--aot" "-j" 20))
```

This patch changes the restarted command to contain `"20"` instead.

## Validation

```sh
DOOMDIR=/tmp/doom-test-doomdir ./bin/doom --load /tmp/doom-test-upgrade-first-stage.el upgrade --aot -j 20 --force
# PASS: doom upgrade -p --aot --force --jobs=20

DOOMDIR=/tmp/doom-test-doomdir ./bin/doom --load /tmp/doom-test-upgrade-package-stage.el upgrade -p --aot --force --jobs=20
# PASS: doom sync -u --aot -j 20
```

Also ran:

```sh
git diff --check
```
