### PR TITLE
fix install instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Check out [the FAQ][FAQ] for answers to common questions about the project.
 # Install
 ``` sh
 git clone --depth 1 --recurse-submodules https://github.com/doomemacs/core ~/.config/emacs
+~/.config/emacs/bin/doom sync
 ~/.config/emacs/bin/doom install
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Check out [the FAQ][FAQ] for answers to common questions about the project.
 
 # Install
 ``` sh
-git clone --depth 1 https://github.com/doomemacs/core ~/.config/emacs
+git clone --depth 1 --recurse-submodules https://github.com/doomemacs/core ~/.config/emacs
 ~/.config/emacs/bin/doom install
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Check out [the FAQ][FAQ] for answers to common questions about the project.
 # Install
 ``` sh
 git clone --depth 1 --recurse-submodules https://github.com/doomemacs/core ~/.config/emacs
-~/.config/emacs/bin/doom sync
 ~/.config/emacs/bin/doom install
+~/.config/emacs/bin/doom sync
 ```
 
 Then [read our Getting Started guide][getting-started] to be walked through


### PR DESCRIPTION
https://github.com/doomemacs/core/issues/8846

<!-- ⚠️ Please do not ignore this template! -->

Add missing `----recurse-submodules` to install instruction.
-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
