### PR TITLE
fix(cli): doom env: merge process-environment

### DIFF
--- a/lisp/cli/env.el
+++ b/lisp/cli/env.el
@@ -133,7 +133,9 @@ Why this over exec-path-from-shell?
                     (throw 'skip t)))
                 (push env vars))))
           (pp `(setq exec-path ',(get 'exec-path 'initial-value)
-                     process-environment ',(reverse vars)
+                     process-environment
+                     (append ',(reverse vars)
+                             (default-value 'process-environment))
                      shell-file-name ,shell-file-name)
               (current-buffer)))
         (print! (success "Generated %s") (path env-file))


### PR DESCRIPTION
Closes #8820

## What

`doom env` generates an elisp envvar file that sets `process-environment`
to the scraped shell variables verbatim. Since denied variables (notably
`HOME`, on the `doom-env-deny` list) are intentionally excluded from the
scrape, this **overwrites** `process-environment` and drops any var that
isn't scraped but was already present at load time. On macOS, where
GUI-launched Emacs relies on this file to inherit the shell environment,
this leaves `HOME` unset.

## Why

The previous loader (`doom-load-envvars-file`) merged the scraped vars
onto the existing `process-environment`, so vars like `HOME` survived.
The new elisp-format file changed that to a full overwrite, dropping
every denied-but-present var.

Excluding `HOME` from the *persisted* file is correct — it shouldn't be
scraped. The fix is to restore the merge at load time, not to start
persisting it.

## How

Merge the scraped vars onto the existing `process-environment` in the
generated `env.el`. Scraped vars still take precedence (Emacs uses the
first occurrence of a var), while denied-but-present vars survive —
matching the behaviour of the previous `doom-load-envvars-file` loader
while keeping the new elisp-based format.

```diff
 ;; lisp/cli/env.el
          (pp `(setq exec-path ',(get 'exec-path 'initial-value)
-                    process-environment ',(reverse vars)
+                    process-environment
+                    (append ',(reverse vars)
+                            (default-value 'process-environment))
                     shell-file-name ,shell-file-name)
              (current-buffer)))
```

### Verification

```elisp
(setq-default process-environment
              '("HOME=/Users/test" "PATH=/usr/bin" "SHELL=/bin/zsh" "USER=test"))
(defconst scraped '("PATH=/opt/homebrew/bin:/usr/bin" "SHELL=/bin/zsh")) ; HOME denied

;; After the fix (merge):
(setq process-environment
      (append scraped (default-value 'process-environment)))
(getenv "HOME") ;; => "/Users/test"  (preserved)
(getenv "PATH") ;; => "/opt/homebrew/bin:/usr/bin"  (scraped wins)
```

The pre-fix form (`(setq process-environment scraped)`) reproduces
`(getenv "HOME") => nil`.
