### PR TITLE
refactor(cli): doom env: read allow/deny cookies with doom-file-cookie

### DIFF
--- a/bin/doom-env
+++ b/bin/doom-env
@@ -95,16 +95,16 @@ Why this over exec-path-from-shell?
     (setq-local coding-system-for-write 'utf-8-unix)
     (unless (equal output-file "-")
       (print! (start "%s envvars file...") (if reload? "Reloading" "Generating")))
-    (let* ((deny  (if reload? (doom-file-cookie-p output-file "deny")))
-           (allow (if reload? (doom-file-cookie-p output-file "allow"))))
+    (let* ((deny  (if reload? (doom-unquote (doom-file-cookie output-file "deny"))))
+           (allow (if reload? (doom-unquote (doom-file-cookie output-file "allow")))))
       (pcase-dolist (`(,option . ,rule) rules)
         (push rule (if (member option '("-a" "--allow")) allow deny)))
       (if deny-only  (setq deny  '(".")))
       (if allow-only (setq allow '(".")))
       (insert ";; -*- mode: emacs-lisp; lexical-binding: t; coding: utf-8-unix; -*-\n"
               ";;;###if (or initial-window-system (daemonp))\n"
-              ";;;###allow " (prin1-to-string `(quote ,allow)) "\n"
-              ";;;###deny  " (prin1-to-string `(quote ,deny)) "\n"
+              ";;;###allow " (prin1-to-string allow) "\n"
+              ";;;###deny  " (prin1-to-string deny) "\n"
               ";;;###date  " (format "%S" (format-time-string "%Y-%m-%d %H:%M:%S")) "\n"
               "(put 'process-environment 'doom t)\n")
       (let ((deny  (append deny doom-env-deny))


### PR DESCRIPTION
I realized there is a simpler way of preventing the cookies from being evaluated as function calls; rather than quoting, just use the cookie function that doesn't eval (`doom-file-cookie` instead of `doom-file-cookie-p`).

This does cause a small breaking change for anyone who pulled in the previous fix (a305b91f44d4), because, without evaluating, the cookie `'nil` (for instance) is a list with two symbols (`(quote nil)`) rather than an empty list so `quote` and `nil` will be treated as regexes to match against. This results in `doom env` reporting `Wrong type argument: (stringp quote)` after reloading the envvars file. However, the fix is easy: edit the envvars file to remove the quoting from the file cookies.

Sorry for all the back and forth on `doom env`, and thanks again for all your help!

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.