### PR TITLE
fix(cli): use defcustom for doom-env-allow

### DIFF
--- a/lisp/cli/env.el
+++ b/lisp/cli/env.el
@@ -31,7 +31,8 @@ Each string is a regexp, matched against variable names."
   :type '(repeat regexp)
   :group 'doom-cli)
 
-(defvar doom-env-allow '()
+;;;###autoload
+(defcustom doom-env-allow '()
   "Environment variables to include in envvar files.
 
 This overrules `doom-env-deny'. Each string is a regexp, matched against


### PR DESCRIPTION
## Summary

- Fixes `doom sync --env` failing with `Too many arguments` when loading `lisp/cli/env.el`
- Commit cf7d5fc61 converted `doom-env-deny` to `defcustom` but left `doom-env-allow` as `defvar` while adding `:type` and `:group` properties, which `defvar` does not accept

## Test plan

- [x] `(load-file "lisp/cli/env.el")` in batch Emacs succeeds past the variable definitions
- [x] `doom sync --env` no longer fails with "Too many arguments"