### PR TITLE
fix(lib): doom/version without git checkout

### DIFF
--- a/lisp/lib/debug.el
+++ b/lisp/lib/debug.el
@@ -391,7 +391,7 @@ FILL-COLUMN determines the column at which lines will be broken."
   (interactive)
   (letf! ((defun gitinfo (dir)
             (let ((default-directory (expand-file-name dir)))
-              (if (locate-dominating-file ".git" default-directory)
+              (if (locate-dominating-file default-directory ".git")
                   (format "%s %s"
                           (or (cdr (doom-call-process "git" "log" "-1" "--format=%h %cs"))
                               "-")


### PR DESCRIPTION
The locate-dominating-file check for Doom and its modules being in a Git repository before running git commands had its arguments reversed. It looks like this causes it to always return non-nil.

Fix this to make the intended "not a git repo" show up when Doom is not in a git repo, while still showing the revision when in a git repo.

(I did not spot other locate-dominating-file calls with the same problem.)

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
